### PR TITLE
Feature/883 layer naming

### DIFF
--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -457,6 +457,21 @@ class App extends React.PureComponent {
           // Ensure to update the map canvas size. Otherwise we can run into #1058.
           this.appModel.getMap().updateSize();
 
+          // Temporarily show a nice overview of added layers
+          this.globalObserver.subscribe("core.appLoaded", () => {
+            const la = this.appModel.map.getAllLayers().map((l) => {
+              return {
+                layerInfo: l.layerInfo,
+                layerType: l.layerType,
+                layersInfo: l.layersInfo,
+                caption: l.get("caption"),
+                name: l.get("name"),
+                type: l.get("type"),
+              };
+            });
+            console.table(la);
+          });
+
           // Tell everyone that we're done loading (in case someone listens)
           this.globalObserver.publish("core.appLoaded");
         }

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -457,21 +457,6 @@ class App extends React.PureComponent {
           // Ensure to update the map canvas size. Otherwise we can run into #1058.
           this.appModel.getMap().updateSize();
 
-          // Temporarily show a nice overview of added layers
-          this.globalObserver.subscribe("core.appLoaded", () => {
-            const la = this.appModel.map.getAllLayers().map((l) => {
-              return {
-                layerInfo: l.layerInfo,
-                layerType: l.layerType,
-                layersInfo: l.layersInfo,
-                caption: l.get("caption"),
-                name: l.get("name"),
-                type: l.get("type"),
-              };
-            });
-            console.table(la);
-          });
-
           // Tell everyone that we're done loading (in case someone listens)
           this.globalObserver.publish("core.appLoaded");
         }

--- a/new-client/src/components/Search/MapViewModel.js
+++ b/new-client/src/components/Search/MapViewModel.js
@@ -48,10 +48,11 @@ class MapViewModel {
     return new VectorSource({ wrapX: false });
   };
 
-  getNewVectorLayer = (source, style) => {
+  getNewVectorLayer = (source, style, props = {}) => {
     return new VectorLayer({
       source: source,
       style: style,
+      ...props,
     });
   };
 
@@ -90,18 +91,23 @@ class MapViewModel {
       this.resultSource,
       this.options.showResultFeaturesInMap ?? true
         ? this.featureStyle.getDefaultSearchResultStyle
-        : null
+        : null,
+      {
+        layerType: "system",
+        name: "pluginSearchResults",
+        caption: "Search results",
+      }
     );
-    // FIXME: Remove "type", use only "name" throughout
-    // the application. Should be done as part of #883.
-    this.resultsLayer.set("type", "searchResultLayer");
-    this.resultsLayer.set("name", "pluginSearchResults");
     this.drawSource = this.getNewVectorSource();
     this.drawLayer = this.getNewVectorLayer(
       this.drawSource,
-      this.getDrawStyle()
+      this.getDrawStyle(),
+      {
+        layerType: "system",
+        name: "pluginSearchDraw",
+        caption: "Search draw",
+      }
     );
-    this.drawLayer.set("name", "pluginSearchDraw");
     this.map.addLayer(this.drawLayer);
     this.map.addLayer(this.resultsLayer);
   };

