### PR TITLE
Fix automatic zoom on mobile devices

### DIFF
--- a/new-client/public/index.html
+++ b/new-client/public/index.html
@@ -2,7 +2,10 @@
 <html lang="sv">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-touch-fullscreen" content="yes" />


### PR DESCRIPTION
If you use the Safari browser on mobile devices, it automatically zooms in whenever you click on a text field.

To prevent the browser from doing that we can add `maximum-scale=1`, which controls how much zoom in is allowed on the page.