### PR TITLE
Can now add custom panel header button in custom-props for basewindow

### DIFF
--- a/new-client/src/components/PanelHeader.js
+++ b/new-client/src/components/PanelHeader.js
@@ -45,6 +45,25 @@ class PanelHeader extends Component {
     title: propTypes.string.isRequired,
   };
 
+  renderCustomHeaderButtons = () => {
+    const { customHeaderButtons, classes } = this.props;
+    return customHeaderButtons.map((buttonInfo, index) => {
+      const HeaderActionIcon = buttonInfo.icon.type;
+      return (
+        <HeaderActionIcon
+          onClick={buttonInfo.onClickCallback}
+          className={classes.icon}
+          key={index}
+        />
+      );
+    });
+  };
+
+  shouldRenderCustomHeaderButtons = () => {
+    const { customHeaderButtons } = this.props;
+    return customHeaderButtons && customHeaderButtons.length > 0;
+  };
+
   render() {
     const { allowMaximizedWindow, classes, mode } = this.props;
     return (
@@ -56,6 +75,8 @@ class PanelHeader extends Component {
           {this.props.title}
         </Typography>
         <nav className={classes.icons}>
+          {this.shouldRenderCustomHeaderButtons() &&
+            this.renderCustomHeaderButtons()}
           {mode !== "maximized" && // If window isn't in fit screen mode currently…
             (mode === "minimized" ? ( // … but it's minimized…
               <FullscreenIcon // …render the maximize icon.

--- a/new-client/src/components/Window.js
+++ b/new-client/src/components/Window.js
@@ -395,6 +395,7 @@ class Window extends React.PureComponent {
       resizingEnabled,
       draggingEnabled,
       allowMaximizedWindow,
+      customPanelHeaderButtons,
     } = this.props;
     const { left, top, width, height } = this.state;
 
@@ -487,6 +488,7 @@ class Window extends React.PureComponent {
           <PanelHeader
             allowMaximizedWindow={allowMaximizedWindow}
             color={color}
+            customHeaderButtons={customPanelHeaderButtons}
             globalObserver={this.props.globalObserver}
             onClose={this.close}
             onMaximize={this.maximize}

--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -153,6 +153,7 @@ class BaseWindowPlugin extends React.PureComponent {
           onMaximize={this.props.custom.onMaximize}
           onMinimize={this.props.custom.onMinimize}
           draggingEnabled={this.props.custom.draggingEnabled}
+          customPanelHeaderButtons={this.props.custom.customPanelHeaderButtons}
           resizingEnabled={this.props.custom.resizingEnabled}
           scrollable={this.props.custom.scrollable}
           allowMaximizedWindow={this.props.custom.allowMaximizedWindow}

--- a/new-client/src/plugins/dummy/dummy.js
+++ b/new-client/src/plugins/dummy/dummy.js
@@ -107,6 +107,13 @@ class Dummy extends React.PureComponent {
           title: this.state.title, // By keeping title and color in Dummy's state we can pass on
           color: this.state.color, // the changes to BaseWindowPlugin which will update internal state too.
           description: "En kort beskrivning som visas i widgeten", // Shown on Widget button
+          customPanelHeaderButtons: [
+            {
+              //Add extra buttons to window-header with a specified onClickCallback
+              icon: <BugReportIcon />,
+              onClickCallback: () => {},
+            },
+          ],
           height: 450, // Custom height/width etc | Use "auto" for automatic or leave undefined
           width: 400,
         }}


### PR DESCRIPTION
Can now add custom panel header button in custom-props for basewindow