### PR TITLE
Changed background color for active tab

### DIFF
--- a/new-admin/src/index.css
+++ b/new-admin/src/index.css
@@ -330,6 +330,10 @@ body.dragging * {
   overflow: hidden;
 }
 
+.nav-tabs .nav-link.active {
+  background-color: #f8f8f8;
+}
+
 .tab-pane-bar {
   margin: 0 0 18px 0;
 }


### PR DESCRIPTION
Changed background color for active tab to make it easier to see which tab is active
![image](https://user-images.githubusercontent.com/50202826/74744396-74ea3480-5262-11ea-860a-d78fb2bc492c.png)

part of #357 