### PR TITLE
Add close button to Snackbar in Coordinates Plugin

### DIFF
--- a/new-client/src/plugins/Coordinates/CoordinatesModel.js
+++ b/new-client/src/plugins/Coordinates/CoordinatesModel.js
@@ -237,6 +237,10 @@ class CoordinatesModel {
     this.map.removeInteraction(this.draw);
     this.map.clickLock.delete("coordinates");
   }
+
+  closeSnackbar() {
+    this.localObserver.publish("hideSnackbar");
+  }
 }
 
 export default CoordinatesModel;

--- a/new-client/src/plugins/Coordinates/CoordinatesView.js
+++ b/new-client/src/plugins/Coordinates/CoordinatesView.js
@@ -41,6 +41,25 @@ class CoordinatesView extends React.PureComponent {
             vertical: "bottom",
             horizontal: "center",
           },
+          sx: {
+            // Custom styling to follow Material Design guidelines for Snackbar.
+            // Placing the close button to the right of the text.
+            ".SnackbarItem-contentRoot": {
+              flexWrap: "inherit !important",
+            },
+          },
+          action: (key) => (
+            <Button
+              aria-label="close"
+              color="inherit"
+              id={key}
+              onClick={() => {
+                this.props.model.closeSnackbar();
+              }}
+            >
+              Stäng
+            </Button>
+          ),
         }
       );
     });


### PR DESCRIPTION
When minimizing the Coordinates Plugin on mobile devices, the window is hidden behind the Snackbar and it is difficult to maximize it.

Adding a close button to the Snackbar solves this problem by giving the user access to the maximize button again and without changing the placement of the Snackbar.

Before:
![image](https://user-images.githubusercontent.com/8030104/199971803-f122440c-d04a-49e3-9430-582dbf2f06d0.png)

After:
![image](https://user-images.githubusercontent.com/8030104/199971687-91cf364c-8042-4b03-ba71-e6ebad566554.png)
