### PR TITLE
This will remove the <br /><br /> tags from Infobox

### DIFF
--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -158,7 +158,7 @@ $.fn.editable = function (component) {
         `<input id="${id5}" type="text" placeholder="Ny länk"/><br />`
       ),
       input3 = $(`<input id="${id6}" type="text" /><br />`),
-      input4 = $(`<textarea id="${id7}" type="text" /><br /><br />`),
+      input4 = $(`<textarea id="${id7}" type="text" /></textarea>`),
       expanded = $('<div class="expanded-at-start"></div>'),
       toggled = $('<div class="expanded-at-start"></div>'),
       visible = $('<div class=""></div>'),

--- a/new-admin/src/views/mapsettings.jsx
+++ b/new-admin/src/views/mapsettings.jsx
@@ -158,7 +158,7 @@ $.fn.editable = function (component) {
         `<input id="${id5}" type="text" placeholder="Ny länk"/><br />`
       ),
       input3 = $(`<input id="${id6}" type="text" /><br />`),
-      input4 = $(`<textarea id="${id7}" type="text" /></textarea>`),
+      input4 = $(`<textarea id="${id7}" type="text"></textarea>`),
       expanded = $('<div class="expanded-at-start"></div>'),
       toggled = $('<div class="expanded-at-start"></div>'),
       visible = $('<div class=""></div>'),


### PR DESCRIPTION
This will remove the text "<br /><br />" from layers infobox in layermenu that in some cases will override the infoclick to not show any information for selected feature.