### PR TITLE
Added `crossorigin="use-credentials"` on manifest-files. Closes #1072

### DIFF
--- a/new-admin/public/index.html
+++ b/new-admin/public/index.html
@@ -9,7 +9,11 @@
       rel="stylesheet"
       type="text/css"
     />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      rel="manifest"
+      href="%PUBLIC_URL%/manifest.json"
+      crossorigin="use-credentials"
+    />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link
       type="text/css"

--- a/new-client/public/index.html
+++ b/new-client/public/index.html
@@ -11,7 +11,11 @@
     <meta name="%REACT_APP_NAME%-git-hash" content="%REACT_APP_GIT_HASH%" />
     <meta name="%REACT_APP_NAME%-version" content="%REACT_APP_VERSION%" />
 
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      rel="manifest"
+      href="%PUBLIC_URL%/manifest.json"
+      crossorigin="use-credentials"
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="stylesheet" type="text/css" href="%PUBLIC_URL%/index.css" />
     <title>Hajk - open source webGIS</title>


### PR DESCRIPTION
Some users has noticed that the `manifest.json` files fails to load when the solution is deployed behind an authentication proxy. Adding `crossorigin="use-credentials"` should solve the issue.

See #1072 for more info.