### PR TITLE
Kommenterat ut kod för bugg med bakgrundskartor

### DIFF
--- a/client/src/js/tools/layerswitcher.js
+++ b/client/src/js/tools/layerswitcher.js
@@ -119,8 +119,8 @@ var LayerSwitcherModel = {
     this.get('baselayers').forEach(baseLayer => {
       var layer = this.get('layerCollection').find(layer => layer.id === baseLayer.id);
       if (layer) {
-        layer.setVisible(baseLayer.visibleAtStart);
-        layer.getLayer().setVisible(layer.getVisible());
+        //layer.setVisible(baseLayer.visibleAtStart);
+        //layer.getLayer().setVisible(layer.getVisible());
         baseLayers.push(layer);
       }
     });


### PR DESCRIPTION
Om man byter bakgrundskarta och sedan klickar på en lagergrupp så ändras
kartan till default-kartan igen