### PR TITLE
Admin ui cleanup

### DIFF
--- a/new-admin/src/index.css
+++ b/new-admin/src/index.css
@@ -56,6 +56,10 @@ article label.full {
   width: 300px;
 }
 
+.long-label {
+  white-space: nowrap;
+}
+
 article input[type="text"] {
   width: 400px;
   margin-right: 5px;

--- a/new-admin/src/views/mapoptions.jsx
+++ b/new-admin/src/views/mapoptions.jsx
@@ -328,6 +328,9 @@ class MapOptions extends Component {
               />
             </div>
             <div>
+              <div className="separator">
+                Grundinställningar för kartvisning
+              </div>
               <label>
                 Projektion{" "}
                 <i
@@ -434,27 +437,6 @@ class MapOptions extends Component {
             </div>
             <div>
               <label>
-                Logo{" "}
-                <i
-                  className="fa fa-question-circle"
-                  data-toggle="tooltip"
-                  title="Sökväg till logga att använda i <img>-taggen. Kan vara relativ Hajk-root eller absolut."
-                />
-              </label>
-              <input
-                type="text"
-                ref="input_logo"
-                value={this.state.logo}
-                className={this.getValidationClass("logo")}
-                onChange={e => {
-                  this.setState({ logo: e.target.value }, () =>
-                    this.validateField("logo")
-                  );
-                }}
-              />
-            </div>
-            <div>
-              <label>
                 Extent{" "}
                 <i
                   className="fa fa-question-circle"
@@ -475,14 +457,6 @@ class MapOptions extends Component {
               />
             </div>
             <div>
-              <label htmlFor="input_constrainOnlyCenter">
-                Lätta på extent{" "}
-                <i
-                  className="fa fa-question-circle"
-                  data-toggle="tooltip"
-                  title="Styr ol.Views 'constrainOnlyCenter'-parameter. Om sant kommer endast centrumkoordinaten att begränsas till extent."
-                />
-              </label>
               <input
                 id="input_constrainOnlyCenter"
                 type="checkbox"
@@ -493,6 +467,36 @@ class MapOptions extends Component {
                 checked={this.state.constrainOnlyCenter}
               />
               &nbsp;
+              <label className="long-label" htmlFor="input_constrainOnlyCenter">
+                Lätta på extent{" "}
+                <i
+                  className="fa fa-question-circle"
+                  data-toggle="tooltip"
+                  title="Styr ol.Views 'constrainOnlyCenter'-parameter. Om sant kommer endast centrumkoordinaten att begränsas till extent."
+                />
+              </label>
+            </div>
+            <div className="separator">Extra inställningar</div>
+            <div>
+              <label>
+                Logo{" "}
+                <i
+                  className="fa fa-question-circle"
+                  data-toggle="tooltip"
+                  title="Sökväg till logga att använda i <img>-taggen. Kan vara relativ Hajk-root eller absolut."
+                />
+              </label>
+              <input
+                type="text"
+                ref="input_logo"
+                value={this.state.logo}
+                className={this.getValidationClass("logo")}
+                onChange={e => {
+                  this.setState({ logo: e.target.value }, () =>
+                    this.validateField("logo")
+                  );
+                }}
+              />
             </div>
             <div>
               <label>
@@ -562,15 +566,8 @@ class MapOptions extends Component {
                 }}
               />
             </div>
+            <div className="separator">Extra kontroller i kartan</div>
             <div>
-              <label htmlFor="input_mapselector">
-                Visa kartväljare{" "}
-                <i
-                  className="fa fa-question-circle"
-                  data-toggle="tooltip"
-                  title="Om aktiv kommer en väljare med andra tillgängliga kartor att visas för användaren"
-                />
-              </label>
               <input
                 id="input_mapselector"
                 type="checkbox"
@@ -581,16 +578,16 @@ class MapOptions extends Component {
                 checked={this.state.mapselector}
               />
               &nbsp;
-            </div>
-            <div>
-              <label htmlFor="input_mapcleaner">
-                Visa knapp för att rensa kartan{" "}
+              <label className="long-label" htmlFor="input_mapselector">
+                Visa kartväljare{" "}
                 <i
                   className="fa fa-question-circle"
                   data-toggle="tooltip"
                   title="Om aktiv kommer en väljare med andra tillgängliga kartor att visas för användaren"
                 />
               </label>
+            </div>
+            <div>
               <input
                 id="input_mapcleaner"
                 type="checkbox"
@@ -601,16 +598,17 @@ class MapOptions extends Component {
                 checked={this.state.mapcleaner}
               />
               &nbsp;
-            </div>
-            <div>
-              <label htmlFor="input_drawerVisible">
-                Starta med sidopanelen synlig{" "}
+              <label className="long-label" htmlFor="input_mapcleaner">
+                Visa knapp för att rensa kartan{" "}
                 <i
                   className="fa fa-question-circle"
                   data-toggle="tooltip"
-                  title="Om aktiv kommer sidopanelen att vara synlig när kartan laddat"
+                  title="Om aktiv kommer en väljare med andra tillgängliga kartor att visas för användaren"
                 />
               </label>
+            </div>
+            <div className="separator">Inställningar för sidopanel</div>
+            <div>
               <input
                 id="input_drawerVisible"
                 type="checkbox"
@@ -627,16 +625,16 @@ class MapOptions extends Component {
                 checked={this.state.drawerVisible}
               />
               &nbsp;
-            </div>
-            <div>
-              <label htmlFor="input_drawerPermanent">
-                Låt sidopanelen vara låst vid start{" "}
+              <label className="long-label" htmlFor="input_drawerVisible">
+                Starta med sidopanelen synlig{" "}
                 <i
                   className="fa fa-question-circle"
                   data-toggle="tooltip"
-                  title="Om aktiv kommer sidopanelen att vara låst vid skärmens kant vid start (gäller ej mobila enheter)"
+                  title="Om aktiv kommer sidopanelen att vara synlig när kartan laddat"
                 />
               </label>
+            </div>
+            <div>
               <input
                 id="input_drawerPermanent"
                 type="checkbox"
@@ -648,7 +646,16 @@ class MapOptions extends Component {
                 disabled={this.state.drawerVisible !== true}
               />
               &nbsp;
+              <label className="long-label" htmlFor="input_drawerPermanent">
+                Låt sidopanelen vara låst vid start{" "}
+                <i
+                  className="fa fa-question-circle"
+                  data-toggle="tooltip"
+                  title="Om aktiv kommer sidopanelen att vara låst vid skärmens kant vid start (gäller ej mobila enheter)"
+                />
+              </label>
             </div>
+            <div className="separator">Färginställningar för kartan</div>
             <div className="clearfix">
               <span className="pull-left">
                 <div>Huvudfärg</div>

--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -1201,21 +1201,16 @@ class Menu extends Component {
    */
   renderThemeMapCheckbox() {
     return (
-      <div className="row">
-        <div className="col-sm-1">
-          <input
-            id="dropdownThemeMaps"
-            name="dropdownThemeMaps"
-            type="checkbox"
-            onChange={this.handleInputChange}
-            checked={this.state.dropdownThemeMaps}
-          />
-          &nbsp;
-        </div>
-        <label
-          className="layer-menu-label-checkbox"
-          htmlFor="dropdownThemeMaps"
-        >
+      <div>
+        <input
+          id="dropdownThemeMaps"
+          name="dropdownThemeMaps"
+          type="checkbox"
+          onChange={this.handleInputChange}
+          checked={this.state.dropdownThemeMaps}
+        />
+        &nbsp;
+        <label className="long-label" htmlFor="dropdownThemeMaps">
           Visa kartan i lista över tillgängliga kartor
         </label>
       </div>
@@ -1271,6 +1266,12 @@ class Menu extends Component {
               </button>
               &nbsp;
               <ul>{this.renderDrawOrder()}</ul>
+              <button
+                className="btn btn-primary"
+                onClick={e => this.saveDrawOrder(e)}
+              >
+                Spara
+              </button>
             </fieldset>
           </article>
         </div>
@@ -1299,102 +1300,20 @@ class Menu extends Component {
                 Spara
               </button>
               &nbsp;
-              <button
-                className="btn btn-success"
-                onClick={e => this.createGroup("Ny grupp", false, false)}
-              >
-                Ny grupp
-              </button>
-              &nbsp;
-              <div className="row">
-                <div className="col-sm-1">
-                  <input
-                    id="active"
-                    name="active"
-                    type="checkbox"
-                    onChange={this.handleInputChange}
-                    checked={this.state.active}
-                  />
-                  &nbsp;
-                </div>
-                <label className="layer-menu-label-checkbox" htmlFor="active">
+              <div>
+                <input
+                  id="active"
+                  name="active"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.active}
+                />
+                &nbsp;
+                <label className="long-label" htmlFor="active">
                   Aktiverad
                 </label>
               </div>
-              <div className="row">
-                <div className="col-sm-1">
-                  <input
-                    id="visibleAtStart"
-                    name="visibleAtStart"
-                    type="checkbox"
-                    onChange={this.handleInputChange}
-                    checked={this.state.visibleAtStart}
-                  />
-                  &nbsp;
-                </div>
-                <label
-                  className="layer-menu-label-checkbox"
-                  htmlFor="visibleAtStart"
-                >
-                  Synlig vid start
-                </label>
-              </div>
-              <div className="row">
-                <div className="col-sm-1">
-                  <input
-                    id="backgroundSwitcherBlack"
-                    name="backgroundSwitcherBlack"
-                    type="checkbox"
-                    onChange={this.handleInputChange}
-                    checked={this.state.backgroundSwitcherBlack}
-                  />
-                  &nbsp;
-                </div>
-                <label
-                  className="layer-menu-label-checkbox"
-                  htmlFor="backgroundSwitcherBlack"
-                >
-                  Svart bakgrundskarta
-                </label>
-              </div>
-              <div className="row">
-                <div className="col-sm-1">
-                  <input
-                    id="backgroundSwitcherWhite"
-                    name="backgroundSwitcherWhite"
-                    type="checkbox"
-                    onChange={this.handleInputChange}
-                    checked={this.state.backgroundSwitcherWhite}
-                  />
-                  &nbsp;
-                </div>
-                <label htmlFor="backgroundSwitcherWhite">
-                  Vit bakgrundskarta
-                </label>
-              </div>
-              <div className="row">
-                <div className="col-sm-1">
-                  <input
-                    id="showBreadcrumbs"
-                    name="showBreadcrumbs"
-                    type="checkbox"
-                    onChange={this.handleInputChange}
-                    checked={this.state.showBreadcrumbs}
-                  />
-                  &nbsp;
-                </div>
-                <label
-                  className="layer-menu-label-checkbox"
-                  htmlFor="showBreadcrumbs"
-                >
-                  Visa "brödsmulor"{" "}
-                  <i
-                    className="fa fa-question-circle"
-                    data-toggle="tooltip"
-                    title="När rutan är ikryssad visas små kort längst ned på skärmen, ett för varje lager som är aktivt"
-                  />
-                </label>
-              </div>
+              <div className="separator">Fönsterinställningar</div>
               <div className="row">
                 <div className="col-sm-12">
                   <label htmlFor="target">
@@ -1462,7 +1381,8 @@ class Menu extends Component {
                   <input
                     id="width"
                     name="width"
-                    type="text"
+                    type="number"
+                    min="0"
                     onChange={this.handleInputChange}
                     value={this.state.width}
                   />
@@ -1481,7 +1401,8 @@ class Menu extends Component {
                   <input
                     id="height"
                     name="height"
-                    type="text"
+                    type="number"
+                    min="0"
                     onChange={this.handleInputChange}
                     value={this.state.height}
                   />
@@ -1516,8 +1437,38 @@ class Menu extends Component {
                   />
                 </div>
               </div>
-              {this.renderThemeMapCheckbox()}
-              {this.renderThemeMapHeaderInput()}
+              <div className="separator">Inställningar för plugins</div>
+              <div>
+                <input
+                  id="visibleAtStart"
+                  name="visibleAtStart"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.visibleAtStart}
+                />
+                &nbsp;
+                <label className="long-label" htmlFor="visibleAtStart">
+                  Synlig vid start
+                </label>
+              </div>
+              <div>
+                <input
+                  id="showBreadcrumbs"
+                  name="showBreadcrumbs"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.showBreadcrumbs}
+                />
+                &nbsp;
+                <label className="long-label" htmlFor="showBreadcrumbs">
+                  Visa "brödsmulor"{" "}
+                  <i
+                    className="fa fa-question-circle"
+                    data-toggle="tooltip"
+                    title="När rutan är ikryssad visas små kort längst ned på skärmen, ett för varje lager som är aktivt"
+                  />
+                </label>
+              </div>
               <div className="row">
                 <div className="col-sm-12">
                   <label htmlFor="instruction">Instruktion</label>
@@ -1533,7 +1484,58 @@ class Menu extends Component {
                 </div>
               </div>
               <div className="row">{this.renderAuthGrps()}</div>
+              <div className="separator">Kartinställningar</div>
+              {this.renderThemeMapCheckbox()}
+              {this.renderThemeMapHeaderInput()}
+              <div className="separator">Inställningar för bakgrundslager</div>
+              <div>
+                <input
+                  id="backgroundSwitcherBlack"
+                  name="backgroundSwitcherBlack"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.backgroundSwitcherBlack}
+                />
+                &nbsp;
+                <label className="long-label" htmlFor="backgroundSwitcherBlack">
+                  Svart bakgrundskarta
+                </label>
+              </div>
+              <div>
+                <input
+                  id="backgroundSwitcherWhite"
+                  name="backgroundSwitcherWhite"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.backgroundSwitcherWhite}
+                />
+                &nbsp;
+                <label htmlFor="backgroundSwitcherWhite">
+                  Vit bakgrundskarta
+                </label>
+              </div>
+              <div className="separator">Justera lagerhanteraren</div>
+              <button
+                className="btn btn-primary"
+                onClick={e => this.saveSettings(e)}
+              >
+                Spara
+              </button>
+              &nbsp;
+              <button
+                className="btn btn-success"
+                onClick={e => this.createGroup("Ny grupp", false, false)}
+              >
+                Ny grupp
+              </button>
+              &nbsp;
               {this.renderLayerMenu()}
+              <button
+                className="btn btn-primary"
+                onClick={e => this.saveSettings(e)}
+              >
+                Spara
+              </button>
             </fieldset>
           </article>
           {this.state.adList}

--- a/new-admin/src/views/tools/anchor.jsx
+++ b/new-admin/src/views/tools/anchor.jsx
@@ -239,12 +239,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -299,7 +301,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -318,13 +321,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/bookmark.jsx
+++ b/new-admin/src/views/tools/bookmark.jsx
@@ -241,12 +241,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -301,7 +303,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -320,13 +323,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/buffer.jsx
+++ b/new-admin/src/views/tools/buffer.jsx
@@ -264,12 +264,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -324,7 +326,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -343,13 +346,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/collector.jsx
+++ b/new-admin/src/views/tools/collector.jsx
@@ -309,12 +309,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -369,7 +371,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -388,13 +391,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           {this.renderVisibleForGroups()}
           <div>
             <label htmlFor="url">Url</label>

--- a/new-admin/src/views/tools/coordinates.jsx
+++ b/new-admin/src/views/tools/coordinates.jsx
@@ -306,12 +306,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -366,7 +368,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -385,13 +388,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}
@@ -429,8 +434,9 @@ class ToolOptions extends Component {
                 <input name="code" type="text" />
               </div>
               <div>
-                <label>Standard*</label>
                 <input name="default" type="checkbox" />
+                &nbsp;
+                <label>Standard*</label>
               </div>
               <div>
                 <label>Beskrivning*</label>
@@ -449,8 +455,9 @@ class ToolOptions extends Component {
                 <input name="ytitle" type="text" />
               </div>
               <div>
-                <label>Inverterad</label>
                 <input name="inverseAxis" type="checkbox" />
+                &nbsp;
+                <label>Inverterad</label>
               </div>
               <button className="btn btn-success">Lägg till</button>
             </form>

--- a/new-admin/src/views/tools/draw.jsx
+++ b/new-admin/src/views/tools/draw.jsx
@@ -254,12 +254,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -314,7 +316,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -333,13 +336,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="exportUrl">URL till export-tjänst</label>
             <input
@@ -373,7 +378,9 @@ class ToolOptions extends Component {
               checked={this.state.base64Encode}
             />
             &nbsp;
-            <label htmlFor="Base64-active">Base64-encoding aktiverad</label>
+            <label className="long-label" htmlFor="Base64-active">
+              Base64-encoding aktiverad
+            </label>
           </div>
           <div>
             <label htmlFor="icons">Ikoner</label>

--- a/new-admin/src/views/tools/dummy.jsx
+++ b/new-admin/src/views/tools/dummy.jsx
@@ -236,12 +236,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -296,7 +298,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -315,13 +318,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           {this.renderVisibleForGroups()}
           <div>Inställningar för dummy plugin</div>
         </form>

--- a/new-admin/src/views/tools/edit.jsx
+++ b/new-admin/src/views/tools/edit.jsx
@@ -296,12 +296,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -356,7 +358,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -375,13 +378,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/export.jsx
+++ b/new-admin/src/views/tools/export.jsx
@@ -263,12 +263,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -323,7 +325,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -342,13 +345,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="scales">Skalor</label>
             <input
@@ -419,7 +424,9 @@ class ToolOptions extends Component {
               checked={this.state.base64Encode}
             />
             &nbsp;
-            <label htmlFor="Base64-active">Base64-encoding</label>
+            <label className="long-label" htmlFor="Base64-active">
+              Base64-encoding
+            </label>
           </div>
           <div>
             <input

--- a/new-admin/src/views/tools/infoclick.jsx
+++ b/new-admin/src/views/tools/infoclick.jsx
@@ -320,7 +320,8 @@ class ToolOptions extends Component {
               id="width"
               name="width"
               placeholder={defaultState.width}
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -340,7 +341,8 @@ class ToolOptions extends Component {
               id="height"
               name="height"
               placeholder={defaultState.height}
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -407,20 +409,6 @@ class ToolOptions extends Component {
             />
           </div>
           <div>
-            <label htmlFor="strokeColor">Färg på markerings ram (rgba)</label>
-            <SketchPicker
-              color={{
-                r: this.state.strokeColor.r,
-                b: this.state.strokeColor.b,
-                g: this.state.strokeColor.g,
-                a: this.state.strokeColor.a
-              }}
-              onChangeComplete={color =>
-                this.handleColorChange("strokeColor", color)
-              }
-            />
-          </div>
-          <div>
             <label htmlFor="strokeWidth">Bredd på markeringens ram (px)</label>
             <input
               value={this.state.strokeWidth}
@@ -435,21 +423,47 @@ class ToolOptions extends Component {
               }}
             />
           </div>
-          <div>
-            <label htmlFor="fillColor">
-              Färg på markeringens fyllnad (rgba)
-            </label>
-            <SketchPicker
-              color={{
-                r: this.state.fillColor.r,
-                b: this.state.fillColor.b,
-                g: this.state.fillColor.g,
-                a: this.state.fillColor.a
-              }}
-              onChangeComplete={color =>
-                this.handleColorChange("fillColor", color)
-              }
-            />
+          <div className="clearfix">
+            <span className="pull-left">
+              <div>
+                <label className="long-label" htmlFor="strokeColor">
+                  Färg på markerings ram (rgba)
+                </label>
+              </div>
+              <div>
+                <SketchPicker
+                  color={{
+                    r: this.state.strokeColor.r,
+                    b: this.state.strokeColor.b,
+                    g: this.state.strokeColor.g,
+                    a: this.state.strokeColor.a
+                  }}
+                  onChangeComplete={color =>
+                    this.handleColorChange("strokeColor", color)
+                  }
+                />
+              </div>
+            </span>
+            <span className="pull-left" style={{ marginLeft: "10px" }}>
+              <div>
+                <label className="long-label" htmlFor="fillColor">
+                  Färg på markeringens fyllnad (rgba)
+                </label>
+              </div>
+              <div>
+                <SketchPicker
+                  color={{
+                    r: this.state.fillColor.r,
+                    b: this.state.fillColor.b,
+                    g: this.state.fillColor.g,
+                    a: this.state.fillColor.a
+                  }}
+                  onChangeComplete={color =>
+                    this.handleColorChange("fillColor", color)
+                  }
+                />
+              </div>
+            </span>
           </div>
         </form>
       </div>

--- a/new-admin/src/views/tools/information.jsx
+++ b/new-admin/src/views/tools/information.jsx
@@ -241,18 +241,21 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.index}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <input
               id="visibleAtStart"
@@ -277,11 +280,13 @@ class ToolOptions extends Component {
               checked={this.state.showInfoOnce}
             />
             &nbsp;
-            <label htmlFor="showInfoOnce">Visa vid start endast en gång</label>
+            <label className="long-label" htmlFor="showInfoOnce">
+              Visa vid start endast en gång
+            </label>
           </div>
           <div>
             <label htmlFor="title">
-              Text vid mouse-over på informationsknappen
+              Text vid mouse-over på informations-knappen
             </label>
             <input
               value={this.state.title}

--- a/new-admin/src/views/tools/informative.jsx
+++ b/new-admin/src/views/tools/informative.jsx
@@ -290,25 +290,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
-          <div>
-            <input
-              id="tocExpanded"
-              name="tocExpanded"
-              type="checkbox"
-              onChange={e => {
-                this.handleInputChange(e);
-              }}
-              checked={this.state.tocExpanded}
-            />
-            &nbsp;
-            <label htmlFor="tocExpanded">Expanderad teckenförklaring</label>
-          </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -363,7 +352,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -382,14 +372,31 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           {this.renderVisibleForGroups()}
+          <div>
+            <input
+              id="tocExpanded"
+              name="tocExpanded"
+              type="checkbox"
+              onChange={e => {
+                this.handleInputChange(e);
+              }}
+              checked={this.state.tocExpanded}
+            />
+            &nbsp;
+            <label className="long-label" htmlFor="tocExpanded">
+              Expanderad teckenförklaring
+            </label>
+          </div>
           <div>
             <label htmlFor="abstract">
               Beskrivning{" "}

--- a/new-admin/src/views/tools/location.jsx
+++ b/new-admin/src/views/tools/location.jsx
@@ -232,12 +232,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -292,7 +294,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -311,13 +314,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          {/* <div className="separator">Övriga inställningar</div> */}
           {this.renderVisibleForGroups()}
         </form>
       </div>

--- a/new-admin/src/views/tools/measure.jsx
+++ b/new-admin/src/views/tools/measure.jsx
@@ -201,12 +201,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -261,7 +263,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -280,13 +283,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/preset.jsx
+++ b/new-admin/src/views/tools/preset.jsx
@@ -446,19 +446,22 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
-          {/*           <div>
-            <label htmlFor="index">Sorteringsordning</label>
-            <input
-              id="index"
-              name="index"
-              type="text"
-              onChange={e => {
-                this.handleInputChange(e);
-              }}
-              value={this.state.index}
-            />
-          </div>
- */}
+          {/*
+            <div className="separator">Fönsterinställningar</div>
+            <div>
+              <label htmlFor="index">Sorteringsordning</label>
+              <input
+                id="index"
+                name="index"
+                type="number"
+                min="0"
+                onChange={e => {
+                  this.handleInputChange(e);
+                }}
+                value={this.state.index}
+              />
+            </div>
+          */}
           {/*           <div>
             <label htmlFor="target">Verktygsplacering</label>
             <select
@@ -509,7 +512,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -528,7 +532,8 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -555,6 +560,7 @@ class ToolOptions extends Component {
               value={this.state.instruction ? atob(this.state.instruction) : ""}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
  */}
           {this.renderVisibleForGroups()}
           <div>

--- a/new-admin/src/views/tools/routing.jsx
+++ b/new-admin/src/views/tools/routing.jsx
@@ -243,12 +243,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -303,7 +305,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -322,25 +325,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
-          <div>
-            <label htmlFor="apiKey">API-nyckel</label>
-            <input
-              id="apiKey"
-              value={this.state.apiKey}
-              type="text"
-              name="apiKey"
-              onChange={e => {
-                this.handleInputChange(e);
-              }}
-            />
-          </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}
@@ -358,6 +351,18 @@ class ToolOptions extends Component {
                 this.handleInputChange(e);
               }}
               value={this.state.instruction ? atob(this.state.instruction) : ""}
+            />
+          </div>
+          <div>
+            <label htmlFor="apiKey">API-nyckel</label>
+            <input
+              id="apiKey"
+              value={this.state.apiKey}
+              type="text"
+              name="apiKey"
+              onChange={e => {
+                this.handleInputChange(e);
+              }}
             />
           </div>
           {this.renderVisibleForGroups()}

--- a/new-admin/src/views/tools/search.jsx
+++ b/new-admin/src/views/tools/search.jsx
@@ -525,7 +525,8 @@ class ToolOptions extends Component {
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -622,7 +623,11 @@ class ToolOptions extends Component {
             />
           </div>
           <div>
-            <label htmlFor="scale">Skala för ikon (flyttal, 0-1)</label>
+            <label htmlFor="scale">
+              Skala för ikon
+              <br />
+              (flyttal, 0-1)
+            </label>
             <input
               value={this.state.scale}
               type="number"
@@ -636,26 +641,9 @@ class ToolOptions extends Component {
               }}
             />
           </div>
+          <div className="separator">Träffmarkering (polygon)</div>
           <div>
-            <label htmlFor="strokeColor">
-              Träffmarkering (polygon) - Färg på ramen (rgba)
-            </label>
-            <SketchPicker
-              color={{
-                r: this.state.strokeColor.r,
-                g: this.state.strokeColor.g,
-                b: this.state.strokeColor.b,
-                a: this.state.strokeColor.a
-              }}
-              onChangeComplete={color =>
-                this.handleColorChange("strokeColor", color)
-              }
-            />
-          </div>
-          <div>
-            <label htmlFor="strokeWidth">
-              Träffmarkering (polygon) - Bredd på ramen (px)
-            </label>
+            <label htmlFor="strokeWidth">Bredd på ramen (px)</label>
             <input
               value={this.state.strokeWidth}
               type="number"
@@ -669,21 +657,43 @@ class ToolOptions extends Component {
               }}
             />
           </div>
-          <div>
-            <label htmlFor="fillColor">
-              Träffmarkering (polygon) - Färg på fyllningen (rgba)
-            </label>
-            <SketchPicker
-              color={{
-                r: this.state.fillColor.r,
-                g: this.state.fillColor.g,
-                b: this.state.fillColor.b,
-                a: this.state.fillColor.a
-              }}
-              onChangeComplete={color =>
-                this.handleColorChange("fillColor", color)
-              }
-            />
+          <div className="clearfix">
+            <span className="pull-left">
+              <div>
+                <label htmlFor="strokeColor">Färg på ramen (rgba)</label>
+              </div>
+              <SketchPicker
+                color={{
+                  r: this.state.strokeColor.r,
+                  g: this.state.strokeColor.g,
+                  b: this.state.strokeColor.b,
+                  a: this.state.strokeColor.a
+                }}
+                onChangeComplete={color =>
+                  this.handleColorChange("strokeColor", color)
+                }
+              />
+            </span>
+            <span className="pull-left" style={{ marginLeft: "10px" }}>
+              <div>
+                <div>
+                  <label className="long-label" htmlFor="fillColor">
+                    Färg på fyllningen (rgba)
+                  </label>
+                </div>
+                <SketchPicker
+                  color={{
+                    r: this.state.fillColor.r,
+                    g: this.state.fillColor.g,
+                    b: this.state.fillColor.b,
+                    a: this.state.fillColor.a
+                  }}
+                  onChangeComplete={color =>
+                    this.handleColorChange("fillColor", color)
+                  }
+                />
+              </div>
+            </span>
           </div>
 
           <div className="separator">Spatial sök</div>
@@ -711,6 +721,7 @@ class ToolOptions extends Component {
                 }}
                 checked={this.state.polygonSearch}
               />
+              &nbsp;
               <label htmlFor="polygonSearch">Polygon</label>
               <div>
                 <input
@@ -722,7 +733,8 @@ class ToolOptions extends Component {
                   }}
                   checked={this.state.radiusSearch}
                 />
-                <label htmlFor="radiusSearch">
+                &nbsp;
+                <label className="long-label" htmlFor="radiusSearch">
                   Radie (aktiverar även en knapp bredvid varje sökresultat)
                 </label>
               </div>
@@ -736,6 +748,7 @@ class ToolOptions extends Component {
                   }}
                   checked={this.state.selectionSearch}
                 />
+                &nbsp;
                 <label htmlFor="selectionSearch">Selektion</label>
               </div>
             </div>

--- a/new-admin/src/views/tools/streetview.jsx
+++ b/new-admin/src/views/tools/streetview.jsx
@@ -243,12 +243,14 @@ class ToolOptions extends Component {
             &nbsp;
             <label htmlFor="active">Aktiverad</label>
           </div>
+          <div className="separator">Fönsterinställningar</div>
           <div>
             <label htmlFor="index">Sorteringsordning</label>
             <input
               id="index"
               name="index"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -303,7 +305,8 @@ class ToolOptions extends Component {
             <input
               id="width"
               name="width"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
@@ -322,13 +325,15 @@ class ToolOptions extends Component {
             <input
               id="height"
               name="height"
-              type="text"
+              type="number"
+              min="0"
               onChange={e => {
                 this.handleInputChange(e);
               }}
               value={this.state.height}
             />
           </div>
+          <div className="separator">Övriga inställningar</div>
           <div>
             <label htmlFor="instruction">
               Instruktion{" "}

--- a/new-admin/src/views/tools/tool.jsx
+++ b/new-admin/src/views/tools/tool.jsx
@@ -172,7 +172,8 @@ class ToolOptions extends Component {
           <input
             id="index"
             name="index"
-            type="text"
+            type="number"
+            min="0"
             onChange={e => {
               this.handleInputChange(e);
             }}


### PR DESCRIPTION
Added separators in all plugins to more easily find and manage the different parts of the configuration.

The input fileds for numbers (Windows height/width ...) has been change to type="number" from "text" to prevent typing errors

part of #357 