### PR TITLE
Fix: AD search loop exits if one container is not found

### DIFF
--- a/backend/mapservice/Components/ActiveDirectoryLookup.cs
+++ b/backend/mapservice/Components/ActiveDirectoryLookup.cs
@@ -76,14 +76,14 @@ namespace MapService.Components
                         }
                         catch (Exception e)
                         {
-                            _log.ErrorFormat("Kunde inte koppla upp mot Active Directory, container '{0}', ERROR: {1}", containerArray[i], e.Message);
+                            _log.ErrorFormat("Could not connect to Active Directory, container '{0}', ERROR: {1}", containerArray[i], e.Message);
                         }
                     }
                 }
             }
             catch (Exception e)
             {
-                _log.ErrorFormat("Kunde inte koppla upp mot Active Directory, kontrollera inloggningsuppgifter: error {0}", e.Message);
+                _log.ErrorFormat("Could not connect to Active Directory, error: {0}", e.Message);
             }
             return userPrincipal;
         }

--- a/backend/mapservice/Components/ActiveDirectoryLookup.cs
+++ b/backend/mapservice/Components/ActiveDirectoryLookup.cs
@@ -58,19 +58,26 @@ namespace MapService.Components
                     string[] containerArray = _container.Split(';');
                     for (int i = 0; i < containerArray.Length; i++)
                     {
-                        if (_useSSL)
+                        try
                         {
-                            _context = new PrincipalContext(ContextType.Domain, _domain, containerArray[i], ContextOptions.Negotiate | ContextOptions.SecureSocketLayer, _adUser, _adPassword);
+                            if (_useSSL)
+                            {
+                                _context = new PrincipalContext(ContextType.Domain, _domain, containerArray[i], ContextOptions.Negotiate | ContextOptions.SecureSocketLayer, _adUser, _adPassword);
+                            }
+                            else
+                            {
+                                _context = new PrincipalContext(ContextType.Domain, _domain, containerArray[i], _adUser, _adPassword);
+                            }
+
+                            userPrincipal = UserPrincipal.FindByIdentity(_context, user);
+
+                            if (userPrincipal != null)
+                                break;
                         }
-                        else
+                        catch (Exception e)
                         {
-                            _context = new PrincipalContext(ContextType.Domain, _domain, containerArray[i], _adUser, _adPassword);
+                            _log.ErrorFormat("Kunde inte koppla upp mot Active Directory, container '{0}', ERROR: {1}", containerArray[i], e.Message);
                         }
-
-                        userPrincipal = UserPrincipal.FindByIdentity(_context, user);
-
-                        if (userPrincipal != null)
-                            break;
                     }
                 }
             }


### PR DESCRIPTION
If you specify more than one AD container in Web.config and one is not found the loop exits.

This fix will continue to search all specified constainers even if one or more is not found.