### PR TITLE
Revert "Fix bug with styles in export"

### DIFF
--- a/backend/mapservice/Components/MapExport/MapExporter.cs
+++ b/backend/mapservice/Components/MapExport/MapExporter.cs
@@ -1,4 +1,4 @@
-using GeoAPI.Geometries;
+﻿using GeoAPI.Geometries;
 using NetTopologySuite.Geometries;
 using SharpMap;
 using SharpMap.Data;
@@ -219,10 +219,6 @@ namespace MapService.Components.MapExport
 					if (sublayerName != "")
 					{
 						layer.AddLayer(sublayerName);
-						if (wmsLayers[i].styles != null)
-						{
-							layer.AddStyle(wmsLayers[i].styles);
-						}
 					}                                        
                 }
                 layer.SRID = wmsLayers[i].coordinateSystemId;                    

--- a/backend/mapservice/Components/MapExport/WMSInfo.cs
+++ b/backend/mapservice/Components/MapExport/WMSInfo.cs
@@ -3,32 +3,31 @@ using System.Text.RegularExpressions;
 
 namespace MapService.Components.MapExport
 {
-  public class WMSInfo
-  {
-    private string _url = "";
-    public string url
+    public class WMSInfo
     {
-      get
-      {
-        return this._url;
-      }
-      set
-      {
-        string replacer = "gwc/service/";
-        Regex regex = new Regex(replacer);
-        // Remove the GWC-part from geoserver url if specified.
-        if (regex.IsMatch(value))
+        private string _url = "";
+        public string url
         {
-          // This in an assumption that there is an equalient url at the rool level of geoserver.
-          value = value.Replace(replacer, "");
+            get
+            {
+                return this._url;
+            }
+            set
+            {
+                string replacer = "gwc/service/";
+                Regex regex = new Regex(replacer);
+                // Remove the GWC-part from geoserver url if specified.
+                if (regex.IsMatch(value))
+                {
+                    // This in an assumption that there is an equalient url at the rool level of geoserver.
+                    value = value.Replace(replacer, "");
+                }
+                this._url = value;
+            }
         }
-        this._url = value;
-      }
+        public int zIndex { get; set; }
+        public string workspacePrefix { get; set; }
+        public List<string> layers { get; set; }
+        public int coordinateSystemId { get; set; }   
     }
-    public int zIndex { get; set; }
-    public string workspacePrefix { get; set; }
-    public List<string> layers { get; set; }
-    public int coordinateSystemId { get; set; }
-    public string styles { get; set; }
-  }
 }

--- a/new-client/src/plugins/export/ExportModel.js
+++ b/new-client/src/plugins/export/ExportModel.js
@@ -131,11 +131,6 @@ class ExportModel {
       .getArray()
       .filter(exportable)
       .map((layer, i) => {
-        var getLayers = layer
-          .getSource()
-          .getParams()
-          .LAYERS.split(",");
-
         return {
           url: layer.getSource().get("url"),
           layers: layer
@@ -148,8 +143,7 @@ class ExportModel {
             .getView()
             .getProjection()
             .getCode()
-            .split(":")[1],
-          styles: layer.layersInfo[getLayers].style || null
+            .split(":")[1]
         };
       });
   }


### PR DESCRIPTION
Reverts hajkmap/Hajk#221

Still multiple issues to be solved. 

For one, there are cases where `layer.layerInfo === undefined`, so `layer.layersInfo[getLayers]` crashes the code. 

Another problem is where we create `var getLayers`. The `LAYERS` parameter is sometimes a string and sometimes an array. So the `.split()` method can't be used in the second case. 

Furthermore, we need to extract exactly one element, as `getLayers` is used to identify an index in the layers.layersInfo object (in those cases where it is an object and not `undefined`).