### PR TITLE
Hotfix: Geometry can be null for raster causing fatal crash on mobile…

### DIFF
--- a/new-client/src/models/AppModel.js
+++ b/new-client/src/models/AppModel.js
@@ -481,7 +481,9 @@ class AppModel {
         this.highlightSource.addFeature(feature);
         if (window.innerWidth < 600) {
           let geom = feature.getGeometry();
-          this.map.getView().setCenter(this.getCenter(geom.getExtent()));
+          if(geom) {
+            this.map.getView().setCenter(this.getCenter(geom.getExtent()));
+          }
         }
       }
     }

--- a/new-client/src/models/AppModel.js
+++ b/new-client/src/models/AppModel.js
@@ -481,7 +481,7 @@ class AppModel {
         this.highlightSource.addFeature(feature);
         if (window.innerWidth < 600) {
           let geom = feature.getGeometry();
-          if(geom) {
+          if (geom) {
             this.map.getView().setCenter(this.getCenter(geom.getExtent()));
           }
         }


### PR DESCRIPTION
A tiny null check.