### PR TITLE
Added property scrollable to basewindowplugin to be able do disable s…

### DIFF
--- a/new-client/src/components/Window.js
+++ b/new-client/src/components/Window.js
@@ -5,6 +5,7 @@ import PanelHeader from "./PanelHeader";
 import { Rnd } from "react-rnd";
 import { isMobile, getIsMobile } from "../utils/IsMobile.js";
 import FeatureInfo from "./FeatureInfo.js";
+import clsx from "clsx";
 
 const zIndexStart = 1e3;
 // Patch the RND component's onDragStart method with the ability to disable drag by its internal state.
@@ -120,6 +121,10 @@ const styles = theme => {
       overflowY: "auto",
       padding: "10px",
       cursor: "default !important"
+    },
+    nonScrollable: {
+      overflowY: "hidden",
+      padding: "0px"
     }
   };
 };
@@ -147,7 +152,8 @@ class Window extends React.PureComponent {
   static defaultProps = {
     draggingEnabled: true,
     resizingEnabled: true,
-    allowMaximizedWindow: true
+    allowMaximizedWindow: true,
+    scrollable: true
   };
 
   constructor(props) {
@@ -499,7 +505,12 @@ class Window extends React.PureComponent {
             onMinimize={this.minimize}
             mode={this.mode}
           />
-          <section className={classes.content}>
+          <section
+            className={clsx(
+              classes.content,
+              this.props.scrollable ? null : classes.nonScrollable
+            )}
+          >
             {features ? (
               <FeatureInfo
                 features={this.props.features}

--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -121,6 +121,7 @@ class BaseWindowPlugin extends React.PureComponent {
           onResize={this.props.custom.onResize}
           draggingEnabled={this.props.custom.draggingEnabled}
           resizingEnabled={this.props.custom.resizingEnabled}
+          scrollable={this.props.custom.scrollable}
           allowMaximizedWindow={this.props.custom.allowMaximizedWindow}
           width={this.width}
           height={this.height}


### PR DESCRIPTION
…croll and handle scroll in own component

Added property "scrollable" to BaseWindowplugin to be able to disable the overflowY and padding for the rendered component in Window component.  This is needed to be able to control scroll-behaviour in "own" plugin