### PR TITLE
Added layer name to dialog when deleting layer

### DIFF
--- a/new-admin/src/views/layermanager.jsx
+++ b/new-admin/src/views/layermanager.jsx
@@ -159,7 +159,7 @@ class Manager extends Component {
     this.setState({
       alert: true,
       confirm: true,
-      alertMessage: "Lagret kommer att tas bort. Är detta ok?",
+      alertMessage: `Lagret "${layer.caption}" kommer att tas bort. Är detta ok?`,
       confirmAction: () => {
         this.props.model.removeLayer(layer, success => {
           if (success) {
@@ -174,7 +174,7 @@ class Manager extends Component {
           } else {
             this.setState({
               alert: true,
-              alertMessage: "Lagret kunde inte tas bort. Försök igen senare."
+              alertMessage: `Lagret "${layer.caption}" kunde inte tas bort. Försök igen senare.`
             });
           }
         });


### PR DESCRIPTION
Now the layer name will show up in all dialogs when deleting a layer. Not just the dialog when layer has been deleted.
![image](https://user-images.githubusercontent.com/50202826/83129616-586d5c00-a0dd-11ea-8d91-040868749b3b.png)

