### PR TITLE
Removed padding from search so it follows theme.spacing

### DIFF
--- a/new-client/src/plugins/search/search.js
+++ b/new-client/src/plugins/search/search.js
@@ -26,7 +26,6 @@ import SearchIcon from "@material-ui/icons/Search";
 const styles = theme => {
   return {
     root: {
-      padding: "2px 4px",
       display: "flex",
       alignItems: "center",
       minWidth: 200,


### PR DESCRIPTION
Removed padding in root for search to follow the theme.spacing and not add some extra pixels.
Shouldn't be a problem?