### PR TITLE
Mobile start configuration changes

### DIFF
--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -156,7 +156,7 @@
           }
         ],
         "active": true,
-        "visibleAtStart": false,
+        "visibleAtStart": true,
         "backgroundSwitcherBlack": false,
         "backgroundSwitcherWhite": true,
         "enableOSM": true,
@@ -167,7 +167,6 @@
         "height": 0,
         "title": "",
         "description": "",
-        "enableTransparencySlider": true,
         "dropdownThemeMaps": true,
         "themeMapHeaderCaption": "Standardkartan",
         "instruction": "",

--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -437,6 +437,7 @@
     "mapcleaner": true,
     "drawerVisible": true,
     "drawerPermanent": true,
+    "drawerVisibleMobile": true,
     "activeDrawerOnStart": "plugins",
     "colors": {
       "primaryColor": "#333333",

--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -157,6 +157,7 @@
         ],
         "active": true,
         "visibleAtStart": true,
+        "visibleAtStartMobile": false,
         "backgroundSwitcherBlack": false,
         "backgroundSwitcherWhite": true,
         "enableOSM": true,

--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -156,7 +156,7 @@
           }
         ],
         "active": true,
-        "visibleAtStart": true,
+        "visibleAtStart": false,
         "backgroundSwitcherBlack": false,
         "backgroundSwitcherWhite": true,
         "enableOSM": true,
@@ -167,6 +167,7 @@
         "height": 0,
         "title": "",
         "description": "",
+        "enableTransparencySlider": true,
         "dropdownThemeMaps": true,
         "themeMapHeaderCaption": "Standardkartan",
         "instruction": "",
@@ -437,7 +438,7 @@
     "mapcleaner": true,
     "drawerVisible": true,
     "drawerPermanent": true,
