### PR TITLE
Fix: Correction of invalid plug-in sample in back-end config

### DIFF
--- a/backend/mapservice/App_Data/map_1.json
+++ b/backend/mapservice/App_Data/map_1.json
@@ -434,7 +434,7 @@
       "index": 15
     },
     {
-      "type": "bookmark",
+      "type": "bookmarks",
       "options": {
         "target": "toolbar",
         "instruction": "",

--- a/new-backend/App_Data/map_1.json
+++ b/new-backend/App_Data/map_1.json
@@ -437,7 +437,7 @@
       "index": 15
     },
     {
-      "type": "bookmark",
+      "type": "bookmarks",
       "options": {
         "target": "toolbar",
         "instruction": "",


### PR DESCRIPTION
Fix invalid demo config syntax, enable the bookmarks plug-in ("Bokmärken").
Resolves #1391