### PR TITLE
Add USER root for builds to work on Openshift. Use minimal image

### DIFF
--- a/Dockerfile.ubi8-nodejs
+++ b/Dockerfile.ubi8-nodejs
@@ -1,6 +1,7 @@
 # Stage 1 - Building the backend
 FROM registry.access.redhat.com/ubi8/nodejs-16 as backendBuilder
 COPY /new-backend/package*.json ./
+USER root
 RUN npm install
 COPY ./new-backend .
 RUN npm run compile
@@ -8,6 +9,7 @@ RUN npm run compile
 # Stage 2 - Building the client
 FROM registry.access.redhat.com/ubi8/nodejs-16 as clientBuilder
 COPY /new-client/package*.json ./
+USER root
 RUN npm install --ignore-scripts
 COPY ./new-client .
 RUN rm ./public/appConfig.json
@@ -17,6 +19,7 @@ RUN npm run build --ignore-scripts
 # Stage 3 - Building the admin
 FROM registry.access.redhat.com/ubi8/nodejs-16 as adminBuilder
 COPY /new-admin/package*.json ./
+USER root
 RUN npm install
 COPY ./new-admin .
 RUN rm ./public/config.json
@@ -24,9 +27,11 @@ RUN mv ./public/config.docker.json ./public/config.json
 RUN npm run build
 
 # Stage 4 - Combine everything and fire it up
-FROM registry.access.redhat.com/ubi8/nodejs-16
+FROM registry.access.redhat.com/ubi8/nodejs-16-minimal
 COPY /new-backend/package*.json ./
+USER root
 RUN npm install --production
+USER 1001
 COPY --from=backendBuilder /opt/app-root/src/dist ./
 COPY /new-backend/.env .
 COPY /new-backend/App_Data ./App_Data


### PR DESCRIPTION
Builds on Openshift needs a USER entry in the Dockerfile,
Also add the minimal image for the runtime part to reduce the final image size