### PR TITLE
Changed justify-content to flex-start instead of space-between

### DIFF
--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -78,7 +78,7 @@ const styles = theme => {
       zIndex: theme.zIndex.appBar,
       height: theme.spacing(8),
       display: "flex",
-      justifyContent: "space-between",
+      justifyContent: "flex-start",
       alignItems: "flex-start",
       [theme.breakpoints.down("xs")]: {
         zIndex: 3


### PR DESCRIPTION
Minor change to header
 
Changed justify-content to flex-start instead of stretch to let everything in header float to the left.
This makes it possible to use margins to separate components rendered in header instead of letting flexbox force a space between them

Needed for new documentPlugin (menu should be left-aligned against search)

