### PR TITLE
Render icon buttons with screen reader typography

### DIFF
--- a/new-client/src/components/PanelHeader.js
+++ b/new-client/src/components/PanelHeader.js
@@ -5,7 +5,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import FullscreenIcon from "@material-ui/icons/Fullscreen";
 import FullscreenExitIcon from "@material-ui/icons/FullscreenExit";
 import AspectRatioIcon from "@material-ui/icons/AspectRatio";
-import { Hidden, Typography } from "@material-ui/core";
+import { Hidden, Typography, IconButton } from "@material-ui/core";
 
 const styles = (theme) => {
   return {
@@ -14,21 +14,9 @@ const styles = (theme) => {
       borderBottom: `4px solid ${theme.palette.primary.main}`,
       userSelect: "none",
       display: "flex",
+      alignItems: "center",
       justifyContent: "space-between",
       minHeight: 46,
-    },
-    icons: {
-      display: "flex",
-      alignItems: "center",
-      "&>*": {
-        marginLeft: theme.spacing(1),
-      },
-    },
-    icon: {
-      cursor: "pointer",
-      "&:hover": {
-        background: theme.palette.action.hover,
-      },
     },
   };
 };
@@ -46,15 +34,19 @@ class PanelHeader extends Component {
   };
 
   renderCustomHeaderButtons = () => {
-    const { customHeaderButtons, classes } = this.props;
+    const { customHeaderButtons } = this.props;
     return customHeaderButtons.map((buttonInfo, index) => {
       const HeaderActionIcon = buttonInfo.icon.type;
+      const description = buttonInfo.description;
       return (
-        <HeaderActionIcon
-          onClick={buttonInfo.onClickCallback}
-          className={classes.icon}
+        <IconButton
           key={index}
-        />
+          onClick={buttonInfo.onClickCallback}
+          size="small"
+        >
+          <Typography variant="srOnly">{description}</Typography>
+          <HeaderActionIcon />
+        </IconButton>
       );
     });
   };
@@ -74,31 +66,36 @@ class PanelHeader extends Component {
         <Typography variant="button" align="left" noWrap={true}>
           {this.props.title}
         </Typography>
-        <nav className={classes.icons}>
+        <nav>
           {this.shouldRenderCustomHeaderButtons() &&
             this.renderCustomHeaderButtons()}
           {mode !== "maximized" && // If window isn't in fit screen mode currently…
             (mode === "minimized" ? ( // … but it's minimized…
-              <FullscreenIcon // …render the maximize icon.
-                onClick={this.props.onMaximize}
-                className={classes.icon}
-              />
+              <IconButton size="small" onClick={this.props.onMaximize}>
+                <Typography variant="srOnly">Maximera fönster</Typography>
+                <FullscreenIcon // …render the maximize icon.
+                />
+              </IconButton>
             ) : (
               // If it's already in "window" mode though, render the minimize icon.
-              <FullscreenExitIcon
-                onClick={this.props.onMinimize}
-                className={classes.icon}
-              />
+              <IconButton size="small" onClick={this.props.onMinimize}>
+                <Typography variant="srOnly">Minimera fönster</Typography>
+                <FullscreenExitIcon />
+              </IconButton>
             ))}
           <Hidden xsDown>
             {allowMaximizedWindow && ( // If we're not on mobile and config allows fit-to-screen…
-              <AspectRatioIcon // … render the action button. Note: it will remain the same…
-                onClick={this.props.onMaximize} // for both "maximized" and "window" modes.
-                className={classes.icon}
-              />
+              <IconButton size="small" onClick={this.props.onMaximize}>
+                <Typography variant="srOnly">Maximera fönster</Typography>
+                <AspectRatioIcon // … render the action button. Note: it will remain the same…
+                />
+              </IconButton>
             )}
           </Hidden>
-          <CloseIcon onClick={this.props.onClose} className={classes.icon} />
+          <IconButton size="small" onClick={this.props.onClose}>
+            <Typography variant="srOnly">Stäng fönster</Typography>
+            <CloseIcon />
+          </IconButton>
         </nav>
       </header>
     );


### PR DESCRIPTION
Changed buttons in panelheader to <IconButton> instead of having onClick on IconElement.
Change made to be able to add <Typography variant="srOnly"> for all panelHeader-buttons.

This enables screenReaders to read what action the buttons actually "fire".
