### PR TITLE
Felaktig text som anger längden på skalstocken

### DIFF
--- a/backend/mapservice/Components/PDFCreator.cs
+++ b/backend/mapservice/Components/PDFCreator.cs
@@ -278,7 +278,7 @@ namespace MapService.Components
                 return scaleBarText;
             }
             if (scale <= 500) {
-                return unitLength * (scale / 10) + " m";
+                return (scale / 10) + " m";
             }
             if (scale < 25000)
             {


### PR DESCRIPTION
Texten som anger längden på skalstocken var felaktig på utskrifterna om
man valde en egen skala.