### PR TITLE
Remove the use of "magic constant" 49.65 when exporting to PDF.

### DIFF
--- a/client/src/js/tools/export.js
+++ b/client/src/js/tools/export.js
@@ -667,10 +667,10 @@ var ExportModel = {
     dy = Math.abs(bottom - top);
 
     data.size = [
-      parseInt(49.65 * (dx / scale) * dpi),
-      parseInt(49.65 * (dy / scale) * dpi)
+      parseInt(options.size.width * dpi),
+      parseInt(options.size.height * dpi)
     ];
-
+    
     data.bbox = [left, right, bottom, top];
     data.orientation = options.orientation;
     data.format = options.format;

--- a/client/src/js/views/panels/exportpanel.jsx
+++ b/client/src/js/views/panels/exportpanel.jsx
@@ -126,13 +126,23 @@ var ExportPdfSettings = React.createClass({
       }
     }
 
-    var dpi    = (25.4 / .28)
-    ,   width  = pageSize(this.getFormat()).width
+    var width  = pageSize(this.getFormat()).width
     ,   height = pageSize(this.getFormat()).height;
 
     return {
-      width: ((width / 25.4) * dpi),
-      height:  ((height / 25.4) * dpi)
+      width: ((width / 25.4)),
+      height:  ((height / 25.4))
+    };
+  },
+
+  getPreviewPaperMeasures: function() { 
+    var size = this.getPaperMeasures()
+    ,   inchInMillimeter = 25.4
+    ,   defaultPixelSizeInMillimeter = 0.28
+    ,   dpi = (inchInMillimeter / defaultPixelSizeInMillimeter); // ~90
+    return {
+      width: size.width * dpi,
+      height:  size.height * dpi
     };
   },
 
@@ -182,7 +192,7 @@ var ExportPdfSettings = React.createClass({
 
   addPreview: function (map) {
     var scale  = this.getScale()
-    ,   paper  = this.getPaperMeasures()
+    ,   paper  = this.getPreviewPaperMeasures()
     ,   center = this.props.model.getPreviewFeature() ?
                  ol.extent.getCenter(this.props.model.getPreviewFeature().getGeometry().getExtent()) :
                  map.getView().getCenter();


### PR DESCRIPTION
Why:

* The print requests were larger due to this "magic" constant, thus causing unnecessary strain on 
  the map servers, causing them to fail. 
* The measurements calculated when using the "magic" constant did not add up to the real world measurements of papers.

This change adresses the need by:

* Calculating the size of papers based on their size in inch multplied by the resolution in DPI.
* Adding a new function called getPreviewPaperMeasures for showing the extent in the map, using a calculated DPI of about 90 (25.4 / 0.28).

Tickets:

* https://trello.com/c/1gzLsGIW/81-felaktig-begaran-av-bildstorlek-vid-utskrift