### PR TITLE
Scalebar now uses maptextcolor, printbutton not covering top-bar

### DIFF
--- a/new-client/src/plugins/print/AdvancedOptions.js
+++ b/new-client/src/plugins/print/AdvancedOptions.js
@@ -26,15 +26,6 @@ const styles = (theme) => ({
     margin: theme.spacing(1),
     display: "flex",
   },
-  mapTextColorLabel: {
-    margin: 0,
-  },
-  printButton: {
-    position: "fixed",
-    bottom: theme.spacing(1),
-    margin: theme.spacing(1),
-    width: "90%",
-  },
 });
 
 class AdvancedOptions extends React.PureComponent {

--- a/new-client/src/plugins/print/GeneralOptions.js
+++ b/new-client/src/plugins/print/GeneralOptions.js
@@ -2,13 +2,7 @@ import React from "react";
 import Grid from "@material-ui/core/Grid";
 import { withStyles } from "@material-ui/core/styles";
 import { withSnackbar } from "notistack";
-import {
-  Button,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-} from "@material-ui/core";
+import { FormControl, InputLabel, MenuItem, Select } from "@material-ui/core";
 
 const styles = (theme) => ({
   root: {
@@ -18,9 +12,6 @@ const styles = (theme) => ({
   formControl: {
     margin: theme.spacing(1),
     width: "100%",
-  },
-  mapTextColorLabel: {
-    margin: 0,
   },
   printButton: {
     position: "fixed",
@@ -60,10 +51,8 @@ class GeneralOptions extends React.PureComponent {
       format,
       scale,
       scales,
-      initiatePrint,
       handleChange,
       model,
-      printInProgress,
       // saveAsType,
     } = this.props;
     return (
@@ -134,17 +123,6 @@ class GeneralOptions extends React.PureComponent {
               <MenuItem value={"PNG"}>PNG</MenuItem>
             </Select>
           </FormControl> */}
-          <FormControl className={classes.printButton}>
-            <Button
-              variant="contained"
-              fullWidth={true}
-              color="primary"
-              onClick={initiatePrint}
-              disabled={printInProgress}
-            >
-              Skriv ut
-            </Button>
-          </FormControl>
         </Grid>
       </>
     );

--- a/new-client/src/plugins/print/PrintModel.js
+++ b/new-client/src/plugins/print/PrintModel.js
@@ -15,13 +15,12 @@ import { saveAs } from "file-saver";
 export default class PrintModel {
   constructor(settings) {
     this.map = settings.map;
-    this.app = settings.app;
-    this.localObserver = settings.localObserver;
     this.dims = settings.dims;
-    this.logoUrl = settings.logoUrl ?? "";
-    this.northArrowUrl = settings.northArrowUrl ?? "";
-    this.logoMaxWidth = settings.logoMaxWidth;
-    this.scales = settings.scales;
+    this.logoUrl = settings.options.logo ?? "";
+    this.northArrowUrl = settings.options.northArrow ?? "";
+    this.logoMaxWidth = settings.options.logoMaxWidth;
+    this.scales = settings.options.scales;
+    this.localObserver = settings.localObserver;
   }
 
   scaleBarLengths = {
@@ -278,7 +277,7 @@ export default class PrintModel {
     const lengthText = this.getLengthText(scaleBarLengthMeters);
     pdf.setFontSize(6);
     pdf.setFontStyle("bold");
-    pdf.setTextColor("#000000"); //Set to color instead?
+    pdf.setTextColor(color);
     pdf.text(
       lengthText,
       scaleBarPosition.x + scaleBarLength + 1,
@@ -290,7 +289,7 @@ export default class PrintModel {
       scaleBarPosition.y + 1
     );
 
-    pdf.setDrawColor("#000000"); //Set to color instead?
+    pdf.setDrawColor(color);
     pdf.line(
       scaleBarPosition.x,
       scaleBarPosition.y + 3,

--- a/new-client/src/plugins/print/PrintView.js
+++ b/new-client/src/plugins/print/PrintView.js
@@ -6,38 +6,37 @@ import PrintDialog from "./PrintDialog";
 import { AppBar, Tab, Tabs } from "@material-ui/core";
 import PrintIcon from "@material-ui/icons/Print";
 import SettingsIcon from "@material-ui/icons/Settings";
-import { Tooltip } from "@material-ui/core";
+import { Tooltip, Button } from "@material-ui/core";
 
 import GeneralOptions from "./GeneralOptions";
 import AdvancedOptions from "./AdvancedOptions";
 
 const styles = (theme) => ({
   root: {
-    display: "flex",
-    flexWrap: "wrap",
-  },
-  formControl: {
-    margin: theme.spacing(1),
-    minWidth: 225,
-  },
-  mapTextColorLabel: {
-    margin: 0,
-  },
-  windowContent: {
     margin: -10,
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
   },
   stickyAppBar: {
     top: -10,
   },
   tabContent: {
-    padding: 10,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+    padding: theme.spacing(1),
+    width: "100%",
+    height: "100%",
+  },
+  printButtonContainer: {
+    padding: theme.spacing(1),
   },
 });
 
 class PrintView extends React.PureComponent {
   static propTypes = {
     model: PropTypes.object.isRequired,
-    app: PropTypes.object.isRequired,
     localObserver: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
     enqueueSnackbar: PropTypes.func.isRequired,
@@ -56,11 +55,11 @@ class PrintView extends React.PureComponent {
     printInProgress: false,
     previewLayerVisible: false,
     activeTab: 0,
-    includeNorthArrow: this.props.options.includeNorthArrow || false,
+    includeNorthArrow: this.props.options.includeNorthArrow ?? false,
     northArrowPlacement: this.props.options.northArrowPlacement || "topLeft",
-    includeScaleBar: this.props.options.includeScaleBar || true,
+    includeScaleBar: this.props.options.includeScaleBar ?? true,
     scaleBarPlacement: this.props.options.scaleBarPlacement || "bottomLeft",
-    includeLogo: this.props.options.includeLogo || true,
+    includeLogo: this.props.options.includeLogo ?? true,
     logoPlacement: this.props.options.logoPlacement || "topRight",
     saveAsType: "PDF",
   };
@@ -74,8 +73,6 @@ class PrintView extends React.PureComponent {
     super(props);
     this.model = this.props.model;
     this.localObserver = this.props.localObserver;
-    this.globalObserver = this.props.app.globalObserver;
-    this.map = this.props.map;
     this.dims = this.props.dims;
 
     // Add the preview layer to map (it doesn't contain any features yet!)
@@ -189,16 +186,7 @@ class PrintView extends React.PureComponent {
 
   renderGeneralOptions = () => {
     const { scales } = this.props;
-    const {
-      scale,
-      format,
-      orientation,
-      resolution,
-      mapTitle,
-      mapTextColor,
-      printInProgress,
-      saveAsType,
-    } = this.state;
+    const { scale, format, orientation, resolution, saveAsType } = this.state;
 
     return (
       <GeneralOptions
@@ -207,30 +195,20 @@ class PrintView extends React.PureComponent {
         format={format}
         resolution={resolution}
         orientation={orientation}
-        mapTitle={mapTitle}
-        mapTextColor={mapTextColor}
         handleChange={(event) => {
           this.handleChange(event);
         }}
-        initiatePrint={this.initiatePrint}
         model={this.model}
-        setMapTextColor={this.setMapTextColor}
-        printInProgress={printInProgress}
         saveAsType={saveAsType}
       ></GeneralOptions>
     );
   };
 
   renderAdvancedOptions = () => {
-    const { scales } = this.props;
     const {
-      scale,
-      format,
-      orientation,
       resolution,
       mapTitle,
       mapTextColor,
-      printInProgress,
       includeNorthArrow,
       northArrowPlacement,
       includeScaleBar,
@@ -241,20 +219,13 @@ class PrintView extends React.PureComponent {
 
     return (
       <AdvancedOptions
-        scales={scales}
-        scale={scale}
-        format={format}
         resolution={resolution}
-        orientation={orientation}
         mapTitle={mapTitle}
         mapTextColor={mapTextColor}
         handleChange={(event) => {
           this.handleChange(event);
         }}
-        initiatePrint={this.initiatePrint}
-        model={this.model}
         setMapTextColor={this.setMapTextColor}
-        printInProgress={printInProgress}
         includeNorthArrow={includeNorthArrow}
         northArrowPlacement={northArrowPlacement}
         includeScaleBar={includeScaleBar}
@@ -277,7 +248,7 @@ class PrintView extends React.PureComponent {
 
     return (
       <>
-        <div className={classes.windowContent}>
+        <div className={classes.root}>
           <AppBar
             position="sticky"
             color="default"
@@ -302,6 +273,17 @@ class PrintView extends React.PureComponent {
           <div className={classes.tabContent}>
             {this.state.activeTab === 0 && this.renderGeneralOptions()}
             {this.state.activeTab === 1 && this.renderAdvancedOptions()}
+            <div className={classes.printButtonContainer}>
+              <Button
+                variant="contained"
+                fullWidth={true}
+                color="primary"
+                onClick={this.initiatePrint}
+                disabled={this.state.printInProgress}
+              >
+                Skriv ut
+              </Button>
+            </div>
           </div>
         </div>
         <PrintDialog

--- a/new-client/src/plugins/print/print.js
+++ b/new-client/src/plugins/print/print.js
@@ -61,13 +61,9 @@ class Print extends React.PureComponent {
 
     this.printModel = new PrintModel({
       localObserver: this.localObserver,
-      app: props.app,
       map: props.map,
-      scales: props.options.scales,
+      options: props.options,
       dims: this.dims,
-      logoUrl: props.options.logo,
-      northArrowUrl: props.options.northArrow,
-      logoMaxWidth: props.options.logoMaxWidth,
     });
   }
 
@@ -88,7 +84,7 @@ class Print extends React.PureComponent {
           icon: <PrintIcon />,
           title: "Skriv ut",
           description: "Skapa en PDF av kartan",
-          height: 500,
+          height: 550,
           width: 350,
           onWindowShow: this.onWindowShow,
           onWindowHide: this.onWindowHide,
@@ -96,9 +92,7 @@ class Print extends React.PureComponent {
       >
         <PrintView
           model={this.printModel}
-          app={this.props.app}
           options={this.props.options}
-          map={this.props.map}
           localObserver={this.localObserver}
           scales={this.props.options.scales}
           visibleAtStart={this.props.options.visibleAtStart}


### PR DESCRIPTION
Scalebar will now use same color as the optional title. Printbutton is no longer covering the top-bar (and the print-button is now available in general- and advanced-options).