### PR TITLE
Important fixes to MapSwitcher:

### DIFF
--- a/new-client/src/components/MapSwitcher.js
+++ b/new-client/src/components/MapSwitcher.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import { withStyles } from "@material-ui/core/styles";
@@ -96,18 +97,29 @@ class MapSwitcher extends React.PureComponent {
   render() {
     const { anchorEl } = this.state;
     const { classes } = this.props;
-
     const open = Boolean(anchorEl);
+
+    const toolOptions = this.props.appModel.config.mapConfig.tools.find(
+      tool => tool.type === "layerswitcher"
+    ).options;
+    const themeMapHeaderCaption =
+      toolOptions.themeMapHeaderCaption || "Byt karta";
+    const instruction = toolOptions.instruction
+      ? window.atob(toolOptions.instruction)
+      : "";
+
     return (
       <>
-        <Button
-          aria-owns={open ? "render-props-menu" : undefined}
-          aria-haspopup="true"
-          onClick={this.handleClick}
-        >
-          <SwitchCameraIcon className={classes.icon} />
-          Byt karta
-        </Button>
+        <Tooltip title={instruction}>
+          <Button
+            aria-owns={open ? "render-props-menu" : undefined}
+            aria-haspopup="true"
+            onClick={this.handleClick}
+          >
+            <SwitchCameraIcon className={classes.icon} />
+            {themeMapHeaderCaption}
+          </Button>
+        </Tooltip>
         <Menu
           id="render-props-menu"
           anchorEl={anchorEl}


### PR DESCRIPTION
- If 'themeMapHeaderCaption' is sat in LayerSwitcher's config, use it as label (i.e. make it possible to customize what the button says)
- If 'instruction' is filled in, use it and display a Tooltip

These settings:

![image](https://user-images.githubusercontent.com/110222/60262128-bc8c0c80-98dd-11e9-9237-b8f6b5e94e8d.png)

Render like this:
![image](https://user-images.githubusercontent.com/110222/60262143-c31a8400-98dd-11e9-9cc9-a366845ee66b.png)

**BTW: We all should start using <Tooltip> component a lot more in our plugins.**


Signed-off-by: Jacob Wodzyński <jacob.wod@gmail.com>