### PR TITLE
Fix/drawer content configuration at start

### DIFF
--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -437,6 +437,7 @@
     "mapcleaner": true,
     "drawerVisible": true,
     "drawerPermanent": true,
+    "activeDrawerOnStart": "plugins",
     "colors": {
       "primaryColor": "#333333",
       "secondaryColor": "#ffa000"

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -225,7 +225,17 @@ class App extends React.PureComponent {
           : (props.config.mapConfig.map.drawerVisible &&
               props.config.mapConfig.map.drawerPermanent) ||
             false,
-      activeDrawerContent: activeDrawerContentFromLocalStorage,
+      
+      //First check the cookie for activeDrawerContent
+      //If cookie is not null, use it set the drawer content.
+      //If cookie is null, fall back to the values from config,
+      //Finally, fall back to 'plugins', the standard tools panel.
+      //This fall back avoids rendering an empty drawer in the case that draw is set to visible but there is no drawer content in local storage.
+      activeDrawerContent:
+        activeDrawerContentFromLocalStorage !== null
+          ? activeDrawerContentFromLocalStorage
+          : props.config.mapConfig.map.activeDrawerOnStart || "plugins",
+
       drawerMouseOverLock: false,
     };
     this.globalObserver = new Observer();
@@ -643,6 +653,11 @@ class App extends React.PureComponent {
                 <DrawerToggleButtons
                   drawerButtons={this.state.drawerButtons}
                   globalObserver={this.globalObserver}
+                  initialActiveButton={
+                    this.state.drawerVisible
+                      ? this.state.activeDrawerContent
+                      : null
+                  }
                 />
               )}
               {this.renderSearchPlugin()}

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -5,6 +5,7 @@ import { withStyles } from "@material-ui/core/styles";
 import cslx from "clsx";
 import { SnackbarProvider } from "notistack";
 import Observer from "react-event-observer";
+import { isMobile } from "./../utils/IsMobile.js";
 
 import AppModel from "./../models/AppModel.js";
 
@@ -219,13 +220,15 @@ class App extends React.PureComponent {
       // If cookie is not null, use it to show/hide Drawer.
       // If cookie however is null, fall back to the values from config.
       // Finally, fall back to "false" if no cookie or config is found.
+      // The drawer should not be permanent on mobile devices.
       drawerPermanent:
-        drawerPermanentFromLocalStorage !== null
+        drawerPermanentFromLocalStorage !== null && !isMobile
           ? drawerPermanentFromLocalStorage
           : (props.config.mapConfig.map.drawerVisible &&
-              props.config.mapConfig.map.drawerPermanent) ||
+              props.config.mapConfig.map.drawerPermanent &&
+              !isMobile) ||
             false,
-      
+
       //First check the cookie for activeDrawerContent
       //If cookie is not null, use it set the drawer content.
       //If cookie is null, fall back to the values from config,

--- a/new-client/src/components/Drawer/DrawerToggleButtons.js
+++ b/new-client/src/components/Drawer/DrawerToggleButtons.js
@@ -30,17 +30,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function DrawerToggleButtons({ drawerButtons, globalObserver }) {
+function DrawerToggleButtons({
+  drawerButtons,
+  globalObserver,
+  initialActiveButton,
+}) {
   const classes = useStyles();
 
-  // If cookie for drawerPermanent is true, get the last active
-  // content and set as active toggle button.
-  const [activeButton, setActiveButton] = useState(
-    window.localStorage.getItem("drawerPermanent") === "true" &&
-      window.localStorage.getItem("activeDrawerContent") !== null
-      ? window.localStorage.getItem("activeDrawerContent")
-      : null
-  );
+  //Set initial active button state based on the initially active drawer, received from App.js
+  //This will either be a drawer button name such as "plugins" or null, depending on whether there
+  //is an active drawer when the map starts (set either from the cookie or config).
+  const [activeButton, setActiveButton] = useState(initialActiveButton);
 
   // Sort by the (optional) @order property prior rendering
   // Sort using minus (-) causes the correct behavior, as this will


### PR DESCRIPTION
1. Fix problem that the drawer can be open with empty content if the drawer is configured to be open on start but there is no active content in local storage. There is an option in config to set the active drawer at the beginning. The drawer will default to plugins if this is not used or empty. The correct drawer button will also be activated. 

2. Change so that the draw is not set to permanent when opening the map on mobile. 