-    "drawerVisibleMobile": true,
+    "drawerVisibleMobile": false,
     "activeDrawerOnStart": "plugins",
     "colors": {
       "primaryColor": "#333333",

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -209,25 +209,30 @@ class App extends React.PureComponent {
       mapClickDataResult: {},
 
       // Drawer-related states
-      // If cookie for "drawerPermanent" is not null, use it to control Drawer visibility,
-      // else fall back to value from config, or finally don't show Drawer.
+      //If on a mobile device, and a config property for if the drawer should initially be open is set, base the drawer state on this.
+      //Otherwise if cookie for "drawerPermanent" is not null, use it to control Drawer visibility,
+      //If there a no cookie settings, use the config drawVisible setting.
+      //Finally, don't show the drawer.
+
       drawerVisible:
-        drawerPermanentFromLocalStorage !== null
+        isMobile && props.config.mapConfig.map.drawerVisibleMobile !== undefined
+          ? props.config.mapConfig.map.drawerVisibleMobile
+          : drawerPermanentFromLocalStorage !== null
           ? drawerPermanentFromLocalStorage
           : props.config.mapConfig.map.drawerVisible || false,
 
-      // To check whether drawer is permanent, first take a look at the cookie.
+      // If on a mobile device, the drawer should never be permanent.
+      // If not on mobile, if cookie is not null, use it to show/hide Drawer.
       // If cookie is not null, use it to show/hide Drawer.
       // If cookie however is null, fall back to the values from config.
       // Finally, fall back to "false" if no cookie or config is found.
-      // The drawer should not be permanent on mobile devices.
-      drawerPermanent:
-        drawerPermanentFromLocalStorage !== null && !isMobile
-          ? drawerPermanentFromLocalStorage
-          : (props.config.mapConfig.map.drawerVisible &&
-              props.config.mapConfig.map.drawerPermanent &&
-              !isMobile) ||
-            false,
+      drawerPermanent: isMobile
+        ? false
+        : drawerPermanentFromLocalStorage !== null
+        ? drawerPermanentFromLocalStorage
+        : (props.config.mapConfig.map.drawerVisible &&
+            props.config.mapConfig.map.drawerPermanent) ||
+          false,
 
       //First check the cookie for activeDrawerContent
       //If cookie is not null, use it set the drawer content.

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -5,7 +5,7 @@ import { withStyles } from "@material-ui/core/styles";
 import cslx from "clsx";
 import { SnackbarProvider } from "notistack";
 import Observer from "react-event-observer";
-import { getIsMobile } from "./../utils/IsMobile.js";
+import { isMobile } from "./../utils/IsMobile";
 
 import AppModel from "./../models/AppModel.js";
 
@@ -215,8 +215,7 @@ class App extends React.PureComponent {
       //Finally, don't show the drawer.
 
       drawerVisible:
-        getIsMobile() &&
-        props.config.mapConfig.map.drawerVisibleMobile !== undefined
+        isMobile && props.config.mapConfig.map.drawerVisibleMobile !== undefined
           ? props.config.mapConfig.map.drawerVisibleMobile
           : drawerPermanentFromLocalStorage !== null
           ? drawerPermanentFromLocalStorage
@@ -227,7 +226,7 @@ class App extends React.PureComponent {
       // If cookie is not null, use it to show/hide Drawer.
       // If cookie however is null, fall back to the values from config.
       // Finally, fall back to "false" if no cookie or config is found.
-      drawerPermanent: getIsMobile()
+      drawerPermanent: isMobile
         ? false
         : drawerPermanentFromLocalStorage !== null
         ? drawerPermanentFromLocalStorage

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -5,7 +5,7 @@ import { withStyles } from "@material-ui/core/styles";
 import cslx from "clsx";
 import { SnackbarProvider } from "notistack";
 import Observer from "react-event-observer";
-import { isMobile } from "./../utils/IsMobile.js";
+import { getIsMobile } from "./../utils/IsMobile.js";
 
 import AppModel from "./../models/AppModel.js";
 
@@ -215,7 +215,8 @@ class App extends React.PureComponent {
       //Finally, don't show the drawer.
 
       drawerVisible:
-        isMobile && props.config.mapConfig.map.drawerVisibleMobile !== undefined
+        getIsMobile() &&
+        props.config.mapConfig.map.drawerVisibleMobile !== undefined
           ? props.config.mapConfig.map.drawerVisibleMobile
           : drawerPermanentFromLocalStorage !== null
           ? drawerPermanentFromLocalStorage
@@ -226,7 +227,7 @@ class App extends React.PureComponent {
       // If cookie is not null, use it to show/hide Drawer.
       // If cookie however is null, fall back to the values from config.
       // Finally, fall back to "false" if no cookie or config is found.
-      drawerPermanent: isMobile
+      drawerPermanent: getIsMobile()
         ? false
         : drawerPermanentFromLocalStorage !== null
         ? drawerPermanentFromLocalStorage

--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -1,5 +1,6 @@
 import React from "react";
 import propTypes from "prop-types";
+import { isMobile } from "./../utils/IsMobile.js";
 import { createPortal } from "react-dom";
 import { withStyles } from "@material-ui/core/styles";
 import { withTheme } from "@material-ui/styles";
@@ -70,11 +71,20 @@ class BaseWindowPlugin extends React.PureComponent {
 
   // Runs on initial render.
   componentDidMount() {
-    // visibleAtStart is false by default. Change to true only if option really is 'true'.
-    this.props.options.visibleAtStart === true &&
+    //If on a mobile, and there is a specific visibleAtStart setting for mobile, check the mobile setting.
+    //visibleAtStart is false by default. Change to true only if visibleAtStartMobile really is 'true'.
+    //Otherwise, if not on mobile, or there is no specific mobile setting, change to true only if visibleAtStart option really is 'true'.
+    if (isMobile && this.props.options.visibleAtStartMobile !== undefined) {
+      if (this.props.options.visibleAtStartMobile === true) {
+        this.setState({
+          windowVisible: true,
+        });
+      }
+    } else if (this.props.options.visibleAtStart === true) {
       this.setState({
         windowVisible: true,
       });
+    }
   }
 
   // Does not run on initial render, but runs on subsequential re-renders.

--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -1,6 +1,6 @@
 import React from "react";
 import propTypes from "prop-types";
-import { getIsMobile } from "./../utils/IsMobile.js";
+import { isMobile } from "./../utils/IsMobile";
 import { createPortal } from "react-dom";
 import { withStyles } from "@material-ui/core/styles";
 import { withTheme } from "@material-ui/styles";
@@ -74,10 +74,7 @@ class BaseWindowPlugin extends React.PureComponent {
     //If on a mobile, and there is a specific visibleAtStart setting for mobile, check the mobile setting.
     //visibleAtStart is false by default. Change to true only if visibleAtStartMobile really is 'true'.
     //Otherwise, if not on mobile, or there is no specific mobile setting, change to true only if visibleAtStart option really is 'true'.
-    if (
-      getIsMobile() &&
-      this.props.options.visibleAtStartMobile !== undefined
-    ) {
+    if (isMobile && this.props.options.visibleAtStartMobile !== undefined) {
       if (this.props.options.visibleAtStartMobile === true) {
         this.setState({
           windowVisible: true,

--- a/new-client/src/plugins/BaseWindowPlugin.js
+++ b/new-client/src/plugins/BaseWindowPlugin.js
@@ -1,6 +1,6 @@
 import React from "react";
 import propTypes from "prop-types";
-import { isMobile } from "./../utils/IsMobile.js";
+import { getIsMobile } from "./../utils/IsMobile.js";
 import { createPortal } from "react-dom";
 import { withStyles } from "@material-ui/core/styles";
 import { withTheme } from "@material-ui/styles";
@@ -74,7 +74,10 @@ class BaseWindowPlugin extends React.PureComponent {
     //If on a mobile, and there is a specific visibleAtStart setting for mobile, check the mobile setting.
     //visibleAtStart is false by default. Change to true only if visibleAtStartMobile really is 'true'.
     //Otherwise, if not on mobile, or there is no specific mobile setting, change to true only if visibleAtStart option really is 'true'.
-    if (isMobile && this.props.options.visibleAtStartMobile !== undefined) {
+    if (
+      getIsMobile() &&
+      this.props.options.visibleAtStartMobile !== undefined
+    ) {
       if (this.props.options.visibleAtStartMobile === true) {
         this.setState({
           windowVisible: true,


### PR DESCRIPTION
Added a separate config property to set whether the drawer should be open on start on mobile. This is to give the option of choosing to have the drawer be open at start if opening on a desktop, but not have the drawer open if opening on a mobile. 

Also simplified the drawer logic relating to mobile settings. It first checks if on a mobile, and if so, deals with that - otherwise it runs the original drawer logic as normal. 

**Question:**
For this change to be effective - there probably should also be a mobile specific configuration for whether the layerswitcher itself is visible on start. The simplest way is to do it in exactly the same way as have done now, to add visibleAtStartMobile in the layerswitcher tool configuration. 

I'm conscious of filling up the configuration with lots of extra mobile properties - would something like the following be better? 

`visibleAtStart: {
  "desktop": true,
  "mobile": false 
}`

It keeps it together a bit more, but comes with a few downsides - the logic changes needed wouldn't work with any previous config for example. 

Any thoughts?

If no objections, will implement the normal way (with a visibleAtStartMobile for layerswitcher) for the moment. 


