### PR TITLE
Added missing customprops for basewindowplugin

### DIFF
--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -119,6 +119,8 @@ class BaseWindowPlugin extends React.PureComponent {
           onClose={this.closeWindow}
           open={this.state.windowVisible}
           onResize={this.props.custom.onResize}
+          onMaximize={this.props.custom.onMaximize}
+          onMinimize={this.props.custom.onMinimize}
           draggingEnabled={this.props.custom.draggingEnabled}
           resizingEnabled={this.props.custom.resizingEnabled}
           scrollable={this.props.custom.scrollable}


### PR DESCRIPTION
Adding the customprops onMaximize and onMinimize to baseWindowPlugin. Already implemented in Window.js but was not able to send them through parameters in baseWindowPlugin.

Useful when you want to know if window is being maximized or minimzed and not only resized.