### PR TITLE
Save state of export panel in localStorage

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,5 +50,8 @@
     "react-dom": "^0.14.7",
     "underscore": "^1.8.3",
     "x2js": "^2.0.1"
+  },
+  "dependencies": {
+    "react-localstorage": "^0.3.1"
   }
 }

--- a/client/src/js/tools/export.js
+++ b/client/src/js/tools/export.js
@@ -155,6 +155,15 @@ var ExportModel = {
     return this.get('previewFeature')
   },
 
+  /**
+   * Get center coordinate of the preview feature.
+   * @return {external:"ol.coordinate"} center coordinate
+   */
+  getPreviewCenter: function () {
+    var extent = this.getPreviewFeature().getGeometry().getExtent();
+    return ol.extent.getCenter(extent);
+  },
+
   addTiffPreview: function (center) {
 
     var dpi = 25.4 / 0.28


### PR DESCRIPTION
* Add new dependency to react-localstorage
* Add new function `getPreviewCenter` to `src/js/tools/export.js`
  which returns the center coordinate of the preview feature.
* `exportpanel.jsx` - use [react-localstorage](https://www.npmjs.com/package/react-localstorage)
  as a mixin to save/retrieve state to local storage.
  This mixin wraps `setState` to save values to `localStorage` and
  retrieves state from localStorage.
  * Add `setCenter` to wrap around `setState`.
  * Add `savePreviewCenterToLocalStorage` function and call it from
    `componentWillUnmount` in order to save the center of the preview
    feature. All other properties of the feature are stored as separate
    values.
  * Use `value` instead of `defaultValue` or the `select` element
    in order to set the value to the one saved in the state.