### PR TITLE
Sort MapSwitcher options

### DIFF
--- a/new-client/src/controls/MapSwitcher.js
+++ b/new-client/src/controls/MapSwitcher.js
@@ -29,6 +29,11 @@ class MapSwitcher extends React.PureComponent {
 
   handleLoading(maps) {
     let { activeMap } = this.appModel.config;
+
+    maps.sort((a, b) =>
+      a.mapConfigurationTitle.localeCompare(b.mapConfigurationTitle)
+    );
+
     // Save fetched map configs to global variable
     this.maps = maps;
 

--- a/new-client/src/controls/MapSwitcher.js
+++ b/new-client/src/controls/MapSwitcher.js
@@ -64,20 +64,16 @@ class MapSwitcher extends React.PureComponent {
   }
 
   renderMenuItems = () => {
-    let menuItems = [];
-    this.maps.forEach((item, index) => {
-      menuItems.push(
-        <MenuItem
-          key={index}
-          // disabled={index === this.state.selectedIndex}
-          selected={index === this.state.selectedIndex}
-          onClick={(event) => this.handleMenuItemClick(event, index)}
-        >
-          {item.mapConfigurationTitle}
-        </MenuItem>
-      );
-    });
-    return menuItems;
+    return this.maps.map((item, index) => (
+      <MenuItem
+        key={index}
+        // disabled={index === this.state.selectedIndex}
+        selected={index === this.state.selectedIndex}
+        onClick={(event) => this.handleMenuItemClick(event, index)}
+      >
+        {item.mapConfigurationTitle}
+      </MenuItem>
+    ));
   };
 
   // Show dropdown menu, anchored to the element clicked


### PR DESCRIPTION
Note: I did some minor refactoring that was out of scope, it's in a different commit in case it causes confusion

- Make sure MapSwitcher maps are sorted
- Refactor renderMenuItems to use Array.map
