### PR TITLE
Feature/orebro tsm

### DIFF
--- a/new-client/src/plugins/Edit/components/AttributeEditor.js
+++ b/new-client/src/plugins/Edit/components/AttributeEditor.js
@@ -76,8 +76,15 @@ class AttributeEditor extends React.Component {
         } else {
           //If the feature has field: "" it will be changed to the default value.
           //Not sure if we want this behavior?
-          valueMap[field.name] =
-            featureProps[field.name] || field.defaultValue || "";
+          //Object that returns as a string results in [object] [Object]
+          if (
+            JSON.stringify(featureProps[field.name]) === '{"xsi:nil":"true"}'
+          ) {
+            valueMap[field.name] = "";
+          } else {
+            valueMap[field.name] =
+              featureProps[field.name] || field.defaultValue || "";
+          }
         }
       }
     });

--- a/new-client/src/plugins/Edit/components/AttributeEditor.js
+++ b/new-client/src/plugins/Edit/components/AttributeEditor.js
@@ -76,15 +76,11 @@ class AttributeEditor extends React.Component {
         } else {
           //If the feature has field: "" it will be changed to the default value.
           //Not sure if we want this behavior?
-          //Object that returns as a string results in [object] [Object]
-          if (
-            JSON.stringify(featureProps[field.name]) === '{"xsi:nil":"true"}'
-          ) {
-            valueMap[field.name] = "";
-          } else {
-            valueMap[field.name] =
-              featureProps[field.name] || field.defaultValue || "";
-          }
+          //QGIS-server, object that returns as a string results in [object] [Object]
+          featureProps[field.name]?.["xsi:nil"] === "true"
+            ? (valueMap[field.name] = "")
+            : (valueMap[field.name] =
+                featureProps[field.name] || field.defaultValue || "");
         }
       }
     });


### PR DESCRIPTION
Issue: https://github.com/hajkmap/Hajk/issues/987

QGIS server returns object that is not empty. HAJK prints out object as string which returns Object Object in fields (text och siffra).
Filename: AttributeEditor.js in new-client/src/plugins/Edit/components