### PR TITLE
Fix search js vbg anpassning/vbg

### DIFF
--- a/backend/mapservice/Components/MapExport/MapExporter.cs
+++ b/backend/mapservice/Components/MapExport/MapExporter.cs
@@ -572,7 +572,21 @@ namespace MapService.Components.MapExport
                             
                             _log.DebugFormat("url: {0}", url);
                             WebClient wc = new WebClient();
-                            byte[] bytes = wc.DownloadData(protocol + url + "/" + featureStyle.pointSrc);                            
+                            string downloadUrl = protocol + url + "/" + featureStyle.pointSrc; // http://localhost:123/http://localhost:9000/assets...
+
+                            // pointSrc will contain the whole URI for some configs, so we need to detect this to prevent from adding the protocol and domain twice
+                            try
+                            {
+                                if (featureStyle.pointSrc.Substring(0, "http://".Length) == "http://" || featureStyle.pointSrc.Substring(0, "https://".Length) == "https://")
+                                {
+                                    downloadUrl = featureStyle.pointSrc;
+                                }
+                            } catch (Exception e)
+                            {
+
+                            }
+                            _log.DebugFormat("Try to download : {0}", downloadUrl);
+                            byte[] bytes = wc.DownloadData(downloadUrl);                            
                             style.Symbol = this.ImageFromBytes(bytes);                            
                         }
                         catch (Exception ex)

--- a/backend/mapservice/Components/MapExport/MapExporter.cs
+++ b/backend/mapservice/Components/MapExport/MapExporter.cs
@@ -577,6 +577,7 @@ namespace MapService.Components.MapExport
                             // pointSrc will contain the whole URI for some configs, so we need to detect this to prevent from adding the protocol and domain twice
                             try
                             {
+                                // This should be backwards compatible
                                 if (featureStyle.pointSrc.Substring(0, "http://".Length) == "http://" || featureStyle.pointSrc.Substring(0, "https://".Length) == "https://")
                                 {
                                     downloadUrl = featureStyle.pointSrc;

--- a/client/src/js/tools/infoclick.js
+++ b/client/src/js/tools/infoclick.js
@@ -427,7 +427,7 @@ var InfoClickModel = {
     properties = feature.getProperties();
     information = layerModel && layerModel.get('information') || '';
 
-    if (feature.infobox) {
+    if (feature.infobox && typeof feature.infobox === "string" && feature.infobox.length > 0) {
       information = feature.infobox;
       information = information.replace(/export:/g, '');
     }

--- a/client/src/js/tools/search.js
+++ b/client/src/js/tools/search.js
@@ -720,18 +720,17 @@ var SearchModel = {
       };
 
       var getAlias = (column, infobox) => {
-        var regExp = new RegExp(`{export:${column}( as .*)?}`),
+        var regExp = new RegExp(`{export:${column}( as [^}]+)?}`),
           result = regExp.exec(infobox);
 
         if (result && result[1]) {
           result[1] = result[1].replace(" as ", "");
         }
-
         return result && result[1] ? result[1] : column;
       };
 
       values = groups[group].map((hit) => {
-        if (typeof hit.aliasDict !== 'undefined' && hit.aliasDict !== null) {
+        if (typeof hit.aliasDict !== 'undefined' && hit.aliasDict !== null && Object.keys(hit.aliasDict).length > 0) {
           var attributes = hit.getProperties(),
             names = Object.keys(attributes),
             aliasKeys = Object.keys(hit.aliasDict);
@@ -749,7 +748,7 @@ var SearchModel = {
                 typeof attributes[name] === "number"
               );
             } else {
-              let regExp = new RegExp(`{export:${name}( as .*)?}`);
+              let regExp = new RegExp(`{export:${name}( as [^}]+)?}`);
               return regExp.test(hit.infobox);
             }
           });
@@ -761,13 +760,12 @@ var SearchModel = {
         }
 
         columns.forEach((column, i) => {
-          if (typeof hit.aliasDict !== "undefined" && hit.aliasDict !== null) {
+          if (typeof hit.aliasDict !== "undefined" && hit.aliasDict !== null && Object.keys(hit.aliasDict).length > 0) {
             aliases[i] = getAliasWithDict(column, hit.aliasDict);
           } else {
             aliases[i] = getAlias(column, hit.infobox);
           }
         });
-
           return columns.map(column => {
                   if (column == "nyckel") {
                       return Number(attributes[column]);


### PR DESCRIPTION
Fixed a bug for when names of column headers are specified as {export:<name from db> as <column name in Excel>. Also fixed a bug when an aliasDict was configured as an empty dict.

A bug existed in the export tool for icons placed in the draw tool where the icon urls were not created correctly.