### PR TITLE
Potential fix for #1320:

### DIFF
--- a/new-backend/.env
+++ b/new-backend/.env
@@ -155,6 +155,15 @@ AD_PASSWORD=pass
 # Leave empty to send an empty query (should work for all cases). 
 #AD_CHECK_CONNECTION_QUERY=
 
+# The followig options allow for better control of reconnection and timeouts.
+# It is recommended to set AD_RECCONNECT to `true`. The various timeout options
+# allow for further customization to ensure a stable LDAP connection, but they
+# are disabled by default. See also http://ldapjs.org/client.html
+AD_RECONNECT=true
+#AD_CONNECTTIMEOUT=60000
+#AD_IDLETIMEOUT=60000
+#AD_TIMEOUT=120000
+
 # Controls whether the AD user object will be sent in the GET map config response.
 # This is a useful way to let Client UI know more about the user and allows for
 # user-specific customization.


### PR DESCRIPTION
- See discussion in #1320 
- I made all the new options configurable in `.env`. This should allow us to have unchanged production environments and only configure the desired parts in `.env`.
- The new options in `.env` default to everything (new from this issue) turned off, except for the reconnect flag being set to `true`. I think it's a sane default for most situations.

Closes #1320 