### PR TITLE
Feature/configurable transparency slider

### DIFF
--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -167,6 +167,7 @@
         "height": 0,
         "title": "",
         "description": "",
+        "enableTransparencySlider": false,
         "dropdownThemeMaps": true,
         "themeMapHeaderCaption": "Standardkartan",
         "instruction": "",

--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -167,7 +167,7 @@
         "height": 0,
         "title": "",
         "description": "",
-        "enableTransparencySlider": false,
+        "enableTransparencySlider": true,
         "dropdownThemeMaps": true,
         "themeMapHeaderCaption": "Standardkartan",
         "instruction": "",

--- a/backend/mapservice/Models/ToolOptions/LayerMenuOptions.cs
+++ b/backend/mapservice/Models/ToolOptions/LayerMenuOptions.cs
@@ -41,6 +41,8 @@ namespace MapService.Models.ToolOptions
 
         public bool showBreadcrumbs { get; set; }
 
+        public bool enableTransparencySlider { get; set; }
+
         public string target { get; set; }
 
         public string position { get; set; }

--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -47,40 +47,40 @@ var defaultState = {
   content: "",
   maps: [],
   confirmAction: () => {},
-  denyAction: () => {},
+  denyAction: () => {}
 };
 
-const ColorButtonRed = withStyles((theme) => ({
+const ColorButtonRed = withStyles(theme => ({
   root: {
     color: theme.palette.getContrastText(red[500]),
     backgroundColor: red[500],
     "&:hover": {
-      backgroundColor: red[700],
-    },
-  },
+      backgroundColor: red[700]
+    }
+  }
 }))(Button);
 
-const ColorButtonGreen = withStyles((theme) => ({
+const ColorButtonGreen = withStyles(theme => ({
   root: {
     color: theme.palette.getContrastText(green[700]),
     backgroundColor: green[500],
     "&:hover": {
-      backgroundColor: green[700],
-    },
-  },
+      backgroundColor: green[700]
+    }
+  }
 }))(Button);
 
-const ColorButtonBlue = withStyles((theme) => ({
+const ColorButtonBlue = withStyles(theme => ({
   root: {
     color: theme.palette.getContrastText(blue[500]),
     backgroundColor: blue[500],
     "&:hover": {
-      backgroundColor: blue[700],
-    },
-  },
+      backgroundColor: blue[700]
+    }
+  }
 }))(Button);
 
-$.fn.editable = function (component) {
+$.fn.editable = function(component) {
   function edit(node, e) {
     function reset() {
       ok.remove();
@@ -124,7 +124,7 @@ $.fn.editable = function (component) {
     var btnCSS = {
         marginLeft: "4px",
         position: "relative",
-        top: "-1px",
+        top: "-1px"
       },
       prev = node.html(),
       id = Math.floor(Math.random() * 1e5),
@@ -171,12 +171,12 @@ $.fn.editable = function (component) {
 
     layerOk2.css(btnCSS).click(saveLayer);
 
-    abort.css(btnCSS).click((e) => {
+    abort.css(btnCSS).click(e => {
       node.html(prev);
       reset();
     });
 
-    abort2.css(btnCSS).click((e) => {
+    abort2.css(btnCSS).click(e => {
       node.html(prev);
       reset();
     });
@@ -213,7 +213,7 @@ $.fn.editable = function (component) {
     visible.append(label6, input4);
     editPreset.append(label4, checkbox4, input2);
 
-    remove.css({ color: "red", marginRight: "4px" }).click((e) => {
+    remove.css({ color: "red", marginRight: "4px" }).click(e => {
       component.setState({
         alert: true,
         confirm: true,
@@ -221,7 +221,7 @@ $.fn.editable = function (component) {
           "Objektet kommer att tas bort från lagermenyn, om det är en grupp som innehåller lager kommer alla undergrupper och ingående lager att tas bort. Är detta ok?",
         confirmAction: () => {
           node.parent().remove();
-        },
+        }
       });
     });
 
@@ -232,19 +232,19 @@ $.fn.editable = function (component) {
 
     input
       .val(inputValue)
-      .keydown((e) => {
+      .keydown(e => {
         if (e.keyCode === 13) {
           store();
         }
       })
       .css({
         marginButtom: "4px",
-        padding: "4px",
+        padding: "4px"
       });
 
     tools.css({
       marginLeft: "13px",
-      marginTop: "7px",
+      marginTop: "7px"
     });
 
     tools.append(ok, abort, toggled, expanded);
@@ -252,7 +252,10 @@ $.fn.editable = function (component) {
     presetTools.append(editPreset, layerOk2, abort2);
 
     if (node.hasClass("group-name")) {
-      node.html(input).after(tools).before(remove);
+      node
+        .html(input)
+        .after(tools)
+        .before(remove);
     }
 
     if (node.hasClass("layer-name") && !elem.editing) {
@@ -266,7 +269,7 @@ $.fn.editable = function (component) {
     }
   }
 
-  var enableEdit = (e) => {
+  var enableEdit = e => {
     var node = $(e.target);
 
     if (node.hasClass("group-name")) {
@@ -282,7 +285,7 @@ $.fn.editable = function (component) {
     }
   };
 
-  var onClick = (e) => {
+  var onClick = e => {
     enableEdit(e);
     e.stopPropagation();
   };
@@ -313,6 +316,7 @@ class Menu extends Component {
       backgroundSwitcherWhite: true,
       enableOSM: false,
       showBreadcrumbs: false,
+      enableTransparencySlider: true,
       instruction: "",
       dropdownThemeMaps: false,
       themeMapHeaderCaption: "Temakartor",
@@ -323,7 +327,7 @@ class Menu extends Component {
       width: "",
       height: "",
       title: "Innehåll",
-      description: "Välj innehåll att visa i kartan",
+      description: "Välj innehåll att visa i kartan"
     };
   }
 
@@ -338,7 +342,7 @@ class Menu extends Component {
 
     this.props.model.on("change:urlMapConfig", () => {
       this.setState({
-        reset: true,
+        reset: true
       });
 
       this.load("layermenu", () => {
@@ -354,6 +358,8 @@ class Menu extends Component {
           enableOSM: this.props.model.get("layerMenuConfig").enableOSM,
           showBreadcrumbs: this.props.model.get("layerMenuConfig")
             .showBreadcrumbs,
+          enableTransparencySlider: this.props.model.get("layerMenuConfig")
+            .enableTransparencySlider,
           instruction: this.props.model.get("layerMenuConfig").instruction,
           dropdownThemeMaps: this.props.model.get("layerMenuConfig")
             .dropdownThemeMaps,
@@ -368,8 +374,7 @@ class Menu extends Component {
           width: this.props.model.get("layerMenuConfig").width || "",
           height: this.props.model.get("layerMenuConfig").height || "",
           title: this.props.model.get("layerMenuConfig").title || "",
-          description:
-            this.props.model.get("layerMenuConfig").description || "",
+          description: this.props.model.get("layerMenuConfig").description || ""
         });
         $(".tree-view li").editable(this);
         $(".tree-view > ul").sortable();
@@ -378,18 +383,18 @@ class Menu extends Component {
 
     this.props.model.on("change:layers", () => {
       this.setState({
-        layers: this.props.model.get("layers"),
+        layers: this.props.model.get("layers")
       });
     });
 
     this.props.model.on("change:layerMenuConfig", () => {
       this.setState({
-        layerMenuConfig: this.props.model.get("layerMenuConfig"),
+        layerMenuConfig: this.props.model.get("layerMenuConfig")
       });
 
       setTimeout(() => {
         this.setState({
-          layers: this.props.model.get("layers"),
+          layers: this.props.model.get("layers")
         });
       }, 0);
 
@@ -461,14 +466,14 @@ class Menu extends Component {
   load(type, callback) {
     switch (type) {
       case "auth":
-        this.props.model.getAuthSetting((auth) => {
+        this.props.model.getAuthSetting(auth => {
           this.setState({ authActive: auth });
         });
         break;
       case "maps":
-        this.props.model.loadMaps((maps) => {
+        this.props.model.loadMaps(maps => {
           this.setState({
-            maps: maps,
+            maps: maps
           });
           if (callback) callback();
         });
@@ -476,18 +481,18 @@ class Menu extends Component {
       case "layers":
         this.props.model.getConfig(
           this.props.model.get("config").url_layers,
-          (data) => {
+          data => {
             var layers = [];
-            data.wmslayers.forEach((l) => {
+            data.wmslayers.forEach(l => {
               l.type = "WMS";
             });
-            data.wmtslayers.forEach((l) => {
+            data.wmtslayers.forEach(l => {
               l.type = "WMTS";
             });
-            data.arcgislayers.forEach((l) => {
+            data.arcgislayers.forEach(l => {
               l.type = "ArcGIS";
             });
-            data.vectorlayers.forEach((l) => {
+            data.vectorlayers.forEach(l => {
               l.type = "Vector";
             });
             layers = data.wmslayers
@@ -507,13 +512,13 @@ class Menu extends Component {
       case "layermenu":
         this.props.model.getConfig(
           this.props.model.get("urlMapConfig"),
-          (data) => {
+          data => {
             this.props.model.set("projectionConfig", data.projection);
             this.props.model.set("toolConfig", data.tools);
             this.props.model.set("mapConfig", data.map);
             this.props.model.set(
               "layerMenuConfig",
-              data.tools.find((tool) => tool.type === "layerswitcher").options
+              data.tools.find(tool => tool.type === "layerswitcher").options
             );
             if (callback) callback();
           }
@@ -529,7 +534,7 @@ class Menu extends Component {
    */
   filterLayers(e) {
     this.setState({
-      filter: e.target.value,
+      filter: e.target.value
     });
   }
 
@@ -537,7 +542,7 @@ class Menu extends Component {
    *
    */
   getLayersWithFilter(filter) {
-    return this.props.model.get("layers").filter((layer) => {
+    return this.props.model.get("layers").filter(layer => {
       return new RegExp(this.state.filter).test(layer.caption.toLowerCase());
     });
   }
@@ -546,7 +551,7 @@ class Menu extends Component {
    *
    */
   getLayerNameFromId(id) {
-    var layer = this.props.model.get("layers").find((layer) => layer.id === id);
+    var layer = this.props.model.get("layers").find(layer => layer.id === id);
     return layer ? layer.caption : `---[layer id ${id} not found]---`;
   }
 
@@ -563,6 +568,7 @@ class Menu extends Component {
       backgroundSwitcherWhite: this.state.backgroundSwitcherWhite,
       enableOSM: this.state.enableOSM,
       showBreadcrumbs: this.state.showBreadcrumbs,
+      enableTransparencySlider: this.state.enableTransparencySlider,
       instruction: this.state.instruction,
       dropdownThemeMaps: this.state.dropdownThemeMaps,
       themeMapHeaderCaption: this.state.themeMapHeaderCaption,
@@ -575,7 +581,7 @@ class Menu extends Component {
       width: this.state.width,
       height: this.state.height,
       title: this.state.title,
-      description: this.state.description,
+      description: this.state.description
     };
 
     var roots = $(".tree-view > ul > li");
@@ -584,7 +590,7 @@ class Menu extends Component {
       return $(node)
         .find("> ul > li.layer-node")
         .toArray()
-        .map((node) => {
+        .map(node => {
           let infobox = node.dataset.infobox ? node.dataset.infobox : "";
           if (that.state.authActive) {
             let visibleForGroups = node.dataset.visibleforgroups
@@ -605,7 +611,7 @@ class Menu extends Component {
                 : 1000,
               visibleAtStart: checkIfTrue(node.dataset.visibleatstart),
               visibleForGroups: visibleForGroups || [],
-              infobox: infobox || "",
+              infobox: infobox || ""
             };
           } else {
             return {
@@ -614,7 +620,7 @@ class Menu extends Component {
                 ? parseInt(node.dataset.draworder)
                 : 1000,
               visibleAtStart: checkIfTrue(node.dataset.visibleatstart),
-              infobox: infobox || "",
+              infobox: infobox || ""
             };
           }
         });
@@ -629,7 +635,7 @@ class Menu extends Component {
       $(node)
         .find("> ul > li.group-node")
         .toArray()
-        .forEach((node) => {
+        .forEach(node => {
           groups.push(groupItem(node));
         });
       return groups;
@@ -637,7 +643,9 @@ class Menu extends Component {
 
     function groupItem(node) {
       function getParent(node) {
-        var parent = $(node).parents(".group-node").first();
+        var parent = $(node)
+          .parents(".group-node")
+          .first();
         if (parent.length === 1) {
           return parent[0].dataset.id;
         }
@@ -651,11 +659,11 @@ class Menu extends Component {
         expanded: checkIfTrue(node.dataset.expanded),
         parent: getParent(node),
         layers: layers(node),
-        groups: groups(node),
+        groups: groups(node)
       };
     }
 
-    roots.toArray().forEach((root) => {
+    roots.toArray().forEach(root => {
       let visibleForGroups = root.dataset.visibleforgroups
         ? root.dataset.visibleforgroups.split(",")
         : [];
@@ -675,7 +683,7 @@ class Menu extends Component {
               visibleAtStart: checkIfTrue(root.dataset.visibleatstart),
               drawOrder: 0,
               visibleForGroups: visibleForGroups || [],
-              infobox: "",
+              infobox: ""
             })
           : settings.groups.push(groupItem(root));
       } else {
@@ -684,7 +692,7 @@ class Menu extends Component {
               id: root.dataset.id,
               visibleAtStart: checkIfTrue(root.dataset.visibleatstart),
               drawOrder: 0,
-              infobox: "",
+              infobox: ""
             })
           : settings.groups.push(groupItem(root));
       }
@@ -701,7 +709,9 @@ class Menu extends Component {
     layers.each((i, layer) => {
       result.push({
         drawOrder: j,
-        id: $(layer).data("id").toString(),
+        id: $(layer)
+          .data("id")
+          .toString()
       });
       j--;
     });
@@ -713,16 +723,16 @@ class Menu extends Component {
    *
    */
   save(settings) {
-    this.props.model.updateConfig(settings, (success) => {
+    this.props.model.updateConfig(settings, success => {
       if (success) {
         this.setState({
-          reset: true,
+          reset: true
         });
 
         this.props.model.set({ layerMenuConfig: settings });
 
         this.setState({
-          reset: false,
+          reset: false
         });
 
         $(".tree-view li").editable(this);
@@ -731,12 +741,12 @@ class Menu extends Component {
         this.setState({
           content: "mapsettings",
           alert: true,
-          alertMessage: "Uppdateringen lyckades.",
+          alertMessage: "Uppdateringen lyckades."
         });
       } else {
         this.setState({
           alert: true,
-          alertMessage: "Uppdateringen misslyckades.",
+          alertMessage: "Uppdateringen misslyckades."
         });
       }
     });
@@ -755,7 +765,7 @@ class Menu extends Component {
   saveDrawOrder() {
     var settings = this.parseDrawSettings();
 
-    settings.forEach((setting) => {
+    settings.forEach(setting => {
       var layer = this.props.model.findLayerInConfig(setting.id);
       if (layer) {
         layer.drawOrder = setting.drawOrder;
@@ -764,18 +774,18 @@ class Menu extends Component {
 
     var config = this.props.model.get("layerMenuConfig");
 
-    this.props.model.updateConfig(config, (success) => {
+    this.props.model.updateConfig(config, success => {
       if (success) {
         this.setState({
           content: "mapsettings",
           alert: true,
-          alertMessage: "Uppdateringen lyckades.",
+          alertMessage: "Uppdateringen lyckades."
         });
         this.forceUpdate();
       } else {
         this.setState({
           alert: true,
-          alertMessage: "Uppdateringen misslyckades.",
+          alertMessage: "Uppdateringen misslyckades."
         });
       }
     });
@@ -836,7 +846,7 @@ class Menu extends Component {
         confirm: false,
         alertMessage:
           "Detta lager är redan tillagt i lagerlistan. Klicka på lagret i lagerlistan och därefter på den röda symbolen för att ta bort det.",
-        confirmAction: () => {},
+        confirmAction: () => {}
       });
       return;
     }
@@ -855,19 +865,19 @@ class Menu extends Component {
     var alphabetically = [];
 
     if (this.state.filter) {
-      layers.forEach((layer) => {
+      layers.forEach(layer => {
         layer.caption.toLowerCase().indexOf(this.state.filter) === 0
           ? startsWith.push(layer)
           : alphabetically.push(layer);
       });
 
-      startsWith.sort(function (a, b) {
+      startsWith.sort(function(a, b) {
         if (a.caption.toLowerCase() < b.caption.toLowerCase()) return -1;
         if (a.caption.toLowerCase() > b.caption.toLowerCase()) return 1;
         return 0;
       });
 
-      alphabetically.sort(function (a, b) {
+      alphabetically.sort(function(a, b) {
         if (a.caption.toLowerCase() < b.caption.toLowerCase()) return -1;
         if (a.caption.toLowerCase() > b.caption.toLowerCase()) return 1;
         return 0;
@@ -1038,13 +1048,13 @@ class Menu extends Component {
       drawOrder: true,
       layerMenu: false,
       mapOptions: false,
-      toolOptions: false,
+      toolOptions: false
     });
 
     setTimeout(() => {
       $(".tree-view > ul").sortable();
       this.setState({
-        drawOrder: true,
+        drawOrder: true
       });
     }, 0);
   }
@@ -1057,13 +1067,13 @@ class Menu extends Component {
       layerMenu: true,
       drawOrder: false,
       mapOptions: false,
-      toolOptions: false,
+      toolOptions: false
     });
 
     setTimeout(() => {
       this.update();
       this.setState({
-        layerMenu: true,
+        layerMenu: true
       });
     }, 0);
   }
@@ -1075,7 +1085,7 @@ class Menu extends Component {
       drawOrder: false,
       layerMenu: false,
       mapOptions: true,
-      toolOptions: false,
+      toolOptions: false
     });
   }
   /**
@@ -1086,7 +1096,7 @@ class Menu extends Component {
       drawOrder: false,
       layerMenu: false,
       mapOptions: false,
-      toolOptions: true,
+      toolOptions: true
     });
   }
 
@@ -1094,7 +1104,7 @@ class Menu extends Component {
     var url = this.props.model.get("config").url_map + "/" + e.target.value;
     this.props.model.set({
       urlMapConfig: url,
-      mapFile: e.target.value,
+      mapFile: e.target.value
     });
   }
 
@@ -1138,7 +1148,7 @@ class Menu extends Component {
     });
   }
 
-  handleInputChange = (event) => {
+  handleInputChange = event => {
     const target = event.target;
     const name = target.name;
     var value = target.type === "checkbox" ? target.checked : target.value;
@@ -1152,7 +1162,7 @@ class Menu extends Component {
     }
 
     this.setState({
-      [name]: value,
+      [name]: value
     });
   };
 
@@ -1172,7 +1182,7 @@ class Menu extends Component {
     }
 
     this.setState({
-      visibleForGroups: value !== "" ? groups : [],
+      visibleForGroups: value !== "" ? groups : []
     });
   }
 
@@ -1182,7 +1192,7 @@ class Menu extends Component {
   toggleHidden() {
     if (this.state.authActive) {
       this.setState({
-        isHidden: !this.state.isHidden,
+        isHidden: !this.state.isHidden
       });
 
       this.state.isHidden
@@ -1196,7 +1206,7 @@ class Menu extends Component {
    */
   renderAdList() {
     if (this.state.authActive) {
-      this.props.model.fetchADGroups((grps) => {
+      this.props.model.fetchADGroups(grps => {
         this.setState({ adGroups: grps });
 
         this.setState({
@@ -1205,7 +1215,7 @@ class Menu extends Component {
               properties={this.state.adGroups}
               show={this.state.isHidden}
             />
-          ),
+          )
         });
       });
     }
@@ -1230,7 +1240,7 @@ class Menu extends Component {
             id="authGroups"
             name="authGroups"
             type="text"
-            onChange={(e) => {
+            onChange={e => {
               this.handleAuthGrpsChange(e);
             }}
             value={this.state.visibleForGroups}
@@ -1286,7 +1296,7 @@ class Menu extends Component {
             name="themeMapHeaderCaption"
             type="text"
             value={this.state.themeMapHeaderCaption}
-            onChange={(e) => {
+            onChange={e => {
               this.setState({ themeMapHeaderCaption: e.target.value });
             }}
           />
@@ -1315,7 +1325,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={(e) => this.saveDrawOrder(e)}
+                onClick={e => this.saveDrawOrder(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1325,7 +1335,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={(e) => this.saveDrawOrder(e)}
+                onClick={e => this.saveDrawOrder(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1342,7 +1352,7 @@ class Menu extends Component {
             <input
               placeholder="filtrera"
               type="text"
-              onChange={(e) => this.filterLayers(e)}
+              onChange={e => this.filterLayers(e)}
             />
             <ul className="config-layer-list">
               {this.renderLayersFromConfig()}
@@ -1354,7 +1364,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={(e) => this.saveSettings(e)}
+                onClick={e => this.saveSettings(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1388,7 +1398,7 @@ class Menu extends Component {
                     id="target"
                     name="target"
                     className="control-fixed-width"
-                    onChange={(e) => {
+                    onChange={e => {
                       this.handleInputChange(e);
                     }}
                     value={this.state.target}
@@ -1421,7 +1431,7 @@ class Menu extends Component {
                     id="position"
                     name="position"
                     className="control-fixed-width"
-                    onChange={(e) => {
+                    onChange={e => {
                       this.handleInputChange(e);
                     }}
                     value={this.state.position}
@@ -1540,6 +1550,27 @@ class Menu extends Component {
                   />
                 </label>
               </div>
+              <div>
+                <input
+                  id="enableTransparencySlider"
+                  name="enableTransparencySlider"
+                  type="checkbox"
+                  onChange={this.handleInputChange}
+                  checked={this.state.enableTransparencySlider}
+                />
+                &nbsp;
+                <label
+                  className="long-label"
+                  htmlFor="enableTransparencySlider"
+                >
+                  Visa "opacitet skjutreglage"{" "}
+                  <i
+                    className="fa fa-question-circle"
+                    data-toggle="tooltip"
+                    title="Global inställning för att gör möjligt opacitet skjutreglage. Om specifika lager har en opacitet skjutreglage går att konfigurarar till varje lager. Om denna global inställning är inte ikryssad kommer inga opacitets skjutreglage att visas."
+                  />
+                </label>
+              </div>
               <div className="row">
                 <div className="col-sm-12">
                   <label htmlFor="instruction">Instruktion</label>
@@ -1601,7 +1632,7 @@ class Menu extends Component {
                 <ColorButtonBlue
                   variant="contained"
                   className="btn"
-                  onClick={(e) => this.saveSettings(e)}
+                  onClick={e => this.saveSettings(e)}
                   startIcon={<SaveIcon />}
                 >
                   Spara
@@ -1610,7 +1641,7 @@ class Menu extends Component {
                 <ColorButtonGreen
                   variant="contained"
                   className="btn"
-                  onClick={(e) => this.createGroup("Ny grupp", false, false)}
+                  onClick={e => this.createGroup("Ny grupp", false, false)}
                   startIcon={<CreateNewFolderIcon />}
                 >
                   Ny grupp
@@ -1621,7 +1652,7 @@ class Menu extends Component {
                 <ColorButtonBlue
                   variant="contained"
                   className="btn"
-                  onClick={(e) => this.saveSettings(e)}
+                  onClick={e => this.saveSettings(e)}
                   startIcon={<SaveIcon />}
                 >
                   Spara
@@ -1648,7 +1679,7 @@ class Menu extends Component {
         this.setState({
           alert: false,
           confirm: false,
-          alertMessage: "",
+          alertMessage: ""
         });
       },
       denyAction: () => {
@@ -1656,15 +1687,15 @@ class Menu extends Component {
         this.setState({
           alert: false,
           confirm: false,
-          alertMessage: "",
+          alertMessage: ""
         });
       },
       onClick: () => {
         this.setState({
           alert: false,
-          alertMessage: "",
+          alertMessage: ""
         });
-      },
+      }
     };
   }
 
@@ -1677,16 +1708,16 @@ class Menu extends Component {
         this.props.model.attributes.mapFile +
         "'?",
       confirmAction: () => {
-        this.props.model.deleteMap((err) => {
+        this.props.model.deleteMap(err => {
           var msg = err || "Kartan raderades";
           this.setState({
             content: "mapsettings",
             alert: true,
-            alertMessage: msg,
+            alertMessage: msg
           });
           this.load("maps");
         });
-      },
+      }
     });
   }
 
@@ -1698,13 +1729,13 @@ class Menu extends Component {
           this.setState({
             content: "mapsettings",
             alert: true,
-            alertMessage: "En ny karta skapades utan problem.",
+            alertMessage: "En ny karta skapades utan problem."
           });
           this.load("maps");
         } else {
           this.setState({
             alert: true,
-            alertMessage: "Karta kunde INTE skapas.",
+            alertMessage: "Karta kunde INTE skapas."
           });
           console.error(d);
         }
@@ -1713,7 +1744,7 @@ class Menu extends Component {
       this.setState({
         alert: true,
         alertMessage:
-          "Felaktigt namn på kartan \nInga eller ogiltiga tecken har angivits. \n\nGiltiga tecken: 0-9 a-z A-Z _",
+          "Felaktigt namn på kartan \nInga eller ogiltiga tecken har angivits. \n\nGiltiga tecken: 0-9 a-z A-Z _"
       });
     }
   }
@@ -1740,7 +1771,7 @@ class Menu extends Component {
               &nbsp;
               <select
                 className="control-fixed"
-                onChange={(e) => {
+                onChange={e => {
                   this.setSelectedConfig(e);
                 }}
                 ref="map-chooser"
@@ -1751,7 +1782,7 @@ class Menu extends Component {
               <ColorButtonRed
                 variant="contained"
                 className="btn"
-                onClick={(e) => this.deleteMap()}
+                onClick={e => this.deleteMap()}
                 startIcon={<DeleteIcon />}
               >
                 Ta bort karta
@@ -1762,7 +1793,7 @@ class Menu extends Component {
 
             <div className="inset-form map-management-margin-left margined">
               <form
-                onSubmit={(e) => {
+                onSubmit={e => {
                   e.preventDefault();
                   this.createMap(e);
                 }}
@@ -1790,7 +1821,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={(e) => this.toggleLayerMenu()}
+              onClick={e => this.toggleLayerMenu()}
               startIcon={<LayersIcon />}
             >
               Lagermeny
@@ -1799,7 +1830,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={(e) => this.toggleDrawOrderMenu()}
+              onClick={e => this.toggleDrawOrderMenu()}
               startIcon={<SwapVertIcon />}
             >
               Ritordning
@@ -1808,7 +1839,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={(e) => this.toggleMapOptionsMenu()}
+              onClick={e => this.toggleMapOptionsMenu()}
               startIcon={<SettingsIcon />}
             >
               Inställningar
@@ -1817,7 +1848,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={(e) => this.toggleToolMenu()}
+              onClick={e => this.toggleToolMenu()}
               startIcon={<BuildIcon />}
             >
               Verktyg

--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -1561,7 +1561,7 @@ class Menu extends Component {
                   <i
                     className="fa fa-question-circle"
                     data-toggle="tooltip"
-                    title="Global inställning för att gör möjligt opacitet skjutreglage. Om specifika lager har en opacitet skjutreglage går att konfigurarar till varje lager. Om denna global inställning är inte ikryssad kommer inga opacitets skjutreglage att visas."
+                    title="Global inställning för att välja om opacitet skutreglage ska vara aktiv eller inte. Om inställningen är aktiv går det då att konfigurera individer lager om opacitet skutreglage ska visas till lagret.  Om denna ruta inte är ikryssad kommer opacitet skutreglage inte visas till någon lager."
                   />
                 </label>
               </div>

--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -47,40 +47,40 @@ var defaultState = {
   content: "",
   maps: [],
   confirmAction: () => {},
-  denyAction: () => {}
+  denyAction: () => {},
 };
 
-const ColorButtonRed = withStyles(theme => ({
+const ColorButtonRed = withStyles((theme) => ({
   root: {
     color: theme.palette.getContrastText(red[500]),
     backgroundColor: red[500],
     "&:hover": {
-      backgroundColor: red[700]
-    }
-  }
+      backgroundColor: red[700],
+    },
+  },
 }))(Button);
 
-const ColorButtonGreen = withStyles(theme => ({
+const ColorButtonGreen = withStyles((theme) => ({
   root: {
     color: theme.palette.getContrastText(green[700]),
     backgroundColor: green[500],
     "&:hover": {
-      backgroundColor: green[700]
-    }
-  }
+      backgroundColor: green[700],
+    },
+  },
 }))(Button);
 
-const ColorButtonBlue = withStyles(theme => ({
+const ColorButtonBlue = withStyles((theme) => ({
   root: {
     color: theme.palette.getContrastText(blue[500]),
     backgroundColor: blue[500],
     "&:hover": {
-      backgroundColor: blue[700]
-    }
-  }
+      backgroundColor: blue[700],
+    },
+  },
 }))(Button);
 
-$.fn.editable = function(component) {
+$.fn.editable = function (component) {
   function edit(node, e) {
     function reset() {
       ok.remove();
@@ -124,7 +124,7 @@ $.fn.editable = function(component) {
     var btnCSS = {
         marginLeft: "4px",
         position: "relative",
-        top: "-1px"
+        top: "-1px",
       },
       prev = node.html(),
       id = Math.floor(Math.random() * 1e5),
@@ -171,12 +171,12 @@ $.fn.editable = function(component) {
 
     layerOk2.css(btnCSS).click(saveLayer);
 
-    abort.css(btnCSS).click(e => {
+    abort.css(btnCSS).click((e) => {
       node.html(prev);
       reset();
     });
 
-    abort2.css(btnCSS).click(e => {
+    abort2.css(btnCSS).click((e) => {
       node.html(prev);
       reset();
     });
@@ -213,7 +213,7 @@ $.fn.editable = function(component) {
     visible.append(label6, input4);
     editPreset.append(label4, checkbox4, input2);
 
-    remove.css({ color: "red", marginRight: "4px" }).click(e => {
+    remove.css({ color: "red", marginRight: "4px" }).click((e) => {
       component.setState({
         alert: true,
         confirm: true,
@@ -221,7 +221,7 @@ $.fn.editable = function(component) {
           "Objektet kommer att tas bort från lagermenyn, om det är en grupp som innehåller lager kommer alla undergrupper och ingående lager att tas bort. Är detta ok?",
         confirmAction: () => {
           node.parent().remove();
-        }
+        },
       });
     });
 
@@ -232,19 +232,19 @@ $.fn.editable = function(component) {
 
     input
       .val(inputValue)
-      .keydown(e => {
+      .keydown((e) => {
         if (e.keyCode === 13) {
           store();
         }
       })
       .css({
         marginButtom: "4px",
-        padding: "4px"
+        padding: "4px",
       });
 
     tools.css({
       marginLeft: "13px",
-      marginTop: "7px"
+      marginTop: "7px",
     });
 
     tools.append(ok, abort, toggled, expanded);
@@ -252,10 +252,7 @@ $.fn.editable = function(component) {
     presetTools.append(editPreset, layerOk2, abort2);
 
     if (node.hasClass("group-name")) {
-      node
-        .html(input)
-        .after(tools)
-        .before(remove);
+      node.html(input).after(tools).before(remove);
     }
 
     if (node.hasClass("layer-name") && !elem.editing) {
@@ -269,7 +266,7 @@ $.fn.editable = function(component) {
     }
   }
 
-  var enableEdit = e => {
+  var enableEdit = (e) => {
     var node = $(e.target);
 
     if (node.hasClass("group-name")) {
@@ -285,7 +282,7 @@ $.fn.editable = function(component) {
     }
   };
 
-  var onClick = e => {
+  var onClick = (e) => {
     enableEdit(e);
     e.stopPropagation();
   };
@@ -327,7 +324,7 @@ class Menu extends Component {
       width: "",
       height: "",
       title: "Innehåll",
-      description: "Välj innehåll att visa i kartan"
+      description: "Välj innehåll att visa i kartan",
     };
   }
 
@@ -342,7 +339,7 @@ class Menu extends Component {
 
     this.props.model.on("change:urlMapConfig", () => {
       this.setState({
-        reset: true
+        reset: true,
       });
 
       this.load("layermenu", () => {
@@ -374,7 +371,8 @@ class Menu extends Component {
           width: this.props.model.get("layerMenuConfig").width || "",
           height: this.props.model.get("layerMenuConfig").height || "",
           title: this.props.model.get("layerMenuConfig").title || "",
-          description: this.props.model.get("layerMenuConfig").description || ""
+          description:
+            this.props.model.get("layerMenuConfig").description || "",
         });
         $(".tree-view li").editable(this);
         $(".tree-view > ul").sortable();
@@ -383,18 +381,18 @@ class Menu extends Component {
 
     this.props.model.on("change:layers", () => {
       this.setState({
-        layers: this.props.model.get("layers")
+        layers: this.props.model.get("layers"),
       });
     });
 
     this.props.model.on("change:layerMenuConfig", () => {
       this.setState({
-        layerMenuConfig: this.props.model.get("layerMenuConfig")
+        layerMenuConfig: this.props.model.get("layerMenuConfig"),
       });
 
       setTimeout(() => {
         this.setState({
-          layers: this.props.model.get("layers")
+          layers: this.props.model.get("layers"),
         });
       }, 0);
 
@@ -466,14 +464,14 @@ class Menu extends Component {
   load(type, callback) {
     switch (type) {
       case "auth":
-        this.props.model.getAuthSetting(auth => {
+        this.props.model.getAuthSetting((auth) => {
           this.setState({ authActive: auth });
         });
         break;
       case "maps":
-        this.props.model.loadMaps(maps => {
+        this.props.model.loadMaps((maps) => {
           this.setState({
-            maps: maps
+            maps: maps,
           });
           if (callback) callback();
         });
@@ -481,18 +479,18 @@ class Menu extends Component {
       case "layers":
         this.props.model.getConfig(
           this.props.model.get("config").url_layers,
-          data => {
+          (data) => {
             var layers = [];
-            data.wmslayers.forEach(l => {
+            data.wmslayers.forEach((l) => {
               l.type = "WMS";
             });
-            data.wmtslayers.forEach(l => {
+            data.wmtslayers.forEach((l) => {
               l.type = "WMTS";
             });
-            data.arcgislayers.forEach(l => {
+            data.arcgislayers.forEach((l) => {
               l.type = "ArcGIS";
             });
-            data.vectorlayers.forEach(l => {
+            data.vectorlayers.forEach((l) => {
               l.type = "Vector";
             });
             layers = data.wmslayers
@@ -512,13 +510,13 @@ class Menu extends Component {
       case "layermenu":
         this.props.model.getConfig(
           this.props.model.get("urlMapConfig"),
-          data => {
+          (data) => {
             this.props.model.set("projectionConfig", data.projection);
             this.props.model.set("toolConfig", data.tools);
             this.props.model.set("mapConfig", data.map);
             this.props.model.set(
               "layerMenuConfig",
-              data.tools.find(tool => tool.type === "layerswitcher").options
+              data.tools.find((tool) => tool.type === "layerswitcher").options
             );
             if (callback) callback();
           }
@@ -534,7 +532,7 @@ class Menu extends Component {
    */
   filterLayers(e) {
     this.setState({
-      filter: e.target.value
+      filter: e.target.value,
     });
   }
 
@@ -542,7 +540,7 @@ class Menu extends Component {
    *
    */
   getLayersWithFilter(filter) {
-    return this.props.model.get("layers").filter(layer => {
+    return this.props.model.get("layers").filter((layer) => {
       return new RegExp(this.state.filter).test(layer.caption.toLowerCase());
     });
   }
@@ -551,7 +549,7 @@ class Menu extends Component {
    *
    */
   getLayerNameFromId(id) {
-    var layer = this.props.model.get("layers").find(layer => layer.id === id);
+    var layer = this.props.model.get("layers").find((layer) => layer.id === id);
     return layer ? layer.caption : `---[layer id ${id} not found]---`;
   }
 
@@ -581,7 +579,7 @@ class Menu extends Component {
       width: this.state.width,
       height: this.state.height,
       title: this.state.title,
-      description: this.state.description
+      description: this.state.description,
     };
 
     var roots = $(".tree-view > ul > li");
@@ -590,7 +588,7 @@ class Menu extends Component {
       return $(node)
         .find("> ul > li.layer-node")
         .toArray()
-        .map(node => {
+        .map((node) => {
           let infobox = node.dataset.infobox ? node.dataset.infobox : "";
           if (that.state.authActive) {
             let visibleForGroups = node.dataset.visibleforgroups
@@ -611,7 +609,7 @@ class Menu extends Component {
                 : 1000,
               visibleAtStart: checkIfTrue(node.dataset.visibleatstart),
               visibleForGroups: visibleForGroups || [],
-              infobox: infobox || ""
+              infobox: infobox || "",
             };
           } else {
             return {
@@ -620,7 +618,7 @@ class Menu extends Component {
                 ? parseInt(node.dataset.draworder)
                 : 1000,
               visibleAtStart: checkIfTrue(node.dataset.visibleatstart),
-              infobox: infobox || ""
+              infobox: infobox || "",
             };
           }
         });
@@ -635,7 +633,7 @@ class Menu extends Component {
       $(node)
         .find("> ul > li.group-node")
         .toArray()
-        .forEach(node => {
+        .forEach((node) => {
           groups.push(groupItem(node));
         });
       return groups;
@@ -643,9 +641,7 @@ class Menu extends Component {
 
     function groupItem(node) {
       function getParent(node) {
-        var parent = $(node)
-          .parents(".group-node")
-          .first();
+        var parent = $(node).parents(".group-node").first();
         if (parent.length === 1) {
           return parent[0].dataset.id;
         }
@@ -659,11 +655,11 @@ class Menu extends Component {
         expanded: checkIfTrue(node.dataset.expanded),
         parent: getParent(node),
         layers: layers(node),
-        groups: groups(node)
+        groups: groups(node),
       };
     }
 
-    roots.toArray().forEach(root => {
+    roots.toArray().forEach((root) => {
       let visibleForGroups = root.dataset.visibleforgroups
         ? root.dataset.visibleforgroups.split(",")
         : [];
@@ -683,7 +679,7 @@ class Menu extends Component {
               visibleAtStart: checkIfTrue(root.dataset.visibleatstart),
               drawOrder: 0,
               visibleForGroups: visibleForGroups || [],
-              infobox: ""
+              infobox: "",
             })
           : settings.groups.push(groupItem(root));
       } else {
@@ -692,7 +688,7 @@ class Menu extends Component {
               id: root.dataset.id,
               visibleAtStart: checkIfTrue(root.dataset.visibleatstart),
               drawOrder: 0,
-              infobox: ""
+              infobox: "",
             })
           : settings.groups.push(groupItem(root));
       }
@@ -709,9 +705,7 @@ class Menu extends Component {
     layers.each((i, layer) => {
       result.push({
         drawOrder: j,
-        id: $(layer)
-          .data("id")
-          .toString()
+        id: $(layer).data("id").toString(),
       });
       j--;
     });
@@ -723,16 +717,16 @@ class Menu extends Component {
    *
    */
   save(settings) {
-    this.props.model.updateConfig(settings, success => {
+    this.props.model.updateConfig(settings, (success) => {
       if (success) {
         this.setState({
-          reset: true
+          reset: true,
         });
 
         this.props.model.set({ layerMenuConfig: settings });
 
         this.setState({
-          reset: false
+          reset: false,
         });
 
         $(".tree-view li").editable(this);
@@ -741,12 +735,12 @@ class Menu extends Component {
         this.setState({
           content: "mapsettings",
           alert: true,
-          alertMessage: "Uppdateringen lyckades."
+          alertMessage: "Uppdateringen lyckades.",
         });
       } else {
         this.setState({
           alert: true,
-          alertMessage: "Uppdateringen misslyckades."
+          alertMessage: "Uppdateringen misslyckades.",
         });
       }
     });
@@ -765,7 +759,7 @@ class Menu extends Component {
   saveDrawOrder() {
     var settings = this.parseDrawSettings();
 
-    settings.forEach(setting => {
+    settings.forEach((setting) => {
       var layer = this.props.model.findLayerInConfig(setting.id);
       if (layer) {
         layer.drawOrder = setting.drawOrder;
@@ -774,18 +768,18 @@ class Menu extends Component {
 
     var config = this.props.model.get("layerMenuConfig");
 
-    this.props.model.updateConfig(config, success => {
+    this.props.model.updateConfig(config, (success) => {
       if (success) {
         this.setState({
           content: "mapsettings",
           alert: true,
-          alertMessage: "Uppdateringen lyckades."
+          alertMessage: "Uppdateringen lyckades.",
         });
         this.forceUpdate();
       } else {
         this.setState({
           alert: true,
-          alertMessage: "Uppdateringen misslyckades."
+          alertMessage: "Uppdateringen misslyckades.",
         });
       }
     });
@@ -846,7 +840,7 @@ class Menu extends Component {
         confirm: false,
         alertMessage:
           "Detta lager är redan tillagt i lagerlistan. Klicka på lagret i lagerlistan och därefter på den röda symbolen för att ta bort det.",
-        confirmAction: () => {}
+        confirmAction: () => {},
       });
       return;
     }
@@ -865,19 +859,19 @@ class Menu extends Component {
     var alphabetically = [];
 
     if (this.state.filter) {
-      layers.forEach(layer => {
+      layers.forEach((layer) => {
         layer.caption.toLowerCase().indexOf(this.state.filter) === 0
           ? startsWith.push(layer)
           : alphabetically.push(layer);
       });
 
-      startsWith.sort(function(a, b) {
+      startsWith.sort(function (a, b) {
         if (a.caption.toLowerCase() < b.caption.toLowerCase()) return -1;
         if (a.caption.toLowerCase() > b.caption.toLowerCase()) return 1;
         return 0;
       });
 
-      alphabetically.sort(function(a, b) {
+      alphabetically.sort(function (a, b) {
         if (a.caption.toLowerCase() < b.caption.toLowerCase()) return -1;
         if (a.caption.toLowerCase() > b.caption.toLowerCase()) return 1;
         return 0;
@@ -1048,13 +1042,13 @@ class Menu extends Component {
       drawOrder: true,
       layerMenu: false,
       mapOptions: false,
-      toolOptions: false
+      toolOptions: false,
     });
 
     setTimeout(() => {
       $(".tree-view > ul").sortable();
       this.setState({
-        drawOrder: true
+        drawOrder: true,
       });
     }, 0);
   }
@@ -1067,13 +1061,13 @@ class Menu extends Component {
       layerMenu: true,
       drawOrder: false,
       mapOptions: false,
-      toolOptions: false
+      toolOptions: false,
     });
 
     setTimeout(() => {
       this.update();
       this.setState({
-        layerMenu: true
+        layerMenu: true,
       });
     }, 0);
   }
@@ -1085,7 +1079,7 @@ class Menu extends Component {
       drawOrder: false,
       layerMenu: false,
       mapOptions: true,
-      toolOptions: false
+      toolOptions: false,
     });
   }
   /**
@@ -1096,7 +1090,7 @@ class Menu extends Component {
       drawOrder: false,
       layerMenu: false,
       mapOptions: false,
-      toolOptions: true
+      toolOptions: true,
     });
   }
 
@@ -1104,7 +1098,7 @@ class Menu extends Component {
     var url = this.props.model.get("config").url_map + "/" + e.target.value;
     this.props.model.set({
       urlMapConfig: url,
-      mapFile: e.target.value
+      mapFile: e.target.value,
     });
   }
 
@@ -1148,7 +1142,7 @@ class Menu extends Component {
     });
   }
 
-  handleInputChange = event => {
+  handleInputChange = (event) => {
     const target = event.target;
     const name = target.name;
     var value = target.type === "checkbox" ? target.checked : target.value;
@@ -1162,7 +1156,7 @@ class Menu extends Component {
     }
 
     this.setState({
-      [name]: value
+      [name]: value,
     });
   };
 
@@ -1182,7 +1176,7 @@ class Menu extends Component {
     }
 
     this.setState({
-      visibleForGroups: value !== "" ? groups : []
+      visibleForGroups: value !== "" ? groups : [],
     });
   }
 
@@ -1192,7 +1186,7 @@ class Menu extends Component {
   toggleHidden() {
     if (this.state.authActive) {
       this.setState({
-        isHidden: !this.state.isHidden
+        isHidden: !this.state.isHidden,
       });
 
       this.state.isHidden
@@ -1206,7 +1200,7 @@ class Menu extends Component {
    */
   renderAdList() {
     if (this.state.authActive) {
-      this.props.model.fetchADGroups(grps => {
+      this.props.model.fetchADGroups((grps) => {
         this.setState({ adGroups: grps });
 
         this.setState({
@@ -1215,7 +1209,7 @@ class Menu extends Component {
               properties={this.state.adGroups}
               show={this.state.isHidden}
             />
-          )
+          ),
         });
       });
     }
@@ -1240,7 +1234,7 @@ class Menu extends Component {
             id="authGroups"
             name="authGroups"
             type="text"
-            onChange={e => {
+            onChange={(e) => {
               this.handleAuthGrpsChange(e);
             }}
             value={this.state.visibleForGroups}
@@ -1296,7 +1290,7 @@ class Menu extends Component {
             name="themeMapHeaderCaption"
             type="text"
             value={this.state.themeMapHeaderCaption}
-            onChange={e => {
+            onChange={(e) => {
               this.setState({ themeMapHeaderCaption: e.target.value });
             }}
           />
@@ -1325,7 +1319,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={e => this.saveDrawOrder(e)}
+                onClick={(e) => this.saveDrawOrder(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1335,7 +1329,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={e => this.saveDrawOrder(e)}
+                onClick={(e) => this.saveDrawOrder(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1352,7 +1346,7 @@ class Menu extends Component {
             <input
               placeholder="filtrera"
               type="text"
-              onChange={e => this.filterLayers(e)}
+              onChange={(e) => this.filterLayers(e)}
             />
             <ul className="config-layer-list">
               {this.renderLayersFromConfig()}
@@ -1364,7 +1358,7 @@ class Menu extends Component {
               <ColorButtonBlue
                 variant="contained"
                 className="btn"
-                onClick={e => this.saveSettings(e)}
+                onClick={(e) => this.saveSettings(e)}
                 startIcon={<SaveIcon />}
               >
                 Spara
@@ -1398,7 +1392,7 @@ class Menu extends Component {
                     id="target"
                     name="target"
                     className="control-fixed-width"
-                    onChange={e => {
+                    onChange={(e) => {
                       this.handleInputChange(e);
                     }}
                     value={this.state.target}
@@ -1431,7 +1425,7 @@ class Menu extends Component {
                     id="position"
                     name="position"
                     className="control-fixed-width"
-                    onChange={e => {
+                    onChange={(e) => {
                       this.handleInputChange(e);
                     }}
                     value={this.state.position}
@@ -1632,7 +1626,7 @@ class Menu extends Component {
                 <ColorButtonBlue
                   variant="contained"
                   className="btn"
-                  onClick={e => this.saveSettings(e)}
+                  onClick={(e) => this.saveSettings(e)}
                   startIcon={<SaveIcon />}
                 >
                   Spara
@@ -1641,7 +1635,7 @@ class Menu extends Component {
                 <ColorButtonGreen
                   variant="contained"
                   className="btn"
-                  onClick={e => this.createGroup("Ny grupp", false, false)}
+                  onClick={(e) => this.createGroup("Ny grupp", false, false)}
                   startIcon={<CreateNewFolderIcon />}
                 >
                   Ny grupp
@@ -1652,7 +1646,7 @@ class Menu extends Component {
                 <ColorButtonBlue
                   variant="contained"
                   className="btn"
-                  onClick={e => this.saveSettings(e)}
+                  onClick={(e) => this.saveSettings(e)}
                   startIcon={<SaveIcon />}
                 >
                   Spara
@@ -1679,7 +1673,7 @@ class Menu extends Component {
         this.setState({
           alert: false,
           confirm: false,
-          alertMessage: ""
+          alertMessage: "",
         });
       },
       denyAction: () => {
@@ -1687,15 +1681,15 @@ class Menu extends Component {
         this.setState({
           alert: false,
           confirm: false,
-          alertMessage: ""
+          alertMessage: "",
         });
       },
       onClick: () => {
         this.setState({
           alert: false,
-          alertMessage: ""
+          alertMessage: "",
         });
-      }
+      },
     };
   }
 
@@ -1708,16 +1702,16 @@ class Menu extends Component {
         this.props.model.attributes.mapFile +
         "'?",
       confirmAction: () => {
-        this.props.model.deleteMap(err => {
+        this.props.model.deleteMap((err) => {
           var msg = err || "Kartan raderades";
           this.setState({
             content: "mapsettings",
             alert: true,
-            alertMessage: msg
+            alertMessage: msg,
           });
           this.load("maps");
         });
-      }
+      },
     });
   }
 
@@ -1729,13 +1723,13 @@ class Menu extends Component {
           this.setState({
             content: "mapsettings",
             alert: true,
-            alertMessage: "En ny karta skapades utan problem."
+            alertMessage: "En ny karta skapades utan problem.",
           });
           this.load("maps");
         } else {
           this.setState({
             alert: true,
-            alertMessage: "Karta kunde INTE skapas."
+            alertMessage: "Karta kunde INTE skapas.",
           });
           console.error(d);
         }
@@ -1744,7 +1738,7 @@ class Menu extends Component {
       this.setState({
         alert: true,
         alertMessage:
-          "Felaktigt namn på kartan \nInga eller ogiltiga tecken har angivits. \n\nGiltiga tecken: 0-9 a-z A-Z _"
+          "Felaktigt namn på kartan \nInga eller ogiltiga tecken har angivits. \n\nGiltiga tecken: 0-9 a-z A-Z _",
       });
     }
   }
@@ -1771,7 +1765,7 @@ class Menu extends Component {
               &nbsp;
               <select
                 className="control-fixed"
-                onChange={e => {
+                onChange={(e) => {
                   this.setSelectedConfig(e);
                 }}
                 ref="map-chooser"
@@ -1782,7 +1776,7 @@ class Menu extends Component {
               <ColorButtonRed
                 variant="contained"
                 className="btn"
-                onClick={e => this.deleteMap()}
+                onClick={(e) => this.deleteMap()}
                 startIcon={<DeleteIcon />}
               >
                 Ta bort karta
@@ -1793,7 +1787,7 @@ class Menu extends Component {
 
             <div className="inset-form map-management-margin-left margined">
               <form
-                onSubmit={e => {
+                onSubmit={(e) => {
                   e.preventDefault();
                   this.createMap(e);
                 }}
@@ -1821,7 +1815,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={e => this.toggleLayerMenu()}
+              onClick={(e) => this.toggleLayerMenu()}
               startIcon={<LayersIcon />}
             >
               Lagermeny
@@ -1830,7 +1824,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={e => this.toggleDrawOrderMenu()}
+              onClick={(e) => this.toggleDrawOrderMenu()}
               startIcon={<SwapVertIcon />}
             >
               Ritordning
@@ -1839,7 +1833,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={e => this.toggleMapOptionsMenu()}
+              onClick={(e) => this.toggleMapOptionsMenu()}
               startIcon={<SettingsIcon />}
             >
               Inställningar
@@ -1848,7 +1842,7 @@ class Menu extends Component {
             <ColorButtonBlue
               variant="contained"
               className="btn"
-              onClick={e => this.toggleToolMenu()}
+              onClick={(e) => this.toggleToolMenu()}
               startIcon={<BuildIcon />}
             >
               Verktyg

--- a/new-client/src/plugins/layerswitcher/LayerSwitcherView.js
+++ b/new-client/src/plugins/layerswitcher/LayerSwitcherView.js
@@ -101,6 +101,7 @@ class LayersSwitcherView extends React.PureComponent {
               model={this.props.model}
               chapters={this.state.chapters}
               app={this.props.app}
+              options={this.props.options}
             />
           );
         })}

--- a/new-client/src/plugins/layerswitcher/components/LayerGroup.js
+++ b/new-client/src/plugins/layerswitcher/components/LayerGroup.js
@@ -152,6 +152,7 @@ class LayerGroup extends React.PureComponent {
           classes={classes}
           child={true}
           chapters={this.props.chapters}
+          options={this.props.options}
         />
       );
     });
@@ -335,6 +336,7 @@ class LayerGroup extends React.PureComponent {
                       key={mapLayer.get("name")}
                       layer={mapLayer}
                       model={this.props.model}
+                      options={this.props.options}
                       chapters={this.props.chapters}
                       app={this.props.app}
                       onOpenChapter={(chapter) => {

--- a/new-client/src/plugins/layerswitcher/components/LayerGroupItem.js
+++ b/new-client/src/plugins/layerswitcher/components/LayerGroupItem.js
@@ -676,6 +676,7 @@ class LayerGroupItem extends Component {
           ) : null}
           <div>
             <LayerSettings
+              options={this.props.options}
               layer={layer}
               cqlFilterVisible={cqlFilterVisible}
               observer={this.props.model.observer}

--- a/new-client/src/plugins/layerswitcher/components/LayerItem.js
+++ b/new-client/src/plugins/layerswitcher/components/LayerItem.js
@@ -353,6 +353,7 @@ class LayerItem extends React.PureComponent {
           mapConfig={app.config.mapConfig}
           layer={layer}
           model={model}
+          options={this.props.options}
           chapters={chapters}
           cqlFilterVisible={cqlFilterVisible}
           onOpenChapter={(chapter) => {
@@ -434,6 +435,7 @@ class LayerItem extends React.PureComponent {
             <hr />
           ) : null}
           <LayerSettings
+            options={this.props.options}
             layer={layer}
             toggled={this.state.toggleSettings}
             showOpacity={true}

--- a/new-client/src/plugins/layerswitcher/components/LayerSettings.js
+++ b/new-client/src/plugins/layerswitcher/components/LayerSettings.js
@@ -108,7 +108,10 @@ class LayerSettings extends React.PureComponent {
     return (
       <div>
         <div className={this.props.classes.settingsContainer}>
-          {this.props.showOpacity ? this.renderOpacitySlider() : null}
+          {this.props.options.enableTransparencySlider !== false &&
+          this.props.showOpacity
+            ? this.renderOpacitySlider()
+            : null}
           {this.props.showLegend ? this.renderLegendImage() : null}
           {this.props.layer.getProperties().filterable ? (
             <VectorFilter layer={this.props.layer} />


### PR DESCRIPTION
Göteborg SBK ville ha en inställningen för att lätt kunna stäng av genomskinlighets skutreglage till alla lager. Har lagt till som configurerbart i layerswitcher verktyg val. 

Funderingar:
enableTransparencySlider ok namn?
admin tooltip beskrivning ok?

Ska det kommer något så att admin checkbox för att ställa in om skutreglage ska finnas på lager nivå är 'greyed out'/disabled om den globala inställning är false, med en meddelande om att den global inställning inte är aktiv? eller lika


