### PR TITLE
Resolve empty drawers showing under certain conditions

### DIFF
--- a/new-client/src/plugins/DocumentHandler/DocumentHandler.js
+++ b/new-client/src/plugins/DocumentHandler/DocumentHandler.js
@@ -147,7 +147,7 @@ class DocumentHandler extends React.PureComponent {
       { title: "Till huvudmeny för webbplatsen", link: "#panelmenu" },
     ]);
     app.globalObserver.publish("core.addDrawerToggleButton", {
-      value: "menu",
+      value: "documenthandler",
       ButtonIcon: MenuIcon,
       caption: options.drawerButtonTitle || "Meny",
       drawerTitle: options.drawerTitle || "Översiktsplan",


### PR DESCRIPTION
Resolve empty drawers showing under certain conditions see #711.

- Drawer is now not shown if we don't have either some customDrawerContent or plugins to render in the drawer.
- Fallback is always plugins as long as the mapconfig actually has any tools active

Need help with testing because there are a lot of conditions arising with different mapconfigs