### PR TITLE
Originalrepo/feature/wildcard at start for autocomplete

### DIFF
--- a/new-admin/src/views/tools/search.jsx
+++ b/new-admin/src/views/tools/search.jsx
@@ -52,7 +52,7 @@ const defaultState = {
   markerImg: "",
   delayBeforeAutoSearch: 500,
   searchBarPlaceholder: "Sök...",
-
+  autocompleteWildcardAtStart: false,
   enablePolygonSearch: true,
   enableRadiusSearch: true,
   enableSelectSearch: true,
@@ -159,6 +159,9 @@ class ToolOptions extends Component {
           delayBeforeAutoSearch:
             tool.options.delayBeforeAutoSearch ||
             this.state.delayBeforeAutoSearch,
+          autocompleteWildcardAtStart:
+            tool.options.autocompleteWildcardAtStart ||
+            this.state.autocompleteWildcardAtStart,
           searchBarPlaceholder:
             tool.options.searchBarPlaceholder ||
             this.state.searchBarPlaceholder,
@@ -343,7 +346,7 @@ class ToolOptions extends Component {
         markerImg: this.state.markerImg,
         delayBeforeAutoSearch: this.state.delayBeforeAutoSearch,
         searchBarPlaceholder: this.state.searchBarPlaceholder,
-
+        autocompleteWildcardAtStart: this.state.autocompleteWildcardAtStart,
         enablePolygonSearch: this.state.enablePolygonSearch,
         enableRadiusSearch: this.state.enableRadiusSearch,
         enableSelectSearch: this.state.enableSelectSearch,
@@ -678,6 +681,21 @@ class ToolOptions extends Component {
                 this.handleInputChange(e);
               }}
             />
+          </div>
+          <div>
+            <input
+              id="autocompleteWildcardAtStart"
+              name="autocompleteWildcardAtStart"
+              value={this.state.autocompleteWildcardAtStart}
+              type="checkbox"
+              checked={this.state.autocompleteWildcardAtStart}
+              onChange={(e) => {
+                this.handleInputChange(e);
+              }}
+            />{" "}
+            <label className="long-label" htmlFor="autocompleteWildcardAtStart">
+              Använd wildcard före sökord för autocomplete
+            </label>
           </div>
 
           <div className="separator">Söktjänster</div>

--- a/new-backend/App_Data/map_1.json
+++ b/new-backend/App_Data/map_1.json
@@ -319,6 +319,7 @@
         "markerImg": "",
         "delayBeforeAutoSearch": 300,
         "searchBarPlaceholder": "Sök...",
+        "autocompleteWildcardAtStart": false,
         "enablePolygonSearch": true,
         "enableRadiusSearch": true,
         "enableSelectSearch": true,

--- a/new-client/public/simpleMapConfig.json
+++ b/new-client/public/simpleMapConfig.json
@@ -319,6 +319,7 @@
         "markerImg": "",
         "delayBeforeAutoSearch": 300,
         "searchBarPlaceholder": "Sök...",
+        "autocompleteWildcardAtStart": false,
         "enablePolygonSearch": true,
         "enableRadiusSearch": true,
         "enableSelectSearch": true,

--- a/new-client/src/components/Search/Search.js
+++ b/new-client/src/components/Search/Search.js
@@ -433,9 +433,11 @@ class Search extends React.PureComponent {
   };
 
   getAutoCompleteFetchSettings = () => {
+    const { options } = this.props;
     let fetchSettings = { ...this.searchModel.getSearchOptions() }; //Getting default-options when fetching auto
     fetchSettings = {
       ...fetchSettings,
+      wildcardAtStart: options.autocompleteWildcardAtStart || false,
       getPossibleCombinations: true,
       initiator: "autocomplete",
     };


### PR DESCRIPTION
Added the possibility to add wildcard at start for autocomplete.
Default is still `wildcardAtStart = false` for autocomplete if not set in admin/config

Solves #777