--- a/new-client/src/components/Search/searchResults/SearchResultsContainer.js
+++ b/new-client/src/components/Search/searchResults/SearchResultsContainer.js
@@ -750,7 +750,7 @@ class SearchResultsContainer extends React.PureComponent {
 
     const layer = this.#getLayerById(featureCollection.source.pid);
 
-    if (layer.layerType === "group") {
+    if (layer.get("layerType") === "group") {
       // Group layers will publish an event to LayerSwitcher that will take
       // care of the somewhat complicated toggling.
 

--- a/new-client/src/models/AppModel.js
+++ b/new-client/src/models/AppModel.js
@@ -590,6 +590,9 @@ class AppModel {
     ];
     this.highlightSource = new VectorSource();
     this.highlightLayer = new VectorLayer({
+      caption: "Infoclick layer",
+      name: "pluginInfoclick",
+      layerType: "system",
       source: this.highlightSource,
       style: new Style({
         stroke: new Stroke({

--- a/new-client/src/models/AppModel.js
+++ b/new-client/src/models/AppModel.js
@@ -379,12 +379,12 @@ class AppModel {
         // search-component rather than in the featureInfo-component.
         const searchResultFeatures = mapClickDataResult.features.filter(
           (feature) => {
-            return feature?.layer.get("type") === "searchResultLayer";
+            return feature?.layer.get("name") === "pluginSearchResults";
           }
         );
         const infoclickFeatures = mapClickDataResult.features.filter(
           (feature) => {
-            return feature?.layer.get("type") !== "searchResultLayer";
+            return feature?.layer.get("name") !== "pluginSearchResults";
           }
         );
 

--- a/new-client/src/models/Click.js
+++ b/new-client/src/models/Click.js
@@ -314,7 +314,7 @@ export function handleClick(evt, map, callback) {
               if (
                 layer &&
                 (layer.get("queryable") === true ||
-                  layer.get("type") === "searchResultLayer")
+                  layer.get("name") === "pluginSearchResults")
               ) {
                 feature.layer = layer;
                 features.push(feature);

--- a/new-client/src/models/Drag.js
+++ b/new-client/src/models/Drag.js
@@ -2,6 +2,8 @@ import { Pointer } from "ol/interaction";
 
 class Drag extends Pointer {
   constructor() {
+    // FIXME: This code looks obsolete, I can't find any imports.
+    // Candidate for removal?
     super();
     Pointer.call(this, {
       handleDownEvent: this.handleDownEvent,
@@ -21,7 +23,8 @@ class Drag extends Pointer {
     this.previousCursor_ = undefined;
 
     this.acceptedLayers = {
-      "preview-layer": true,
+      pluginPrint: true,
+      pluginExport: true,
     };
   }
 

--- a/new-client/src/models/DrawModel.js
+++ b/new-client/src/models/DrawModel.js
@@ -249,7 +249,7 @@ class DrawModel {
   // the layerName supplied when initiating the model. Also makes
   // sure that the layer is a vectorLayer.
   #layerHasCorrectNameAndType = (layer) => {
-    return layer.get("type") === this.#layerName && this.#isVectorLayer(layer);
+    return layer.get("name") === this.#layerName && this.#isVectorLayer(layer);
   };
 
   // Checks wether the supplied layer is a vectorLayer or not.
@@ -277,10 +277,7 @@ class DrawModel {
     this.#drawSource = this.#getNewVectorSource();
     // Then we'll create the layer
     this.#drawLayer = this.#getNewVectorLayer(this.#drawSource);
-    // Make sure to set the layer type to something understandable.
-    this.#drawLayer.set("type", this.#layerName);
-    // FIXME: Remove "type", use only "name" throughout
-    // the application. Should be done as part of #883.
+    // Make sure to set a unique name
     this.#drawLayer.set("name", this.#layerName);
     // We're also gonna have to set the queryable-property to true
     // so that we can enable "Select" on the layer.
@@ -992,6 +989,8 @@ class DrawModel {
   #getNewVectorLayer = (source) => {
     return new VectorLayer({
       source: source,
+      layerType: "system",
+      caption: "Draw model",
     });
   };
 

--- a/new-client/src/models/KmlModel.js
+++ b/new-client/src/models/KmlModel.js
@@ -159,7 +159,7 @@ class KmlModel {
   // the layerName supplied when initiating the model. Also makes
   // sure that the layer is a vectorLayer.
   #layerHasCorrectNameAndType = (layer) => {
-    return layer.get("type") === this.#layerName && this.#isVectorLayer(layer);
+    return layer.get("name") === this.#layerName && this.#isVectorLayer(layer);
   };
 
   // Checks wether the supplied layer is a vectorLayer or not.
@@ -187,10 +187,7 @@ class KmlModel {
     this.#kmlSource = this.#getNewVectorSource();
     // Let's create a layer
     this.#kmlLayer = this.#getNewVectorLayer(this.#kmlSource);
-    // Make sure to set the layer type to something understandable.
-    this.#kmlLayer.set("type", this.#layerName);
-    // FIXME: Remove "type", use only "name" throughout
-    // the application. Should be done as part of #883.
+    // Make sure to set a unique name
     this.#kmlLayer.set("name", this.#layerName);
     // Then we can add the layer to the map.
     this.#map.addLayer(this.#kmlLayer);
@@ -205,6 +202,8 @@ class KmlModel {
   #getNewVectorLayer = (source) => {
     return new VectorLayer({
       source: source,
+      layerType: "system",
+      caption: "KML model",
     });
   };
 

--- a/new-client/src/models/MapClickModel.js
+++ b/new-client/src/models/MapClickModel.js
@@ -244,7 +244,7 @@ export default class MapClickModel {
       this.map.forEachFeatureAtPixel(
         e.pixel,
         (feature, layer) => {
-          if (layer?.get("type") === "searchResultLayer") {
+          if (layer?.get("name") === "pluginSearchResults") {
             // Super-special case here: we don't follow the new
             // interface for a return object (see the "r" constant above),
             // because we want to conform to the old, working search results

--- a/new-client/src/models/MapClickModel.js
+++ b/new-client/src/models/MapClickModel.js
@@ -24,8 +24,9 @@ export default class MapClickModel {
     this.source = new VectorSource();
     this.vector = new VectorLayer({
       source: this.source,
-      name: "MapClickModel", // #883, should we call the layers the same as models that create them?
-      type: "system", // #883: "system" for the core system layers, to differentiate from "normal" WMS/Vector/etc layers?
+      caption: "MapClick Viewer", // #883, should we call the layers the same as models that create them?
+      name: "pluginMapClickViewer", // #883, should we call the layers the same as models that create them?
+      layerType: "system", // #883: "system" for the core system layers, to differentiate from "normal" WMS/Vector/etc layers?
       zIndex: 1000, // We want this to stay on top of other layers
     });
     this.map.addLayer(this.vector);

--- a/new-client/src/models/layers/VectorLayer.js
+++ b/new-client/src/models/layers/VectorLayer.js
@@ -58,6 +58,7 @@ class WFSVectorLayer {
 
     this.layer = new VectorLayer({
       information: config.information,
+      layerType: config.layerType,
       caption: config.caption,
       name: config.name,
       visible: config.visible,

--- a/new-client/src/models/layers/WMSLayer.js
+++ b/new-client/src/models/layers/WMSLayer.js
@@ -59,6 +59,7 @@ class WMSLayer {
       }
       this.layer = new ImageLayer({
         name: config.name,
+        layerType: this.getLayerType(),
         visible: config.visible,
         caption: config.caption,
         opacity: config.opacity,
@@ -75,6 +76,7 @@ class WMSLayer {
     } else {
       this.layer = new TileLayer({
         name: config.name,
+        layerType: this.getLayerType(),
         visible: config.visible,
         caption: config.caption,
         opacity: config.opacity,
@@ -92,7 +94,6 @@ class WMSLayer {
 
     this.layer.layersInfo = config.layersInfo;
     this.layer.subLayers = this.subLayers;
-    this.layer.layerType = this.getLayerType();
     this.layer.getSource().set("url", config.url);
     this.type = "wms";
     this.bindHandlers();

--- a/new-client/src/plugins/Buffer/BufferModel.js
+++ b/new-client/src/plugins/Buffer/BufferModel.js
@@ -20,7 +20,9 @@ class BufferModel {
     this.highlightSource = new VectorSource();
     this.highlightLayer = new VectorLayer({
       source: this.highlightSource,
-      name: "bufferSelectionLayer",
+      layerType: "system",
+      name: "pluginBufferSelection",
+      caption: "Buffer selection layer",
       style: new Style({
         fill: new Fill({
           color: "rgba(255, 168, 231, 0.47)",
@@ -46,7 +48,9 @@ class BufferModel {
     this.bufferSource = new VectorSource();
     this.bufferLayer = new VectorLayer({
       source: this.bufferSource,
-      name: "bufferLayer",
+      layerType: "system",
+      name: "pluginBuffer",
+      caption: "Buffer layer",
       style: new Style({
         fill: new Fill({
           color: "rgba(255, 255, 255, 0.5)",
@@ -97,7 +101,7 @@ class BufferModel {
       .getFeaturesAtPixel(e.pixel, {
         layerFilter: function (l) {
           const name = l.get("name");
-          return name !== "bufferLayer" && name !== "bufferSelectionLayer"; // …but ignore them if they happen to come from buffer layer.
+          return name !== "pluginBuffer" && name !== "pluginBufferSelection"; // …but ignore them if they happen to come from buffer layer.
         },
       })
       // Take each of the returned features from any vector layer…

--- a/new-client/src/plugins/Collector/CollectorModel.js
+++ b/new-client/src/plugins/Collector/CollectorModel.js
@@ -336,7 +336,9 @@ class CollectorModel {
     });
 
     this.layer = new Vector({
+      layerType: "system",
       name: "pluginCollector",
+      caption: "Collector layer",
       source: this.vectorSource,
       style: this.getVectorStyle(),
     });

--- a/new-client/src/plugins/Coordinates/CoordinatesModel.js
+++ b/new-client/src/plugins/Coordinates/CoordinatesModel.js
@@ -45,8 +45,10 @@ class CoordinatesModel {
 
     this.source = new VectorSource();
     this.vector = new Vector({
+      layerType: "system",
+      name: "pluginCoordinate",
+      caption: "Coordinate layer",
       source: this.source,
-      name: "coordinateLayer",
     });
     this.map.addLayer(this.vector);
     this.localObserver.subscribe("newCoordinates", (incomingCoords) => {

--- a/new-client/src/plugins/Draw/DrawModel.js
+++ b/new-client/src/plugins/Draw/DrawModel.js
@@ -28,8 +28,10 @@ class DrawModel {
 
     this.source = new VectorSource();
     this.vector = new VectorLayer({
+      layerType: "system",
+      name: "pluginDraw",
+      caption: "Draw layer",
       source: this.source,
-      name: "drawLayer",
     });
 
     this.map.addLayer(this.vector);

--- a/new-client/src/plugins/Dummy/DummyView.js
+++ b/new-client/src/plugins/Dummy/DummyView.js
@@ -228,7 +228,7 @@ class DummyView extends React.PureComponent {
       ...this.props.app.map
         .getLayers()
         .getArray()
-        .filter((l) => l.getProperties().layerInfo?.layerType === "base")
+        .filter((l) => l.get("layerType") === "base")
         .map((l) => l.getProperties()),
     ];
   }

--- a/new-client/src/plugins/Edit/EditModel.js
+++ b/new-client/src/plugins/Edit/EditModel.js
@@ -459,7 +459,9 @@ class EditModel {
     });
 
     this.layer = new Vector({
+      layerType: "system",
       name: "pluginEdit",
+      caption: "Edit layer",
       source: this.vectorSource,
       style: this.getVectorStyle(),
     });

--- a/new-client/src/plugins/Export/ExportModel.js
+++ b/new-client/src/plugins/Export/ExportModel.js
@@ -61,7 +61,9 @@ class ExportModel {
   addPreviewLayer() {
     this.previewLayer = new Vector({
       source: new VectorSource(),
-      name: "preview-layer",
+      layerType: "system",
+      name: "pluginExport",
+      caption: "Export plugin",
       style: new Style({
         stroke: new Stroke({
           color: "rgba(0, 0, 0, 0.7)",
@@ -424,7 +426,7 @@ class ExportModel {
       (layer) =>
         layer instanceof Vector &&
         layer.getVisible() &&
-        layer.get("name") !== "preview-layer"
+        layer.get("name") !== "pluginExport"
     );
 
     vectorLayers = vectorLayers

--- a/new-client/src/plugins/Fir/FirLayerController.js
+++ b/new-client/src/plugins/Fir/FirLayerController.js
@@ -43,6 +43,7 @@ class FirLayerController {
     }
 
     this.model.layers.feature = new VectorLayer({
+      layerType: "system",
       caption: "FIRSearchResultsLayer",
       name: "FIRSearchResultsLayer",
       source: new VectorSource(),
@@ -51,6 +52,7 @@ class FirLayerController {
     });
 
     this.model.layers.highlight = new VectorLayer({
+      layerType: "system",
       caption: "FIRHighlightsLayer",
       name: "FIRHighlightsLayer",
       source: new VectorSource(),
@@ -59,6 +61,7 @@ class FirLayerController {
     });
 
     this.model.layers.buffer = new VectorLayer({
+      layerType: "system",
       caption: "FIRBufferLayer",
       name: "FIRBufferLayer",
       source: new VectorSource(),
@@ -67,6 +70,7 @@ class FirLayerController {
     });
 
     this.model.layers.draw = new VectorLayer({
+      layerType: "system",
       caption: "FIRDrawLayer",
       name: "FIRDrawLayer",
       source: new VectorSource(),
@@ -81,6 +85,7 @@ class FirLayerController {
     });
 
     this.model.layers.label = new VectorLayer({
+      layerType: "system",
       caption: "FIRLabels",
       name: "FIRLabels",
       source: new VectorSource(),
@@ -89,6 +94,7 @@ class FirLayerController {
     });
 
     this.model.layers.marker = new VectorLayer({
+      layerType: "system",
       caption: "FIRMarker",
       name: "FIRMarker",
       source: new VectorSource(),

--- a/new-client/src/plugins/Fme/FmeModel.js
+++ b/new-client/src/plugins/Fme/FmeModel.js
@@ -14,6 +14,7 @@ export default class FmeModel {
     this.active = false;
     this.source = new VectorSource();
     this.vector = new VectorLayer({
+      layerType: "system",
       source: this.source,
       name: "drawLayer",
     });

--- a/new-client/src/plugins/FmeServer/models/MapViewModel.js
+++ b/new-client/src/plugins/FmeServer/models/MapViewModel.js
@@ -48,13 +48,12 @@ class MapViewModel {
     // Let's create a layer
     this.#drawLayer = this.#getNewVectorLayer(
       this.#drawSource,
-      this.#getDrawStyle()
+      this.#getDrawStyle(),
+      {
+        layerType: "system",
+        name: "pluginFmeServer",
+      }
     );
-    // Make sure to set the layer type to something understandable.
-    this.#drawLayer.set("type", "fmeServerDrawLayer");
-    // FIXME: Remove "type", use only "name" throughout
-    // the application. Should be done as part of #883.
-    this.#drawLayer.set("name", "fmeServerDrawLayer");
     // Then we can add the layer to the map.
     this.#map.addLayer(this.#drawLayer);
   };
@@ -200,10 +199,11 @@ class MapViewModel {
   };
 
   // Returns a new vector layer.
-  #getNewVectorLayer = (source, style) => {
+  #getNewVectorLayer = (source, style, props = {}) => {
     return new VectorLayer({
       source: source,
       style: style,
+      ...props,
     });
   };
 

--- a/new-client/src/plugins/GeosuiteExport/GeosuiteExportModel.js
+++ b/new-client/src/plugins/GeosuiteExport/GeosuiteExportModel.js
@@ -45,8 +45,10 @@ class GeosuiteExportModel {
     };
     this.#source = new VectorSource();
     this.#vector = new VectorLayer({
+      layerType: "system",
       source: this.#source,
-      name: "geoSuiteDrawLayer",
+      name: "pluginGeoSuite",
+      caption: "GeoSuite layer",
     });
     this.#style = new Style({
       fill: new Fill({

--- a/new-client/src/plugins/Kir/KirLayerController.js
+++ b/new-client/src/plugins/Kir/KirLayerController.js
@@ -28,6 +28,7 @@ class KirLayerController {
 
   initLayers() {
     this.model.layers.buffer = new VectorLayer({
+      layerType: "system",
       caption: "KIRBufferLayer",
       name: "KIRBufferLayer",
       source: new VectorSource(),
@@ -36,6 +37,7 @@ class KirLayerController {
     });
 
     this.model.layers.draw = new VectorLayer({
+      layerType: "system",
       caption: "KIRDrawLayer",
       name: "KIRDrawLayer",
       source: new VectorSource(),
@@ -50,6 +52,7 @@ class KirLayerController {
     });
 
     this.model.layers.features = new VectorLayer({
+      layerType: "system",
       caption: "KIRFeatures",
       name: "KIRFeatures",
       source: new VectorSource(),
@@ -58,6 +61,7 @@ class KirLayerController {
     });
 
     this.model.layers.marker = new VectorLayer({
+      layerType: "system",
       caption: "KIRMarker",
       name: "KIRMarker",
       source: new VectorSource(),

--- a/new-client/src/plugins/LayerComparer/LayerComparer.js
+++ b/new-client/src/plugins/LayerComparer/LayerComparer.js
@@ -36,14 +36,14 @@ const LayerComparer = (props) => {
   useEffect(() => {
     const allLayers = props.map.getAllLayers();
     const baseLayers = allLayers
-      .filter((l) => l.layerType === "base")
+      .filter((l) => l.get("layerType") === "base")
       .map((l) => {
         return { id: l.ol_uid, label: l.get("caption") };
       });
 
     if (props.options.showNonBaseLayersInSelect) {
       const layers = allLayers
-        .filter((l) => l.layerType === "layer")
+        .filter((l) => ["layer", "group"].includes(l.get("layerType")))
         .map((l) => {
           return { id: l.ol_uid, label: l.get("caption") };
         });
@@ -88,7 +88,7 @@ const LayerComparer = (props) => {
       // Hide old background layers
       oldBackgroundLayer.current = props.map
         .getAllLayers()
-        .find((l) => l.getVisible() === true && l.layerType === "base");
+        .find((l) => l.getVisible() === true && l.get("layerType") === "base");
       oldBackgroundLayer.current?.setVisible(false);
 
       sds.current.open();

--- a/new-client/src/plugins/LayerSwitcher/LayerSwitcherModel.js
+++ b/new-client/src/plugins/LayerSwitcher/LayerSwitcherModel.js
@@ -16,11 +16,7 @@ class LayerSwitcherModel {
     return this.olMap
       .getLayers()
       .getArray()
-      .filter(
-        (l) =>
-          l.getProperties().layerInfo &&
-          l.getProperties().layerInfo.layerType === "base"
-      )
+      .filter((l) => l.get("layerType") === "base")
       .map((l) => l.getProperties());
   }
 }

--- a/new-client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
+++ b/new-client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
@@ -40,6 +40,9 @@ class BackgroundSwitcher extends React.PureComponent {
         visible: false,
         source: this.osmSource,
         zIndex: -1,
+        layerType: "base",
+        name: "osm-layer",
+        caption: "OpenStreetMap",
         layerInfo: {
           caption: "OpenStreetMap",
           layerType: "base",

--- a/new-client/src/plugins/LayerSwitcher/components/BreadCrumbs.js
+++ b/new-client/src/plugins/LayerSwitcher/components/BreadCrumbs.js
@@ -132,15 +132,7 @@ class BreadCrumbs extends Component {
   }
 
   clear = () => {
-    this.state.visibleLayers
-      .filter((layer) =>
-        layer.getProperties().layerInfo
-          ? layer.getProperties().layerInfo.layerType !== "base"
-          : false
-      )
-      .forEach((layer) => {
-        layer.setVisible(false);
-      });
+    this.props.app.clear();
   };
 
   componentDidMount() {
@@ -153,19 +145,11 @@ class BreadCrumbs extends Component {
     }
   }
 
-  // Returns all active layers that contains layer-info
-  // and is not a background-layer.
+  // Returns all active layers except background layers
   getBreadCrumbCompatibleLayers = () => {
-    return this.state.visibleLayers.filter((layer) => {
-      if (
-        !layer.getProperties().layerInfo ||
-        (layer.getProperties().layerInfo &&
-          layer.getProperties().layerInfo.layerType === "base")
-      ) {
-        return false;
-      }
-      return true;
-    });
+    return this.state.visibleLayers.filter((layer) =>
+      ["layer", "group"].includes(layer.get("layerType"))
+    );
   };
 
   toggle = () => {

--- a/new-client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/new-client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -276,14 +276,14 @@ class LayerGroup extends React.PureComponent {
   }
 
   toggleLayers(visibility, layers) {
-    var mapLayers = this.props.app.getMap().getLayers().getArray();
-
-    mapLayers
+    this.props.app
+      .getMap()
+      .getAllLayers()
       .filter((mapLayer) => {
         return layers.some((layer) => layer.id === mapLayer.get("name"));
       })
       .forEach((mapLayer) => {
-        if (mapLayer.layerType === "group") {
+        if (mapLayer.get("layerType") === "group") {
           if (visibility === true) {
             this.model.observer.publish("showLayer", mapLayer);
           } else {

--- a/new-client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
+++ b/new-client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
@@ -269,7 +269,7 @@ class LayerGroupItem extends Component {
   setHidden = (l) => {
     const { layer } = this.props;
     if (l === layer) {
-      // Fix underlaying source
+      // Fix underlying source
       this.props.layer.getSource().updateParams({
         // Ensure that the list of sublayers is emptied (otherwise they'd be
         // "remembered" the next time user toggles group)

--- a/new-client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/new-client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -573,7 +573,7 @@ class LayerItem extends React.PureComponent {
       return null;
     }
 
-    if (layer.layerType === "group") {
+    if (layer.get("layerType") === "group") {
       return (
         <LayerGroupItem
           appConfig={app.config.appConfig}

--- a/new-client/src/plugins/Location/LocationModel.js
+++ b/new-client/src/plugins/Location/LocationModel.js
@@ -15,7 +15,9 @@ class LocationModel {
     this.source = new VectorSource({ wrapX: false });
     this.layer = new VectorLayer({
       source: this.source,
-      name: "geolocation-layer",
+      layerType: "system",
+      name: "pluginLocation",
+      caption: "Location layer",
     });
     this.map.addLayer(this.layer);
 

--- a/new-client/src/plugins/Measure/MeasureModel.js
+++ b/new-client/src/plugins/Measure/MeasureModel.js
@@ -13,7 +13,9 @@ class MeasureModel {
     this.localObserver = settings.localObserver;
     this.source = new VectorSource();
     this.vector = new VectorLayer({
+      layerType: "system",
       name: "pluginMeasure",
+      caption: "Measure layer",
       source: this.source,
       style: this.createStyle,
     });

--- a/new-client/src/plugins/Print/PrintModel.js
+++ b/new-client/src/plugins/Print/PrintModel.js
@@ -96,7 +96,9 @@ export default class PrintModel {
   addPreviewLayer() {
     this.previewLayer = new Vector({
       source: new VectorSource(),
-      name: "preview-layer",
+      layerType: "system",
+      name: "pluginPrint",
+      caption: "Print layer",
       style: new Style({
         stroke: new Stroke({
           color: "rgba(0, 0, 0, 0.7)",

--- a/new-client/src/plugins/Routing/RoutingModel.js
+++ b/new-client/src/plugins/Routing/RoutingModel.js
@@ -1,6 +1,6 @@
 import { Style, Icon, Fill, Stroke, Circle } from "ol/style";
 import { Vector } from "ol/source";
-import { Vector as layerVector } from "ol/layer";
+import { Vector as VectorLayer } from "ol/layer";
 import { Point } from "ol/geom";
 import { Feature } from "ol";
 import { transform } from "ol/proj";
@@ -156,34 +156,38 @@ class RouteModel {
     var source_drawing = new Vector({});
 
     if (this.layer_start === undefined) {
-      this.layer_start = new layerVector({
+      this.layer_start = new VectorLayer({
+        layerType: "system",
         source: source_start,
-        name: "routing",
-        content: "Punkt",
+        name: "pluginRoutingStart",
+        content: "point",
         queryable: false,
         style: this.style_start,
       });
 
-      this.layer_end = new layerVector({
+      this.layer_end = new VectorLayer({
+        layerType: "system",
         source: source_end,
-        name: "routing",
-        content: "Punkt",
+        name: "pluginRoutingEnd",
+        content: "point",
         queryable: false,
         style: this.style_end,
       });
 
-      this.layer_route = new layerVector({
+      this.layer_route = new VectorLayer({
+        layerType: "system",
         source: source_route,
-        name: "routing",
-        content: "Punkt",
+        name: "pluginRoutingRoute",
+        content: "point",
         queryable: true,
         style: this.style_route,
       });
 
-      this.layer_drawing = new layerVector({
+      this.layer_drawing = new VectorLayer({
+        layerType: "system",
         source: source_drawing,
-        name: "routing",
-        content: "linje",
+        name: "pluginRoutingDrawing",
+        content: "line",
         queryable: false,
         style: this.layer_drawing_style,
       });

--- a/new-client/src/plugins/Sketch/Sketch.js
+++ b/new-client/src/plugins/Sketch/Sketch.js
@@ -62,7 +62,7 @@ const Sketch = (props) => {
   const [drawModel] = React.useState(
     () =>
       new DrawModel({
-        layerName: "sketchLayer",
+        layerName: "pluginSketch",
         map: props.map,
         observer: localObserver,
         measurementSettings: measurementSettings,
@@ -87,7 +87,7 @@ const Sketch = (props) => {
   const [kmlModel] = React.useState(
     () =>
       new KmlModel({
-        layerName: "sketchLayer",
+        layerName: "pluginSketch",
         map: props.map,
         observer: localObserver,
         drawModel: drawModel,

--- a/new-client/src/plugins/StreetView/StreetViewModel.js
+++ b/new-client/src/plugins/StreetView/StreetViewModel.js
@@ -26,7 +26,9 @@ class StreetViewModel {
 
     this.streetViewMarkerLayer = new Vector({
       source: new VectorSource({}),
-      name: "streetViewMarkerLayer",
+      layerType: "system",
+      name: "pluginStreetView",
+      caption: "StreetView layer",
     });
     this.map.addLayer(this.streetViewMarkerLayer);
   }

--- a/new-client/src/plugins/vtsearch/MapViewModel.js
+++ b/new-client/src/plugins/vtsearch/MapViewModel.js
@@ -276,6 +276,7 @@ export default class MapViewModel {
 
   addDrawSearch = () => {
     this.drawlayer = new VectorLayer({
+      layerType: "system",
       source: new VectorSource({}),
     });
     this.map.addLayer(this.drawlayer);
@@ -303,6 +304,7 @@ export default class MapViewModel {
       width: this.model.mapColors.searchStrokeLineWidth,
     });
     var searchResultLayer = new VectorLayer({
+      layerType: "system",
       style: new Style({
         image: new Circle({
           fill: fill,
@@ -348,6 +350,7 @@ export default class MapViewModel {
     });
 
     this.highlightLayer = new VectorLayer({
+      layerType: "system",
       style: new Style({
         image: new Circle({
           fill: fill,

--- a/new-client/src/plugins/vtsearch/MapViewModel.js
+++ b/new-client/src/plugins/vtsearch/MapViewModel.js
@@ -317,7 +317,6 @@ export default class MapViewModel {
       source: new VectorSource({}),
     });
     console.log(this.map, "map");
-    searchResultLayer.set("type", "system");
     searchResultLayer.set("name", "vt-search-result-layer");
     searchResultLayer.set("searchResultId", searchResultId);
     searchResultLayer.set("queryable", false);
@@ -362,7 +361,7 @@ export default class MapViewModel {
       }),
       source: new VectorSource({}),
     });
-    this.highlightLayer.set("type", "vt-highlight-layer");
+    this.highlightLayer.set("name", "vt-highlight-layer");
     this.highlightLayer.setZIndex(50);
     this.map.addLayer(this.highlightLayer);
   };

--- a/new-client/src/plugins/vtsearch/MapViewModel.js
+++ b/new-client/src/plugins/vtsearch/MapViewModel.js
@@ -70,7 +70,7 @@ export default class MapViewModel {
 
     this.localObserver.subscribe("close-all-vt-searchLayer", () => {
       this.map.getLayers().forEach((layer) => {
-        if (layer.get("type") === "vt-search-result-layer")
+        if (layer.get("name") === "vt-search-result-layer")
           this.map.removeLayer(layer);
       });
     });
@@ -133,7 +133,7 @@ export default class MapViewModel {
       .getArray()
       .filter((layer) => {
         return (
-          layer.get("type") === "vt-search-result-layer" &&
+          layer.get("name") === "vt-search-result-layer" &&
           layer.get("searchResultId") === searchResultId
         );
       })[0];
@@ -315,7 +315,8 @@ export default class MapViewModel {
       source: new VectorSource({}),
     });
     console.log(this.map, "map");
-    searchResultLayer.set("type", "vt-search-result-layer");
+    searchResultLayer.set("type", "system");
+    searchResultLayer.set("name", "vt-search-result-layer");
     searchResultLayer.set("searchResultId", searchResultId);
     searchResultLayer.set("queryable", false);
     searchResultLayer.set("visible", false);
@@ -432,7 +433,7 @@ export default class MapViewModel {
    */
   hideAllLayers = () => {
     this.map.getLayers().forEach((layer) => {
-      if (layer.get("type") === "vt-search-result-layer") {
+      if (layer.get("name") === "vt-search-result-layer") {
         layer.set("visible", false);
       }
     });
@@ -465,7 +466,7 @@ export default class MapViewModel {
     this.map.forEachFeatureAtPixel(
       evt.pixel,
       (feature, layer) => {
-        if (layer.get("type") === "vt-search-result-layer") {
+        if (layer.get("name") === "vt-search-result-layer") {
           features.push(feature);
         }
       },


### PR DESCRIPTION
The purpose of this fix to ensure that we have a standard way of **identifying what kind of layer an OL layer is, i.e. its intended usage in Hajk**.

The main difference is that we go from "custom" (erroneous) solution with `layerType` being a real property on each `ol/layer` instance. Instead we now utilise the `set/get` as intended for `ol/layer`s. So, basically, we go from:

`someLayer.layerType` => `someLayer.get("layerType")`

I've ensured to set one of the following values for `layerType` on each layer:
```
layer
group
system
```

Closes #883.