### PR TITLE
Fix/1115 admin wms projection

### DIFF
--- a/new-admin/src/views/layerforms/wmslayerform.jsx
+++ b/new-admin/src/views/layerforms/wmslayerform.jsx
@@ -1075,6 +1075,12 @@ class WMSLayerForm extends Component {
       projections = this.state.capabilities.Capability.Layer[RS];
     }
 
+    if (projections) {
+      projections = projections.map((projection) => {
+        return projection.toUpperCase();
+      });
+    }
+
     let projEles = projections
       ? supportedProjections.map((proj, i) => {
           if (projections.indexOf(proj) > -1) {


### PR DESCRIPTION
Some servers return the projections in lower case, which causes an issue when trying to load the layer.

Upper case all projections to match the EPSG codes in the projection list. Closes #1115.