### PR TITLE
Get url from location-object instead of creating a-tag

### DIFF
--- a/new-admin/src/views/layermanager.jsx
+++ b/new-admin/src/views/layermanager.jsx
@@ -610,11 +610,9 @@ class Manager extends Component {
             window.location.hostname +
             (window.location.port ? ":" + window.location.port : "");
         }
-        var node = $(this.refs.uploadIframe.contentDocument).find("body")[0],
-          url = node.innerHTML,
-          a = $(`<a href="${url}"">temp</a>`),
-          b = a[0].href;
-        this.props.model.set("legend", b);
+        let node = $(this.refs.uploadIframe.contentDocument).find("body")[0];
+        let url = `${window.location.origin}/${node.innerHTML}`;
+        this.props.model.set("legend", url);
       }
     });
   }


### PR DESCRIPTION
Getting url for legend from Location object on Window instead of manually creating an a-tag.
Change made because it's sometimes buggy to create the a-tag.
Also changes because of ongoing extension of admin in separate branch in fork