### PR TITLE
Fix to WMS admin

### DIFF
--- a/new-admin/src/views/layerforms/wmslayerform.jsx
+++ b/new-admin/src/views/layerforms/wmslayerform.jsx
@@ -175,8 +175,14 @@ class WMSLayerForm extends Component {
       ].Capability.Layer.Layer.find(l => {
         return l.Name === checkedLayer;
       });
-      // We can not be sure that CRS property exists
-      if (foundCrs !== undefined && foundCrs.hasOwnProperty("CRS")) {
+      // Proceed only if this is the first layer to be added (else we risk overwriting existing user selection of projection).
+      // Also, make sure that CRS property really exists before proceeding.
+      if (
+        foundCrs !== undefined &&
+        foundCrs.hasOwnProperty("CRS") &&
+        Object.keys(this.state.addedLayers).length === 0 &&
+        this.state.addedLayers.constructor === Object
+      ) {
         let projection;
         // Sometimes a layer announces multiple CRSs, and we need to handle that too
         if (Array.isArray(foundCrs.CRS)) {


### PR DESCRIPTION
Previously, each time users checked a layer, the projection was set to the latest checked layer's.
The correct behavior is to only set projection if layer checked is the first being added - else we risk overwriting already existing projection selection.