### PR TITLE
Revert mapconfig delete gone from NodeJS API v1

### DIFF
--- a/new-backend/server/apis/v1/controllers/mapconfig/router.js
+++ b/new-backend/server/apis/v1/controllers/mapconfig/router.js
@@ -6,10 +6,8 @@ export default express
   .Router()
   .use(restrictAdmin) // We will not allow any of the following routes unless user is admin
   // First we handle _specific_ routes, so we can catch them…
-  .get("/create/:name", controller.createNewMap) // FIXME: Replace with a PUT when Admin is ready
-  .put("/create/:name", controller.createNewMap)
-  .get("/delete/:name", controller.deleteMap) // FIXME: Replace with a DELETE when Admin is ready
-  .delete("/delete/:name", controller.deleteMap)
+  .get("/create/:name", controller.createNewMap)
+  .get("/delete/:name", controller.deleteMap)
   .put("/duplicate/:nameFrom/:nameTo", controller.duplicateMap)
   .get("/export/:map/:format", controller.exportMapConfig) // Describe all available layers in a human-readable format
   .get("/layers", controller.layers) // Get all layers (from layers.json)

--- a/new-backend/server/common/api.v1.yml
+++ b/new-backend/server/common/api.v1.yml
@@ -303,17 +303,18 @@ paths:
         200:
           description: Success
           content: {}
-    put:
+  /mapconfig/delete/{name}:
+    get:
       tags:
         - Admin - Maps and layers
       parameters:
         - name: name
           in: path
-          description: File name of the new map config
+          description: Name of the map to be deleted
           required: true
           schema:
             type: string
-      description: Create a new map configuration
+      description: Delete an existing map configuration
       responses:
         200:
           description: Success


### PR DESCRIPTION
* Resolves #1412
* Adjust 48a4c8afd672cd0fdf907c219545bf412d4d6064, HTTP method clean-up in OpenAPI spec v1
* NodeJS back-end mapconfig router: follow-up 48a4c8afd672cd0fdf907c219545bf412d4d6064 HTTP method clean-up in API v1