### PR TITLE
Make 'markera flera' optional in search tool.

### DIFF
--- a/admin/src/js/views/tools/search.jsx
+++ b/admin/src/js/views/tools/search.jsx
@@ -33,6 +33,7 @@ var defaultState = {
   bothSynlig: false,
   enableViewTogglePopupInSnabbsok: true,
   selectionTools: true,
+  displayMultiAreaSelectButton: true,
   base64Encode: false,
   instruction: '',
   filterVisible: true,
@@ -79,6 +80,7 @@ class ToolOptions extends Component {
         bothSynlig: tool.options.bothSynlig,
         enableViewTogglePopupInSnabbsok: tool.options.enableViewTogglePopupInSnabbsok,
         selectionTools: tool.options.selectionTools,
+        displayMultiAreaSelectButton: tool.options.displayMultiAreaSelectButton || this.state.displayMultiAreaSelectButton,
         base64Encode: tool.options.base64Encode,
         instruction: tool.options.instruction,
         filterVisible: tool.options.filterVisible,
@@ -210,6 +212,7 @@ class ToolOptions extends Component {
         excelExportUrl: this.state.excelExportUrl,
         displayPopup: this.state.displayPopup,
         selectionTools: this.state.selectionTools,
+        displayMultiAreaSelectButton: this.state.displayMultiAreaSelectButton,
         base64Encode: this.state.base64Encode,
         instruction: this.state.instruction,
         filterVisible: this.state.filterVisible,
@@ -417,6 +420,15 @@ class ToolOptions extends Component {
               onChange={(e) => { this.handleInputChange(e); }}
               checked={this.state.selectionTools} />&nbsp;
             <label htmlFor='selectionTools'>Verktyg för ytsökning</label>
+          </div>
+          <div>
+            <input
+              id='displayMultiAreaSelectButton'
+              name='displayMultiAreaSelectButton'
+              type='checkbox'
+              onChange={(e) => { this.handleInputChange(e); }}
+              checked={this.state.displayMultiAreaSelectButton} />&nbsp;
+            <label htmlFor='selectionTools'>Aktivera markera flera område</label>
           </div>
           <div>
             <input

--- a/client/src/js/tools/search.js
+++ b/client/src/js/tools/search.js
@@ -39,6 +39,7 @@ var SearchModelProperties = {
   maxZoom: 14,
   exportUrl: '',
   selectionTools: false,
+  displayMultiAreaSelectButton: true,
   displayPopup: false,
   displayPopupBar: true,
   hits: [],

--- a/client/src/js/views/components/search.jsx
+++ b/client/src/js/views/components/search.jsx
@@ -420,7 +420,9 @@ var SearchView = {
     };
 
     var selectionToolbar = this.props.model.get('selectionTools')
-      ? <SelectionToolbar model={this.props.model.get('selectionModel')} />
+      ? <SelectionToolbar 
+          model={this.props.model.get('selectionModel')} 
+          displayMultiAreaSelectButton={this.props.model.get('displayMultiAreaSelectButton')}/>
       : null;
 
     return (

--- a/client/src/js/views/components/selectiontoolbar.jsx
+++ b/client/src/js/views/components/selectiontoolbar.jsx
@@ -75,31 +75,48 @@ var SelectionPanelView = {
    */
   render: function() {
     var anchor = this.props.model.get("anchor");
+    const displayMultiAreaSelectButton = this.props.displayMultiAreaSelectButton;
+
+    const DrawSelectionButton = (
+      <button
+        onClick={() => this.activateTool("drawSelection")}
+        type="button"
+        className={this.getClassNames("drawSelection")}
+        title="Markera efter polygon"
+      >
+        <i className="fa iconmoon-yta icon" />
+      </button>
+    );
+
+    const MultiSelectButton = (
+      <button
+        onClick={() => this.activateTool("multiSelect")}
+        type="button"
+        className={this.getClassNames("multiSelect")}
+        title="Markera flera objekt"
+      >
+        <i className="fa fa-plus icon" />
+      </button>
+    );
 
     return (
       <div className="selection-toolbar">
         <div>Sök baserat på markering i kartan</div>
-        <div className="btn-group btn-group-lg">
-          <button
-            onClick={() => this.activateTool("drawSelection")}
-            type="button"
-            className={this.getClassNames("drawSelection")}
-            title="Markera efter polygon"
-          >
-            <i className="fa iconmoon-yta icon" />
-          </button>
-          <button
-            onClick={() => this.activateTool("multiSelect")}
-            type="button"
-            className={this.getClassNames("multiSelect")}
-            title="Markera flera objekt"
-          >
-            <i className="fa fa-plus icon" />
-          </button>
-        </div>
+
+        {displayMultiAreaSelectButton ? (
+          <div className="btn-group btn-group-lg">
+            {DrawSelectionButton}
+            {MultiSelectButton}
+          </div>
+        ) : (
+          <div className="btn-group btn-group-lg">
+            {DrawSelectionButton}
+          </div>
+        )}
+
         <div
           className="btn btn-link"
-          onClick={e => {
+          onClick={(e) => {
             e.preventDefault();
             this.props.model.abort();
           }}


### PR DESCRIPTION
Makes 'markera flera' button within the search tool panel optional from admin and config.  'Markera flera' does not work reliably and Varberg don't use it. This change is a part of Varberg moving private customizations to be configurable in hajk2.

Default is that the button renders as normal, unless this is set to false in admin. 
If the option "displayMultiAreaSelectButton" is not added to config, the button will show as normal. 

