### PR TITLE
Added functionality for adding frame around image in admin

### DIFF
--- a/new-admin/src/views/tools/print.jsx
+++ b/new-admin/src/views/tools/print.jsx
@@ -41,6 +41,7 @@ var defaultState = {
   useMargin: false,
   mapTextColor: "#000000",
   useCustomTileLoaders: true,
+  includeImageBorder: false,
   maxTileSize: 4096,
 };
 
@@ -99,6 +100,8 @@ class ToolOptions extends Component {
             : this.state.includeNorthArrow,
         northArrowPlacement:
           tool.options.northArrowPlacement || this.state.northArrowPlacement,
+        includeImageBorder:
+          tool.options.includeImageBorder || this.state.includeImageBorder,
         useCustomTileLoaders:
           tool.options.useCustomTileLoaders ?? this.state.useCustomTileLoaders,
         maxTileSize: tool.options.maxTileSize || this.state.maxTileSize,
@@ -188,6 +191,7 @@ class ToolOptions extends Component {
         scaleBarPlacement: this.state.scaleBarPlacement,
         includeNorthArrow: this.state.includeNorthArrow,
         northArrowPlacement: this.state.northArrowPlacement,
+        includeImageBorder: this.state.includeImageBorder,
         useCustomTileLoaders: this.state.useCustomTileLoaders,
         maxTileSize: this.state.maxTileSize,
       },
@@ -692,6 +696,22 @@ class ToolOptions extends Component {
               "scaleBarPlacement"
             )}
           </div>
+
+          <div>
+            <label htmlFor="includeImageBorder">
+              Inkludera bildram{" "}
+              <i
+                className="fa fa-question-circle"
+                data-toggle="tooltip"
+                title="Inställning för om kartbildsram skall inkluderas som standard. Användarna kan ändra detta själva."
+              />
+            </label>
+            {this.renderIncludeSelect(
+              this.state.includeImageBorder,
+              "includeImageBorder"
+            )}
+          </div>
+
           <div>
             <input
               id="useMargin"

--- a/new-client/src/plugins/Print/Print.js
+++ b/new-client/src/plugins/Print/Print.js
@@ -78,6 +78,11 @@ class Print extends React.PureComponent {
     // If no path to north-arrow image is supplied, use fallback
     props.options.northArrow = props.options.northArrow || "/north_arrow.png";
 
+    props.options.includeImageBorder =
+      typeof props.options?.includeImageBorder === "boolean"
+        ? props.options.includeImageBorder
+        : false;
+
     // Ensure we have a value for the crossOrigin parameter
     props.options.crossOrigin =
       props.app.config.mapConfig.map?.crossOrigin || "anonymous";

--- a/new-client/src/plugins/Print/PrintModel.js
+++ b/new-client/src/plugins/Print/PrintModel.js
@@ -27,6 +27,7 @@ export default class PrintModel {
     this.logoUrl = settings.options.logo || "";
     this.northArrowUrl = settings.options.northArrow || "";
     this.logoMaxWidth = settings.options.logoMaxWidth;
+    this.includeImageBorder = settings.options.includeImageBorder;
     this.scales = settings.options.scales;
     this.copyright = settings.options.copyright || "";
     this.date = settings.options.date || "";
@@ -1012,6 +1013,19 @@ export default class PrintModel {
           pdf.setLineWidth(this.margin * 2);
           // Draw the border (margin) around the entire image
           pdf.rect(0, 0, dim[0], dim[1], "S");
+          // If selected as feature in Admin, we draw a frame around the map image
+          if (this.includeImageBorder) {
+            // Frame color is set to dark gray
+            pdf.setDrawColor("#5A5A5A");
+            pdf.setLineWidth(0.5);
+            pdf.rect(
+              this.margin,
+              this.margin,
+              dim[0] - this.margin * 2,
+              dim[1] - this.margin * 2,
+              "S"
+            );
+          }
           // Now we check if user did choose text in margins
         } else {
           // We do a special check for a5-format and set the dimValue
@@ -1023,9 +1037,21 @@ export default class PrintModel {
           // Draw the increased border (margin) around the entire image
           // here with special values for larger margins.
           pdf.rect(-(dimValue * 2), 0, dim[0] + dimValue * 4, dim[1], "S");
+          // If selected as feature in Admin, we draw a frame around the map image
+          if (this.includeImageBorder) {
+            // Frame color is set to dark gray
+            pdf.setDrawColor("#5A5A5A");
+            pdf.setLineWidth(0.5);
+            pdf.rect(
+              dimValue,
+              dimValue * 3,
+              dim[0] - dimValue * 2,
+              dim[1] - dimValue * 6,
+              "S"
+            );
+          }
         }
       }
-
       // If logo URL is provided, add the logo to the map
       if (options.includeLogo && this.logoUrl.trim().length >= 5) {
         try {


### PR DESCRIPTION
You can now select in admin to add a dark gray frame around the map image in the pdf. The option to add frame is only available there, and not for the user.