### PR TITLE
Set homepage relative to current folder

### DIFF
--- a/new-admin/package.json
+++ b/new-admin/package.json
@@ -2,7 +2,7 @@
   "name": "new-admin",
   "version": "3.0.0-alpha.5",
   "private": true,
-  "homepage": "/admin3",
+  "homepage": ".",
   "dependencies": {
     "backbone": "^1.4.0",
     "draft-js": "^0.10.5",

--- a/new-client/package.json
+++ b/new-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hajk-client",
   "version": "3.0.0-alpha.5",
-  "homepage": "/hajk3",
+  "homepage": ".",
   "private": true,
   "scripts": {
     "start": "set HTTPS=false && react-scripts start",


### PR DESCRIPTION
Use relative path instead of static names for admin and client applications.