### PR TITLE
fix/715-Android-text-input

### DIFF
--- a/new-client/src/components/Window.js
+++ b/new-client/src/components/Window.js
@@ -178,7 +178,7 @@ class Window extends React.PureComponent {
   }
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (this.props.open) {
+    if (prevProps.open === false && this.props.open === true) {
       //This is ugly but there is a timing problem further down somewhere (i suppose?).
       //componentDidUpdate is run before the render is actually fully completed and the DOM is ready
       setTimeout(() => {


### PR DESCRIPTION
For some reason the accessibility fix was executed more than neccesary on Android.
This fix makes sure it only executes once, when the window opens.

Please check and make sure the accessibility fix still works as intended.

The text-input issue on Chrome for Android has been tested on 2 phones with good results.

Closing #715 
