### PR TITLE
Print performance validation

### DIFF
--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -91,7 +91,8 @@ var ExportTiffSettings = React.createClass({
 
 var ExportPdfSettings = React.createClass({
 
-  resolutions: [72, 96, 150, 200, 300],
+    resolutions: [72, 96, 150, 200, 300],
+    paperFormats: ["A2", "A3", "A4"],
 
   getInitialState: function() {
     return {
@@ -225,6 +226,7 @@ var ExportPdfSettings = React.createClass({
     ,   scales = this.props.model.get('scales')
     ,   options
     ,   resolutionOptions
+    ,   paperFormatOptions
     ,   loader = null
     ,   downloadLink = null
     ;
@@ -236,7 +238,26 @@ var ExportPdfSettings = React.createClass({
     if (!this.props.visible) return null;
 
     options = scales.map((s, i) => <option key={i} value={s}>1:{s}</option>);
-    resolutionOptions = this.resolutions.map((s, i) => <option key={i} value={s}>{s}</option>);
+    resolutionOptions = this.resolutions.map((s, i) => {
+      if (this.state.selectFormat === 'A2') {
+        console.log(s);
+        return s !== '300' 
+          ? <option key={i} value={s}>{s}</option>
+          : <option key={i} value={s} disabled>{s}</option>;
+        } else {
+          return <option key={i} value={s}>{s}</option>;
+        }
+      });
+    paperFormatOptions = this.paperFormats.map((s, i) => {
+      if (this.state.selectResolution === '300') {
+        console.log(s);
+        return s !== 'A2'
+          ? <option key={i} value={s}>{s}</option>
+          : <option key={i} value={s} disabled>{s}</option>;
+        } else {
+          return <option key={i} value={s}>{s}</option>;
+        }
+    });
         
     this.addPreview(map);
 
@@ -255,9 +276,7 @@ var ExportPdfSettings = React.createClass({
           <div className="panel-heading">Välj pappersstorlek</div>
           <div className="panel-body">
             <select onChange={this.setFormat} defaultValue={this.state.selectFormat}>
-              <option value="A2">A2</option>
-              <option value="A3">A3</option>
-              <option value="A4">A4</option>
+              {paperFormatOptions}
             </select>
           </div>
         </div>

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -91,7 +91,7 @@ var ExportTiffSettings = React.createClass({
 
 var ExportPdfSettings = React.createClass({
 
-  resolutions: [72, 96, 150],
+  resolutions: [72, 96, 150, 200, 300],
 
   getInitialState: function() {
     return {

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -240,7 +240,6 @@ var ExportPdfSettings = React.createClass({
     options = scales.map((s, i) => <option key={i} value={s}>1:{s}</option>);
     resolutionOptions = this.resolutions.map((s, i) => {
       if (this.state.selectFormat === 'A2') {
-        console.log(s);
         return s !== 300 
           ? <option key={i} value={s}>{s}</option>
           : <option key={i} value={s} disabled>{s}</option>;
@@ -250,7 +249,6 @@ var ExportPdfSettings = React.createClass({
       });
     paperFormatOptions = this.paperFormats.map((s, i) => {
       if (this.state.selectResolution === '300') {
-        console.log(s);
         return s !== 'A2'
           ? <option key={i} value={s}>{s}</option>
           : <option key={i} value={s} disabled>{s}</option>;

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -241,7 +241,7 @@ var ExportPdfSettings = React.createClass({
     resolutionOptions = this.resolutions.map((s, i) => {
       if (this.state.selectFormat === 'A2') {
         console.log(s);
-        return s !== '300' 
+        return s !== 300 
           ? <option key={i} value={s}>{s}</option>
           : <option key={i} value={s} disabled>{s}</option>;
         } else {

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -91,8 +91,8 @@ var ExportTiffSettings = React.createClass({
 
 var ExportPdfSettings = React.createClass({
 
-    resolutions: [72, 96, 150, 200, 300],
-    paperFormats: ["A2", "A3", "A4"],
+  resolutions: [72, 96, 150, 200, 300],
+  paperFormats: ["A2", "A3", "A4"],
 
   getInitialState: function() {
     return {


### PR DESCRIPTION
Why:

* The services can't handle some combinations of large resoltions and large papers.

This change adresses the need by:

* Disabling A2 if DPI 300 is selected, and disabling DPI 300 if A2 is selected.

Tickets:

* https://trello.com/c/n190HV9c/22-skriv-ut-prestanda
* https://trello.com/c/yaBiKiR8/23-skriv-ut-pappersstorlek
* https://trello.com/c/bCU5vUja/24-skriv-ut-upplosning