### PR TITLE
Print select other scale

### DIFF
--- a/backend/mapservice/Components/PDFCreator.cs
+++ b/backend/mapservice/Components/PDFCreator.cs
@@ -120,8 +120,8 @@ namespace MapService.Components
                         {250000, 10000}
                     };
 
-            int displayLength = (int)(unitLength * scaleBarLengths.FirstOrDefault(a => a.Key == scale).Value);
-            string displayText = scaleBarTexts.FirstOrDefault(a => a.Key == scale).Value;
+            int displayLength = GetDisplayLength(unitLength, scaleBarLengths, scale);
+            string displayText = GetDisplayText(unitLength, scaleBarTexts, scale);
 
             this.drawImage(gfx, img, 0, 0, page);
 
@@ -179,6 +179,38 @@ namespace MapService.Components
             }            
 
             return bytes;
+        }
+
+        private int GetDisplayLength(double unitLength, Dictionary<int, int> scaleBarLengths, int scale)
+        {
+            int scaleBarLength = 0;
+            if (scaleBarLengths.TryGetValue(scale, out scaleBarLength))
+            {
+                return (int) (unitLength * scaleBarLength);
+            }
+            if (scale <= 500)
+            {
+                return (int) (unitLength * (scale / 10));
+            }
+            return (int)(unitLength * (scale * 0.05)); 
+
+        }
+
+        private string GetDisplayText(double unitLength, Dictionary<int, string> scaleBarTexts, int scale)
+        {
+            string scaleBarText = "";
+            if (scaleBarTexts.TryGetValue(scale, out scaleBarText))
+            {
+                return scaleBarText;
+            }
+            if (scale <= 500) {
+                return unitLength * (scale / 10) + " m";
+            }
+            if (scale < 25000)
+            {
+                return Math.Ceiling(scale * 0.05) + " m";
+            }
+            return Math.Ceiling(scale * 0.05 / 1000) + " km";
         }
 
         /// <summary>

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -98,6 +98,7 @@ var ExportPdfSettings = React.createClass({
       selectFormat: 'A4',
       selectOrientation: 'S',
       selectScale: '2500',
+      manualScale: '2500',
       selectResolution: '72',
       loading: false
     };
@@ -137,7 +138,7 @@ var ExportPdfSettings = React.createClass({
   },
 
   getScale: function () {
-    return this.state.selectScale;
+    return (this.state.selectScale === 'other') ? this.state.manualScale : this.state.selectScale;
   },
 
   getResolution: function () {
@@ -167,6 +168,24 @@ var ExportPdfSettings = React.createClass({
   setScale: function(e) {
     this.setState({
       selectScale: e.target.value
+    });
+  },
+
+  setManualScale: function(e) {
+    if (e.target.value.startsWith('1:')) {
+      e.target.value = e.target.value.split(':')[1];
+    }
+
+    var val = this.getScale();
+    if (e.target.value < 250) {
+      val = 250;
+    } else if (e.target.value > 250000) {
+      val = 250000;
+    } else {
+      val = e.target.value;
+    }
+    this.setState({
+      manualScale: val
     });
   },
 
@@ -231,6 +250,7 @@ var ExportPdfSettings = React.createClass({
     if (!this.props.visible) return null;
 
     options = scales.map((s, i) => <option key={i} value={s}>1:{s}</option>);
+    
     resolutionOptions = this.resolutions.map((s, i) => <option key={i} value={s}>{s}</option>);
         
     this.addPreview(map);
@@ -269,7 +289,9 @@ var ExportPdfSettings = React.createClass({
           <div className="panel-body">
             <select onChange={this.setScale} defaultValue={this.state.selectScale}>
               {options}
+              <option value="other">Annan skala</option>
             </select>
+            {this.state.selectScale==='other' && <input type="text" onChange={this.setManualScale} defaultValue={this.state.manualScale}></input>}
           </div>
         </div>
         <div className="panel panel-default">


### PR DESCRIPTION
Add option to select other (manual) scale. 
Why:

* A user wants to print in a scale not available in the prepopulated select box.

This change adresses the need by:

* Adding an option to the select box to choose another scale, and then a
  text input for picking a manual scale.

Tickets:

* https://trello.com/c/DPDbFHwx/21-skriv-ut-skala