### PR TITLE
Let the rotation icon always point to north

### DIFF
--- a/new-client/src/controls/Rotate.js
+++ b/new-client/src/controls/Rotate.js
@@ -57,7 +57,7 @@ const RotateControl = React.memo(props => {
             className={classes.button}
             onClick={rotateNorth}
           >
-            <NavigationIcon />
+            <NavigationIcon style={{ transform: `rotate(${rotation}rad)` }} />
           </Button>
         </Paper>
       </Tooltip>


### PR DESCRIPTION
The addition of a rotation button was really good. This adds a small fix that makes the icon always point to the north. Part of #368 