### PR TITLE
Fix: Prevent console-warning on correct plugin config

### DIFF
--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -449,11 +449,12 @@ class App extends React.PureComponent {
       });
 
     // Display a silent info message in console
-    console.log(
-      `The map configuration contains unavailable plugins: ${unsupportedToolsFoundInMapConfig.join(
-        ", "
-      )}. Please check your map config and buildConfig.json.  `
-    );
+    unsupportedToolsFoundInMapConfig.length > 0 &&
+      console.info(
+        `The map configuration contains unavailable plugins: ${unsupportedToolsFoundInMapConfig.join(
+          ", "
+        )}. Please check your map config and buildConfig.json.  `
+      );
   };
   /**
    * @summary Initiates the wanted analytics model (if any).

--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -431,6 +431,10 @@ class App extends React.PureComponent {
       t.toLowerCase()
     );
 
+    // Let's push some built-in core elements, that previously were plugins
+    // and that still have their config there.
+    lowerCaseActiveTools.push("preset");
+
     // Check which plugins defined in mapConfig don't exist in buildConfig
     const unsupportedToolsFoundInMapConfig = this.props.config.mapConfig.tools
       .map((t) => t.type.toLowerCase())


### PR DESCRIPTION
git cherry-pick of @jacobwod existing fixes to prevent "false flag" console logging re. invalid plugin config
Fixes #1390
Cherry picks:
* https://github.com/hajkmap/Hajk/commit/b10b50afdbebefa4161c6aed995e4413c413b00a
* https://github.com/hajkmap/Hajk/commit/89cdefa095dc94ba4f5befc66d3e1249bd3dd5c6
