### PR TITLE
Added consistent height for parent-children in drawer to fix scroll iOS

### DIFF
--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -84,6 +84,9 @@ const styles = (theme) => {
         pointerEvents: "auto",
       },
     },
+    drawerContent: {
+      height: "inherit",
+    },
     header: {
       zIndex: theme.zIndex.appBar,
       maxHeight: theme.spacing(8),
@@ -143,8 +146,9 @@ const styles = (theme) => {
       justifyContent: "space-between",
       backgroundColor: theme.palette.background.paper,
     },
-    drawerContent: {
+    drawerContentContainer: {
       backgroundColor: theme.palette.background.paper,
+      height: "100%",
       overflow: "auto",
     },
     logoBox: {
@@ -579,9 +583,10 @@ class App extends React.PureComponent {
     const { classes } = this.props;
 
     return (
-      <div id="drawer-content" className={classes.drawerContent}>
+      <div id="drawer-content" className={classes.drawerContentContainer}>
         <Box
           key="plugins"
+          className={classes.drawerContent}
           display={
             this.state.activeDrawerContent === "plugins" ? "unset" : "none"
           }
@@ -592,6 +597,7 @@ class App extends React.PureComponent {
           return (
             <Box
               key={db.value}
+              className={classes.drawerContent}
               display={
                 this.state.activeDrawerContent === db.value ? "unset" : "none"
               }


### PR DESCRIPTION
Minor fix
Setting height for all tree of containers in drawer to avoid height set to auto. 
This fixes problem with non-working automatic scrolling in all iOS-browsers.