### PR TITLE
Teckenförklaring laddas vid klick

### DIFF
--- a/client/src/js/views/components/layeritem.jsx
+++ b/client/src/js/views/components/layeritem.jsx
@@ -235,7 +235,7 @@ var LayerItemView = {
         </div>
 
         <div className={innerBodyClass}>
-          {components.legend.legendPanel}
+          {expanded ? components.legend.legendPanel : null}
         </div>
       </div>
     );


### PR DESCRIPTION
Istället för att hämta alla teckenförklaringar (bilder) innan WMS:erna
laddats vid initieringen så hämtas de nu när man klickar på fliken.