### PR TITLE
Vbg hajk2 fixes

### DIFF
--- a/client/src/js/tools/infoclick.js
+++ b/client/src/js/tools/infoclick.js
@@ -145,7 +145,8 @@ var InfoClickModel = {
     var wmsLayers = this.layerCollection.filter((layer) => {
         return (layer.get('type') === 'wms' || layer.get('type') === 'arcgis') &&
                  layer.get('queryable') &&
-                 layer.getVisible();
+                 layer.getVisible() &&
+                 this.checkLayerResolution(layer, this.map.getView().getResolution())
       }),
       projection = this.map.getView().getProjection().getCode(),
       resolution = this.map.getView().getResolution(),
@@ -525,6 +526,32 @@ var InfoClickModel = {
    */
   clearHighlight: function () {
     this.get('highlightLayer').clearHighlight();
+  },
+
+  /**
+   * Checks if layers have a minResolution and maxResolution property
+   * and compares to the current map resolution.
+   * @param {*} layer 
+   * @param {*} resolution 
+   */
+  checkLayerResolution: function (layer, resolution) {
+    var maxResPasses = true;
+    var minResPasses = true;
+    
+    if (layer.get('minResolution') > 0 || layer.get('maxResolution') > 0) {
+      if (resolution > layer.get('maxResolution') + 0.001) {
+        maxResPasses = false;
+      }
+      if (resolution < layer.get('minResolution')) {
+        minResPasses = false;
+      } 
+    }
+   
+    if (maxResPasses === false || minResPasses === false) {
+      return false;
+    }
+
+    return true;
   }
 
 };

--- a/client/src/js/views/components/kirsearch.jsx
+++ b/client/src/js/views/components/kirsearch.jsx
@@ -361,7 +361,7 @@ var KirSearchView = {
           </div>
 
           {/* Boendeförteckning */
-            this.props.model.get("residentListDataLayer") !== null &&
+            (this.props.model.get("residentListDataLayer") && this.props.model.get("residentList") != null) &&
             <ResidentList model={this.props.model} residentData={this.state.searchResults}></ResidentList>
           }
 


### PR DESCRIPTION
- Corrected authentication check in KIR that wasn't working in 626f3598dc8322b34ab88a4410a1cb666ecd772f. Boendeforteckning will now correctly not render if no authentication. 
- Added check in infoclick so that infobox will not come up for layers that are not visible because of the min and max resolution functionality added in  038fadd816289da88b5aaff1726048989d04d1a6