### PR TITLE
Now we're loading Roboto from CDN

### DIFF
--- a/new-client/public/index.html
+++ b/new-client/public/index.html
@@ -7,6 +7,10 @@
       content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#FFFFFF" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css" />


### PR DESCRIPTION
Somehow we missed to add Roboto (can be either from CDN or local, by npm install), even
though we're using it (as it's the default font for Material Design). This way
(<link> in index.html) is the recommended one, according to docs: https://material-ui.com/components/typography/#roboto-font-cdn .