### PR TITLE
Add supported tool

### DIFF
--- a/new-client/src/components/App.js
+++ b/new-client/src/components/App.js
@@ -435,6 +435,7 @@ class App extends React.PureComponent {
     // and that still have their config there.
     lowerCaseActiveTools.push("preset");
     lowerCaseActiveTools.push("externallinks");
+    lowerCaseActiveTools.push("information");
 
     // Check which plugins defined in mapConfig don't exist in buildConfig
     const unsupportedToolsFoundInMapConfig = this.props.config.mapConfig.tools


### PR DESCRIPTION
The 'information' tool, if present in the mapConfig, is recognized as a supported tool and not flagged as unsupported.

Closes #1118.