### PR TITLE
Changed layout of pages for layer types

### DIFF
--- a/new-admin/src/views/edit.jsx
+++ b/new-admin/src/views/edit.jsx
@@ -737,6 +737,7 @@ class Search extends Component {
       <select
         ref="input_projection"
         value={this.state.projection}
+        className="control-fixed-width"
         onChange={e => {
           this.setState({
             projection: e.target.value

--- a/new-admin/src/views/informativeeditor.jsx
+++ b/new-admin/src/views/informativeeditor.jsx
@@ -635,6 +635,7 @@ class InformativeEditor extends Component {
         <div className="inset-form">
           <label>Välj dokument:&nbsp;</label>
           <select
+            className="control-fixed-width"
             onChange={e => {
               this.load(e.target.value);
             }}

--- a/new-admin/src/views/layerforms/arcgislayerform.jsx
+++ b/new-admin/src/views/layerforms/arcgislayerform.jsx
@@ -420,21 +420,7 @@ class ArcGISLayerForm extends Component {
     return (
       <fieldset>
         <legend>ArcGIS MapServer-lager</legend>
-        <div>
-          <label>Visningsnamn*</label>
-          <input
-            type="text"
-            ref="input_caption"
-            value={this.state.caption}
-            className={this.getValidationClass("caption")}
-            onChange={e => {
-              const v = e.target.value;
-              this.setState({ caption: v }, () =>
-                this.validateField("caption", v)
-              );
-            }}
-          />
-        </div>
+        <div className="separator">Anslutning</div>
         <div>
           <label>Url*</label>
           <input
@@ -456,40 +442,7 @@ class ArcGISLayerForm extends Component {
             Ladda {loader}
           </span>
         </div>
-        <div>
-          <label>Senast ändrad</label>
-          <span ref="input_date">
-            <i>{this.props.model.parseDate(this.state.date)}</i>
-          </span>
-        </div>
-        <div>
-          <label>Innehåll</label>
-          <input
-            type="text"
-            ref="input_content"
-            value={this.state.content}
-            onChange={e => {
-              this.setState({ content: e.target.value });
-            }}
-          />
-        </div>
-        <div>
-          <label>Teckenförklaring</label>
-          <input
-            type="text"
-            ref="input_legend"
-            value={this.state.legend}
-            onChange={e => this.setState({ legend: e.target.value })}
-          />
-          <span
-            onClick={e => {
-              this.loadLegendImage(e);
-            }}
-            className="btn btn-default"
-          >
-            Välj fil {imageLoader}
-          </span>
-        </div>
+        <div className="separator">Inställningar för request</div>
         <div>
           <label>Projektion*</label>
           <input
@@ -521,6 +474,76 @@ class ArcGISLayerForm extends Component {
           />
         </div>
         <div>
+          <input
+            type="checkbox"
+            ref="input_singleTile"
+            onChange={e => {
+              this.setState({ singleTile: e.target.checked });
+            }}
+            checked={this.state.singleTile}
+          />
+          &nbsp;
+          <label>Single tile</label>
+        </div>
+        <div className="separator">Tillgängliga lager</div>
+        <div>
+          <label>Lagerlista</label>
+          {this.renderLayerList()}
+        </div>
+        <div className="separator">Hantera valda lager</div>
+        <div>
+          <label>Valda lager*</label>
+          <div
+            ref="input_layers"
+            className={
+              this.getValidationClass("layers") + " layer-list-choosen"
+            }
+          >
+            <ul>{this.renderSelectedLayers()}</ul>
+          </div>
+        </div>
+        <div>
+          <label>Visningsnamn*</label>
+          <input
+            type="text"
+            ref="input_caption"
+            value={this.state.caption}
+            className={this.getValidationClass("caption")}
+            onChange={e => {
+              const v = e.target.value;
+              this.setState({ caption: v }, () =>
+                this.validateField("caption", v)
+              );
+            }}
+          />
+        </div>
+        <div>
+          <label>Inforuta</label>
+          <textarea
+            ref="input_infobox"
+            value={this.state.infobox}
+            onChange={e => this.setState({ infobox: e.target.value })}
+          />
+        </div>
+        <div>
+          <label>Teckenförklaring</label>
+          <input
+            type="text"
+            ref="input_legend"
+            value={this.state.legend}
+            onChange={e => this.setState({ legend: e.target.value })}
+          />
+          <span
+            onClick={e => {
+              this.loadLegendImage(e);
+            }}
+            className="btn btn-default"
+          >
+            Välj fil {imageLoader}
+          </span>
+        </div>
+
+        <div>
           <label>Opacitet*</label>
           <input
             type="number"
@@ -541,7 +564,6 @@ class ArcGISLayerForm extends Component {
           />
         </div>
         <div>
-          <label>Infoklickbar</label>
           <input
             type="checkbox"
             ref="input_queryable"
@@ -550,40 +572,26 @@ class ArcGISLayerForm extends Component {
             }}
             checked={this.state.queryable}
           />
+          &nbsp;
+          <label>Infoklickbar</label>
         </div>
+        <div className="separator">Metadata</div>
         <div>
-          <label>Single tile</label>
+          <label>Innehåll</label>
           <input
-            type="checkbox"
-            ref="input_singleTile"
+            type="text"
+            ref="input_content"
+            value={this.state.content}
             onChange={e => {
-              this.setState({ singleTile: e.target.checked });
+              this.setState({ content: e.target.value });
             }}
-            checked={this.state.singleTile}
           />
         </div>
         <div>
-          <label>Valda lager*</label>
-          <div
-            ref="input_layers"
-            className={
-              this.getValidationClass("layers") + " layer-list-choosen"
-            }
-          >
-            <ul>{this.renderSelectedLayers()}</ul>
-          </div>
-        </div>
-        <div>
-          <label>Lagerlista</label>
-          {this.renderLayerList()}
-        </div>
-        <div>
-          <label>Inforuta</label>
-          <textarea
-            ref="input_infobox"
-            value={this.state.infobox}
-            onChange={e => this.setState({ infobox: e.target.value })}
-          />
+          <label>Senast ändrad</label>
+          <span ref="input_date">
+            <i>{this.props.model.parseDate(this.state.date)}</i>
+          </span>
         </div>
         <div>
           <label>Upphovsrätt</label>
@@ -602,7 +610,6 @@ class ArcGISLayerForm extends Component {
         </div>
         <div className="info-container">
           <div>
-            <label htmlFor="info-document">Infodokument</label>
             <input
               type="checkbox"
               ref="input_infoVisible"
@@ -612,6 +619,8 @@ class ArcGISLayerForm extends Component {
               }}
               checked={this.state.infoVisible}
             />
+            &nbsp;
+            <label htmlFor="info-document">Infodokument</label>
           </div>
           <div className={infoClass}>
             <label>Rubrik</label>

--- a/new-admin/src/views/layerforms/vectorlayerform.jsx
+++ b/new-admin/src/views/layerforms/vectorlayerform.jsx
@@ -534,11 +534,13 @@ class VectorLayerForm extends Component {
     return (
       <fieldset>
         <legend>Vektor-lager</legend>
+        <div className="separator">Anslutning</div>
         <div>
           <label>Dataformat*</label>
           <select
             ref="input_dataFormat"
             value={this.state.dataFormat}
+            className="control-fixed-width"
             onChange={e => {
               this.setState({
                 dataFormat: e.target.value
@@ -548,21 +550,6 @@ class VectorLayerForm extends Component {
             <option>WFS</option>
             <option>GeoJSON</option>
           </select>
-        </div>
-        <div>
-          <label>Visningsnamn*</label>
-          <input
-            type="text"
-            ref="input_caption"
-            value={this.state.caption}
-            className={this.getValidationClass("caption")}
-            onChange={e => {
-              const v = e.target.value;
-              this.setState({ caption: v }, () =>
-                this.validateField("caption")
-              );
-            }}
-          />
         </div>
         <div>
           <label>Url*</label>
@@ -585,23 +572,12 @@ class VectorLayerForm extends Component {
             Ladda {loader}
           </span>
         </div>
+        <div className="separator">Tillgängliga lager</div>
         <div>
-          <label>Senast ändrad</label>
-          <span ref="input_date">
-            <i>{this.props.model.parseDate(this.state.date)}</i>
-          </span>
+          <label>Lagerlista</label>
+          {this.renderLayerList()}
         </div>
-        <div>
-          <label>Innehåll</label>
-          <input
-            type="text"
-            ref="input_content"
-            value={this.state.content}
-            onChange={e => {
-              this.setState({ content: e.target.value });
-            }}
-          />
-        </div>
+        <div className="separator">Hantera valda lager</div>
         <div>
           <label>Valt lager*</label>
           <div
@@ -612,8 +588,67 @@ class VectorLayerForm extends Component {
           </div>
         </div>
         <div>
-          <label>Lagerlista</label>
-          {this.renderLayerList()}
+          <label>Visningsnamn*</label>
+          <input
+            type="text"
+            ref="input_caption"
+            value={this.state.caption}
+            className={this.getValidationClass("caption")}
+            onChange={e => {
+              const v = e.target.value;
+              this.setState({ caption: v }, () =>
+                this.validateField("caption")
+              );
+            }}
+          />
+        </div>
+        <div>
+          <label>Projektion*</label>
+          <input
+            type="text"
+            ref="input_projection"
+            value={this.state.projection}
+            className={this.getValidationClass("projection")}
+            onChange={e => {
+              const v = e.target.value;
+              this.setState({ projection: v }, () =>
+                this.validateField("projection")
+              );
+            }}
+          />
+        </div>
+        <div>
+          <label>Opacitet*</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            max="1"
+            ref="input_opacity"
+            value={this.state.opacity}
+            className={
+              (this.getValidationClass("opacity"), "control-fixed-width")
+            }
+            onChange={e => {
+              const v = e.target.value;
+              this.setState({ opacity: v }, () =>
+                this.validateField("opacity")
+              );
+            }}
+          />
+        </div>
+        <div>
+          <input
+            type="checkbox"
+            ref="input_queryable"
+            id="queryable"
+            onChange={e => {
+              this.setState({ queryable: e.target.checked });
+            }}
+            checked={this.state.queryable}
+          />
+          &nbsp;
+          <label htmlFor="queryable">Infoklickbar</label>
         </div>
         <div>
           <label>Inforuta</label>
@@ -622,6 +657,20 @@ class VectorLayerForm extends Component {
             value={this.state.infobox}
             onChange={e => this.setState({ infobox: e.target.value })}
           />
+        </div>
+        <div className="separator">Filtrering</div>
+        <div>
+          <input
+            type="checkbox"
+            ref="input_filterable"
+            id="filterable"
+            onChange={e => {
+              this.setState({ filterable: e.target.checked });
+            }}
+            checked={this.state.filterable}
+          />
+          &nbsp;
+          <label htmlFor="filterable">Filterbar</label>
         </div>
         <div>
           <label>Filterattribut</label>
@@ -639,6 +688,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_filterComparer"
             value={this.state.filterComparer}
+            className="control-fixed-width"
             onChange={e => {
               this.setState({
                 filterComparer: e.target.value
@@ -662,6 +712,7 @@ class VectorLayerForm extends Component {
             }}
           />
         </div>
+        <div className="separator">Inställningar för objekt</div>
         <div>
           <label>Ikon</label>
           <input
@@ -717,6 +768,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_pointSize"
             value={this.state.pointSize}
+            className="control-fixed-width"
             onChange={e => {
               this.setPointSize(e);
             }}
@@ -733,6 +785,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_lineWidth"
             value={this.state.lineWidth}
+            className="control-fixed-width"
             onChange={e => {
               this.setLineWidth(e);
             }}
@@ -748,6 +801,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_lineStyle"
             value={this.state.lineStyle}
+            className="control-fixed-width"
             onChange={e => {
               this.setLineStyle(e);
             }}
@@ -757,29 +811,47 @@ class VectorLayerForm extends Component {
             <option value="dot">Punktad</option>
           </select>
         </div>
-        <div>
-          <label>Linjefärg</label>
-          <SketchPicker
-            color={this.state.lineColor}
-            onChangeComplete={color => this.setLineColor(color.rgb)}
-          />
+        <div className="clearfix">
+          <span className="pull-left">
+            <label>Fyllnadsfärg</label>
+            <br />
+            <SketchPicker
+              color={this.state.fillColor}
+              onChangeComplete={color => this.setFillColor(color.rgb)}
+            />
+          </span>
+          <span className="pull-left" style={{ marginLeft: "10px" }}>
+            <label>Linjefärg</label>
+            <br />
+            <SketchPicker
+              color={this.state.lineColor}
+              onChangeComplete={color => this.setLineColor(color.rgb)}
+            />
+          </span>
         </div>
+        <div className="separator">Inställningar för etiketter</div>
         <div>
-          <label>Fyllnadsfärg</label>
-          <SketchPicker
-            color={this.state.fillColor}
-            onChangeComplete={color => this.setFillColor(color.rgb)}
-          />
-        </div>
-        <div>
-          <label>Visa etikett</label>
           <input
             type="checkbox"
             ref="input_showLabels"
+            id="showLabels"
             onChange={e => {
               this.setState({ showLabels: e.target.checked });
             }}
             checked={this.state.showLabels}
+          />
+          &nbsp;
+          <label htmlFor="showLabels">Visa etikett</label>
+        </div>
+        <div>
+          <label>Attribut för text</label>
+          <input
+            type="text"
+            ref="input_labelAttribute"
+            value={this.state.labelAttribute}
+            onChange={e => {
+              this.setState({ labelAttribute: e.target.value });
+            }}
           />
         </div>
         <div>
@@ -787,6 +859,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_labelAlign"
             value={this.state.labelAlign}
+            className="control-fixed-width"
             onChange={e => {
               this.setLabelAlign(e);
             }}
@@ -802,6 +875,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_labelBaseline"
             value={this.state.labelBaseline}
+            className="control-fixed-width"
             onChange={e => {
               this.setLabelBaseline(e);
             }}
@@ -852,6 +926,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_labelWeight"
             value={this.state.labelWeight}
+            className="control-fixed-width"
             onChange={e => {
               this.setLabelWeight(e);
             }}
@@ -865,6 +940,7 @@ class VectorLayerForm extends Component {
           <select
             ref="input_labelFont"
             value={this.state.labelFont}
+            className="control-fixed-width"
             onChange={e => {
               this.setLabelFont(e);
             }}
@@ -875,104 +951,60 @@ class VectorLayerForm extends Component {
             <option value="Verdana">Verdana</option>
           </select>
         </div>
-        <div>
-          <label>Fyllnadsfärg (text)</label>
-          <SketchPicker
-            color={this.state.labelFillColor}
-            onChangeComplete={color => this.setLabelFillColor(color.rgb)}
-          />
-        </div>
-        <div>
-          <label>Kantlinjefärg (text)</label>
-          <SketchPicker
-            color={this.state.labelOutlineColor}
-            onChangeComplete={color => this.setLabelOutlineColor(color.rgb)}
-          />
-        </div>
+        <div className="separator">Etikettfärger</div>
         <div>
           <label>Kantlinjebredd (text)</label>
           <input
-            type="text"
+            type="number"
+            min="0"
             ref="input_labelOutlineWidth"
             value={this.state.labelOutlineWidth}
+            className="control-fixed-width"
             onChange={e => {
               this.setState({ labelOutlineWidth: e.target.value });
             }}
           />
         </div>
+        <div className="clearfix">
+          <span className="pull-left">
+            <label>Fyllnadsfärg (text)</label>
+            <br />
+            <SketchPicker
+              color={this.state.labelFillColor}
+              onChangeComplete={color => this.setLabelFillColor(color.rgb)}
+            />
+          </span>
+          <span className="pull-left" style={{ marginLeft: "10px" }}>
+            <label>Kantlinjefärg (text)</label>
+            <br />
+            <SketchPicker
+              color={this.state.labelOutlineColor}
+              onChangeComplete={color => this.setLabelOutlineColor(color.rgb)}
+            />
+          </span>
+        </div>
+
+        <div className="separator">Metadata</div>
         <div>
-          <label>Attribut för text</label>
+          <label>Innehåll</label>
           <input
             type="text"
-            ref="input_labelAttribute"
-            value={this.state.labelAttribute}
+            ref="input_content"
+            value={this.state.content}
             onChange={e => {
-              this.setState({ labelAttribute: e.target.value });
+              this.setState({ content: e.target.value });
             }}
           />
         </div>
         <div>
-          <label>Projektion*</label>
-          <input
-            type="text"
-            ref="input_projection"
-            value={this.state.projection}
-            className={this.getValidationClass("projection")}
-            onChange={e => {
-              const v = e.target.value;
-              this.setState({ projection: v }, () =>
-                this.validateField("projection")
-              );
-            }}
-          />
+          <label>Senast ändrad</label>
+          <span ref="input_date">
+            <i>{this.props.model.parseDate(this.state.date)}</i>
+          </span>
         </div>
-        <div>
-          <label>Opacitet*</label>
-          <input
-            type="number"
-            step="0.01"
-            min="0"
-            max="1"
-            ref="input_opacity"
-            value={this.state.opacity}
-            className={
-              (this.getValidationClass("opacity"), "control-fixed-width")
-            }
-            onChange={e => {
-              const v = e.target.value;
-              this.setState({ opacity: v }, () =>
-                this.validateField("opacity")
-              );
-            }}
-          />
-        </div>
-        <div>
-          <label htmlFor="queryable">Infoklickbar</label>
-          <input
-            type="checkbox"
-            ref="input_queryable"
-            id="queryable"
-            onChange={e => {
-              this.setState({ queryable: e.target.checked });
-            }}
-            checked={this.state.queryable}
-          />
-        </div>
-        <div>
-          <label htmlFor="filterable">Filterbar</label>
-          <input
-            type="checkbox"
-            ref="input_filterable"
-            id="filterable"
-            onChange={e => {
-              this.setState({ filterable: e.target.checked });
-            }}
-            checked={this.state.filterable}
-          />
-        </div>
+
         <div className="info-container">
           <div>
-            <label htmlFor="info-document">Infodokument</label>
             <input
               type="checkbox"
               ref="input_infoVisible"
@@ -982,6 +1014,8 @@ class VectorLayerForm extends Component {
               }}
               checked={this.state.infoVisible}
             />
+            &nbsp;
+            <label htmlFor="info-document">Infodokument</label>
           </div>
           <div className={infoClass}>
             <label>Rubrik</label>

--- a/new-admin/src/views/layerforms/wmslayerform.jsx
+++ b/new-admin/src/views/layerforms/wmslayerform.jsx
@@ -373,6 +373,7 @@ class WMSLayerForm extends Component {
           </div>
           <select
             value={layerInfo.style}
+            className="control-fixed-width"
             onChange={e => {
               let addedLayersInfo = this.state.addedLayersInfo;
               addedLayersInfo[layerInfo.id].style = e.target.value;
@@ -961,11 +962,24 @@ class WMSLayerForm extends Component {
     return (
       <fieldset>
         <legend>WMS-lager</legend>
+        <div className="separator">Anslutning</div>
         <div>
-          <label>
-            <b>Url*</b>
-          </label>
-          <br />
+          <label>Servertyp</label>
+          <select
+            className="control-fixed-width"
+            style={{ width: "50%" }}
+            ref="input_serverType"
+            value={this.state.serverType}
+            onChange={e => this.setState({ serverType: e.target.value })}
+          >
+            <option>geoserver</option>
+            <option>mapserver</option>
+            <option>qgis</option>
+            <option>arcgis</option>
+          </select>
+        </div>
+        <div>
+          <label>Url*</label>
           <input
             type="text"
             ref="input_url"
@@ -985,76 +999,74 @@ class WMSLayerForm extends Component {
             Ladda {loader}
           </span>
         </div>
-        <div
-          style={{
-            background: "rgb(238, 238, 238)",
-            float: "left",
-            width: "100%"
-          }}
-        >
-          <div style={{ width: "50%", padding: "15px", float: "left" }}>
-            <label>
-              <b>Version</b>
-            </label>
-            <br />
-            <select
-              ref="input_version"
-              onChange={this.selectVersion.bind(this)}
-              value={version}
-              className="form-control"
-            >
-              {this.state.capabilitiesList.map(capa => {
-                return (
-                  <option key={capa.version} value={capa.version}>
-                    {capa.version}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-          <div style={{ width: "50%", padding: "15px", float: "left" }}>
-            <label>
-              <b>Single tile</b>
-            </label>
-            <br />
-            <input
-              type="checkbox"
-              ref="input_singleTile"
-              onChange={e => this.setState({ singleTile: e.target.checked })}
-              checked={this.state.singleTile}
-            />
-          </div>
+        <div className="separator">Inställningar för request</div>
+        <div>
+          <label>Version</label>
+          <select
+            className="control-fixed-width"
+            style={{ width: "50%" }}
+            ref="input_version"
+            onChange={this.selectVersion.bind(this)}
+            value={version}
+          >
+            {this.state.capabilitiesList.map(capa => {
+              return (
+                <option key={capa.version} value={capa.version}>
+                  {capa.version}
+                </option>
+              );
+            })}
+          </select>
         </div>
         <div>
-          <label>
-            <b>Bildformat</b>
-          </label>
-          <br />
+          <label>Bildformat</label>
           <select
+            className="control-fixed-width"
             style={{ width: "50%" }}
             ref="input_imageFormat"
             value={this.state.imageFormat}
             onChange={e => this.setState({ imageFormat: e.target.value })}
-            className="form-control"
           >
             {this.setImageFormats()}
           </select>
         </div>
         <div>
-          <label>
-            <b>Koordinatsystem</b>
-          </label>
-          <br />
+          <label>Koordinatsystem</label>
           <select
+            className="control-fixed-width"
             style={{ width: "50%" }}
             ref="input_projection"
             value={this.state.projection !== null ? this.state.projection : ""}
             onChange={e => this.setState({ projection: e.target.value })}
-            className="form-control"
           >
             {this.setProjections()}
           </select>
         </div>
+        <div>
+          <input
+            type="checkbox"
+            ref="input_singleTile"
+            id="input_singleTile"
+            onChange={e => this.setState({ singleTile: e.target.checked })}
+            checked={this.state.singleTile}
+          />
+          &nbsp;
+          <label htmlFor="input_singleTile">Single tile</label>
+        </div>
+        <div>
+          <input
+            type="checkbox"
+            ref="input_tiled"
+            id="input_tiled"
+            onChange={e => {
+              this.setState({ tiled: e.target.checked });
+            }}
+            checked={this.state.tiled}
+          />
+          &nbsp;
+          <label htmlFor="input_tiled">GeoWebCache</label>
+        </div>
+        <div className="separator">Tillgängliga lager</div>
         <div>
           <table
             style={{
@@ -1074,11 +1086,9 @@ class WMSLayerForm extends Component {
             {this.renderLayerList()}
           </table>
         </div>
+        <div className="separator">Hantera valda lager</div>
         <div>
-          <label>
-            <b>Valda lager*</b>
-          </label>
-          <br />
+          <label>Valda lager*</label>
           <div
             ref="input_layers"
             className={
@@ -1089,10 +1099,7 @@ class WMSLayerForm extends Component {
           </div>
         </div>
         <div>
-          <label>
-            <b>Visningsnamn*</b>
-          </label>
-          <br />
+          <label>Visningsnamn*</label>
           <input
             type="text"
             ref="input_caption"
@@ -1104,49 +1111,9 @@ class WMSLayerForm extends Component {
             className={this.getValidationClass("caption")}
           />
         </div>
+
         <div>
-          <label>
-            <b>Innehåll</b>
-          </label>
-          <br />
-          <input
-            type="text"
-            ref="input_content"
-            value={this.state.content}
-            onChange={e => this.setState({ content: e.target.value })}
-            className="form-control"
-          />
-        </div>
-        <div>
-          <label>
-            <b>Senast ändrad</b>
-          </label>
-          <br />
-          <span ref="input_date">
-            <i>{this.props.model.parseDate(this.state.date)}</i>
-          </span>
-        </div>
-        <div>
-          <label>
-            <b>Upphovsrätt</b>
-          </label>
-          <br />
-          <input
-            type="text"
-            ref="input_attribution"
-            onChange={e => {
-              this.setState({ attribution: e.target.value });
-              this.validateField("attribution", e);
-            }}
-            value={this.state.attribution}
-            className={this.getValidationClass("attribution")}
-          />
-        </div>
-        <div>
-          <label>
-            <b>Teckenförklaring</b>
-          </label>
-          <br />
+          <label>Teckenförklaring</label>
           <input
             type="text"
             ref="input_legend"
@@ -1163,43 +1130,20 @@ class WMSLayerForm extends Component {
           </span>
         </div>
         <div>
-          <label>
-            <b>Infoklick-format</b>
-          </label>
-          <br />
+          <label>Infoklick-format</label>
           <select
-            style={{ width: "50%" }}
+            className="control-fixed-width"
+            style={{ width: "50%", dispaly: "in-line" }}
             ref="input_infoFormat"
             value={infoFormat}
             onChange={e => this.setState({ infoFormat: e.target.value })}
-            className="form-control"
           >
             {this.setInfoFormats()}
           </select>
         </div>
+
         <div>
-          <label>
-            <b>Servertyp</b>
-          </label>
-          <br />
-          <select
-            style={{ width: "50%" }}
-            ref="input_serverType"
-            value={this.state.serverType}
-            onChange={e => this.setState({ serverType: e.target.value })}
-            className="form-control"
-          >
-            <option>geoserver</option>
-            <option>mapserver</option>
-            <option>qgis</option>
-            <option>arcgis</option>
-          </select>
-        </div>
-        <div>
-          <label>
-            <b>Opacitet*</b>
-          </label>
-          <br />
+          <label>Opacitet*</label>
           <input
             type="number"
             step="0.01"
@@ -1216,11 +1160,38 @@ class WMSLayerForm extends Component {
             }}
           />
         </div>
+        <div className="separator">Metadata</div>
+        <div>
+          <label>Innehåll</label>
+          <input
+            className="control-fixed-width"
+            type="text"
+            ref="input_content"
+            value={this.state.content}
+            onChange={e => this.setState({ content: e.target.value })}
+          />
+        </div>
+        <div>
+          <label>Senast ändrad</label>
+          <span ref="input_date">
+            <i>{this.props.model.parseDate(this.state.date)}</i>
+          </span>
+        </div>
+        <div>
+          <label>Upphovsrätt</label>
+          <input
+            type="text"
+            ref="input_attribution"
+            onChange={e => {
+              this.setState({ attribution: e.target.value });
+              this.validateField("attribution", e);
+            }}
+            value={this.state.attribution}
+            className={this.getValidationClass("attribution")}
+          />
+        </div>
         <div className="info-container">
           <div>
-            <label htmlFor="info-document">
-              <b>Infodokument</b>
-            </label>
             <input
               type="checkbox"
               ref="input_infoVisible"
@@ -1230,6 +1201,8 @@ class WMSLayerForm extends Component {
               }}
               checked={this.state.infoVisible}
             />
+            &nbsp;
+            <label htmlFor="info-document">Infodokument</label>
           </div>
           <div className={infoClass}>
             <label>Rubrik</label>
@@ -1299,20 +1272,8 @@ class WMSLayerForm extends Component {
             />
           </div>
         </div>
-        <div>
-          <label>
-            <b>GeoWebCache</b>
-          </label>
-          <input
-            type="checkbox"
-            ref="input_tiled"
-            onChange={e => {
-              this.setState({ tiled: e.target.checked });
-            }}
-            checked={this.state.tiled}
-          />
-        </div>
-        <h2>Sökning</h2>
+        <div className="separator">Sökning</div>
+        {/* <h2>Sökning</h2> */}
         <div>
           <label>Url</label>
           <input

--- a/new-admin/src/views/layerforms/wmtslayerform.jsx
+++ b/new-admin/src/views/layerforms/wmtslayerform.jsx
@@ -238,20 +238,7 @@ class WMTSLayerForm extends Component {
     return (
       <fieldset>
         <legend>WMTS-lager</legend>
-        <div>
-          <label>Visningsnamn*</label>
-          <input
-            type="text"
-            ref="input_caption"
-            value={this.state.caption}
-            className={this.getValidationClass("caption")}
-            onChange={e => {
-              this.setState({ caption: e.target.value }, () =>
-                this.validateField("caption")
-              );
-            }}
-          />
-        </div>
+        <div className="separator">Val av lager</div>
         <div>
           <label>Url*</label>
           <input
@@ -267,19 +254,29 @@ class WMTSLayerForm extends Component {
           />
         </div>
         <div>
-          <label>Senast ändrad</label>
-          <span ref="input_date">
-            <i>{this.props.model.parseDate(this.state.date)}</i>
-          </span>
-        </div>
-        <div>
-          <label>Innehåll</label>
+          <label>Lager*</label>
           <input
             type="text"
-            ref="input_content"
-            value={this.state.content}
+            ref="input_layer"
             onChange={e => {
-              this.setState({ content: e.target.value });
+              const v = e.target.value;
+              this.setState({ layer: v }, () => this.validateField("layer", v));
+            }}
+            value={this.state.layer}
+            className={this.getValidationClass("layer")}
+          />
+        </div>
+        <div>
+          <label>Visningsnamn*</label>
+          <input
+            type="text"
+            ref="input_caption"
+            value={this.state.caption}
+            className={this.getValidationClass("caption")}
+            onChange={e => {
+              this.setState({ caption: e.target.value }, () =>
+                this.validateField("caption")
+              );
             }}
           />
         </div>
@@ -300,19 +297,7 @@ class WMTSLayerForm extends Component {
             Välj fil {imageLoader}
           </span>
         </div>
-        <div>
-          <label>Lager*</label>
-          <input
-            type="text"
-            ref="input_layer"
-            onChange={e => {
-              const v = e.target.value;
-              this.setState({ layer: v }, () => this.validateField("layer", v));
-            }}
-            value={this.state.layer}
-            className={this.getValidationClass("layer")}
-          />
-        </div>
+        <div className="separator">Inställningar för request</div>
         <div>
           <label>Matrisuppsättning*</label>
           <input
@@ -401,6 +386,24 @@ class WMTSLayerForm extends Component {
             className={this.getValidationClass("matrixIds")}
           />
         </div>
+        <div className="separator">Metadata</div>
+        <div>
+          <label>Innehåll</label>
+          <input
+            type="text"
+            ref="input_content"
+            value={this.state.content}
+            onChange={e => {
+              this.setState({ content: e.target.value });
+            }}
+          />
+        </div>
+        <div>
+          <label>Senast ändrad</label>
+          <span ref="input_date">
+            <i>{this.props.model.parseDate(this.state.date)}</i>
+          </span>
+        </div>
         <div>
           <label>Upphovsrätt</label>
           <input
@@ -418,7 +421,6 @@ class WMTSLayerForm extends Component {
         </div>
         <div className="info-container">
           <div>
-            <label htmlFor="info-document">Infodokument</label>
             <input
               type="checkbox"
               ref="input_infoVisible"
@@ -428,6 +430,8 @@ class WMTSLayerForm extends Component {
               }}
               checked={this.state.infoVisible}
             />
+            &nbsp;
+            <label htmlFor="info-document">Infodokument</label>
           </div>
           <div className={infoClass}>
             <label>Rubrik</label>

--- a/new-admin/src/views/layermanager.jsx
+++ b/new-admin/src/views/layermanager.jsx
@@ -721,6 +721,7 @@ class Manager extends Component {
               <select
                 disabled={typeSelectorDisabled}
                 value={this.state.layerType}
+                className="control-fixed-width"
                 onChange={e => {
                   this.setState({ layerType: e.target.value });
                 }}

--- a/new-admin/src/views/search.jsx
+++ b/new-admin/src/views/search.jsx
@@ -804,6 +804,7 @@ class Search extends Component {
                 <select
                   ref="input_outputFormat"
                   value={this.state.outputFormat}
+                  className="control-fixed-width"
                   onChange={e => {
                     this.setState(
                       {


### PR DESCRIPTION
Have made same changes that other pages for admin has already got. Dividers are now in place on every page for layer types as well.

Some ui-fixes to some input/select that i have found since the last pull request

part of #357 