### PR TITLE
Opportunity to disable stroke for drawtypes "Circle" & "Polygon"

### DIFF
--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleAccordion.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleAccordion.js
@@ -173,6 +173,9 @@ const FeatureStyleAccordion = (props) => {
               <StrokeTypeSelector
                 handleStrokeTypeChange={props.handleStrokeTypeChange}
                 strokeType={props.strokeType}
+                activeDrawType={props.activeDrawType}
+                setDrawStyle={props.setDrawStyle}
+                drawStyle={props.drawStyle}
               />
             </Grid>
           )}

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleAccordion.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleAccordion.js
@@ -111,7 +111,9 @@ const AccordionSummaryContents = (props) => {
           }%`}</Typography>
         )}
         {typeof props.strokeWidth === "number" && (
-          <Typography variant="caption">{`${props.strokeWidth}px`}</Typography>
+          <Typography variant="caption">
+            {props.strokeType !== "none" ? `${props.strokeWidth}px` : null}
+          </Typography>
         )}
         <ColorBadge color={colorString} />
       </Grid>
@@ -135,41 +137,14 @@ const FeatureStyleAccordion = (props) => {
             showOpacitySlider={props.showOpacitySlider}
             strokeWidth={props.strokeWidth}
             drawModel={props.drawModel}
+            strokeType={props.strokeType}
           />
         </StyledAccordionSummary>
       </Tooltip>
       <AccordionDetails style={{ maxWidth: "100%" }}>
         <Grid container>
-          <Grid item xs={12}>
-            <TwitterPicker
-              colors={DRAW_COLORS}
-              triangle="hide"
-              onChange={props.handleColorChange}
-              styles={{
-                default: {
-                  card: {
-                    maxWidth: "100%",
-                    background: "unset", // Hard-coded to white, we don't want that.
-                  },
-                },
-              }}
-              color={props.color}
-            />
-          </Grid>
-          {props.showOpacitySlider && (
-            <OpacitySlider
-              handleOpacityChange={props.handleOpacityChange}
-              opacity={isNaN(props.color?.a) ? 1 : props.color.a}
-            />
-          )}
-          {props.showStrokeWidthSlider && (
-            <StrokeWidthSlider
-              handleStrokeWidthChange={props.handleStrokeWidthChange}
-              strokeWidth={props.strokeWidth}
-            />
-          )}
           {props.showStrokeTypeSelector && (
-            <Grid item xs={12} style={{ marginTop: 8 }}>
+            <Grid item xs={12} sx={{ mb: 1 }}>
               <StrokeTypeSelector
                 handleStrokeTypeChange={props.handleStrokeTypeChange}
                 strokeType={props.strokeType}
@@ -178,6 +153,36 @@ const FeatureStyleAccordion = (props) => {
                 drawStyle={props.drawStyle}
               />
             </Grid>
+          )}
+          {props.strokeType !== "none" && (
+            <Grid item xs={12}>
+              <TwitterPicker
+                colors={DRAW_COLORS}
+                triangle="hide"
+                onChange={props.handleColorChange}
+                styles={{
+                  default: {
+                    card: {
+                      maxWidth: "100%",
+                      background: "unset", // Hard-coded to white, we don't want that.
+                    },
+                  },
+                }}
+                color={props.color}
+              />
+            </Grid>
+          )}
+          {props.showOpacitySlider && props.strokeType !== "none" && (
+            <OpacitySlider
+              handleOpacityChange={props.handleOpacityChange}
+              opacity={isNaN(props.color?.a) ? 1 : props.color.a}
+            />
+          )}
+          {props.showStrokeWidthSlider && props.strokeType !== "none" && (
+            <StrokeWidthSlider
+              handleStrokeWidthChange={props.handleStrokeWidthChange}
+              strokeWidth={props.strokeWidth}
+            />
           )}
         </Grid>
       </AccordionDetails>

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
@@ -19,7 +19,7 @@ export default function FeatureStyleSelector(props) {
       !["Circle", "Polygon"]?.includes(activeDrawType) &&
       drawStyle.strokeType === "none"
     ) {
-      // Update drawStyle with solid strokeType
+      // We want to update the drawStyle with the default values
       setDrawStyle((prevDrawStyle) => ({
         ...prevDrawStyle,
         strokeType: DEFAULT_DRAW_STYLE_SETTINGS.strokeType,

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
@@ -1,12 +1,37 @@
 import React from "react";
 import { Grid, Typography, TextField } from "@mui/material";
-import { STROKE_DASHES } from "plugins/Sketch/constants";
+import {
+  STROKE_DASHES,
+  DEFAULT_DRAW_STYLE_SETTINGS,
+} from "plugins/Sketch/constants";
 
 import FeatureStyleAccordion from "./FeatureStyleAccordion";
 import FeaturePointSizeAccordion from "./FeatureSizeAccordion";
 import StrokeTypeSelector from "./StrokeTypeSelector";
 
 export default function FeatureStyleSelector(props) {
+  // set the strokeType automatically to the default value "solid" if activeDrawType is not "Circle" or "Polygon"
+  React.useEffect(() => {
+    // Check if activeDrawType is not "Circle" or "Polygon" and strokeType is not already "solid"
+    if (
+      !["Circle", "Polygon"]?.includes(props.activeDrawType) &&
+      props.drawStyle.strokeType !== "solid" &&
+      props.drawStyle.strokeType === "none"
+    ) {
+      // Update drawStyle with solid strokeType
+      props.setDrawStyle((prevDrawStyle) => ({
+        ...prevDrawStyle,
+        strokeType: DEFAULT_DRAW_STYLE_SETTINGS.strokeType,
+        lineDash: STROKE_DASHES.get("solid"),
+        strokeColor: {
+          ...props.drawStyle.strokeColor,
+          a: DEFAULT_DRAW_STYLE_SETTINGS.strokeColor.a,
+        },
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.activeDrawType, props.drawStyle]);
+
   // We need a handler that can update the stroke-dash setting
   const handleStrokeTypeChange = (e) => {
     // We are storing both the stroke-type (e.g. "dashed", "dotted", or "solid") as well as
@@ -15,11 +40,14 @@ export default function FeatureStyleSelector(props) {
     const strokeType = e.target.value;
     // And corresponds to a line-dash from the constants
     const lineDash = STROKE_DASHES.get(strokeType);
+    // Check if strokeType is "none" and set alpha value accordingly
+    const alphaCheck = strokeType === "none" ? 0 : 1;
     // When everything we need is fetched, we update the draw-style.
     props.setDrawStyle({
       ...props.drawStyle,
       strokeType: strokeType,
       lineDash: lineDash,
+      strokeColor: { ...props.drawStyle.strokeColor, a: alphaCheck },
     });
   };
 
@@ -33,7 +61,10 @@ export default function FeatureStyleSelector(props) {
 
   // We need a handler that can update the stroke color
   const handleStrokeColorChange = (e) => {
-    props.setDrawStyle({ ...props.drawStyle, strokeColor: e.rgb });
+    props.setDrawStyle({
+      ...props.drawStyle,
+      strokeColor: { ...e.rgb, a: props.drawStyle.strokeColor.a }, // Retains the alpha value
+    });
   };
 
   // We need a handler that can update the fill color
@@ -139,6 +170,9 @@ export default function FeatureStyleSelector(props) {
             showStrokeTypeSelector
             handleStrokeTypeChange={handleStrokeTypeChange}
             strokeType={props.drawStyle.strokeType}
+            activeDrawType={props.activeDrawType}
+            setDrawStyle={props.setDrawStyle}
+            drawStyle={props.drawStyle}
           />
         </Grid>
       </Grid>

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
@@ -22,7 +22,7 @@ export default function FeatureStyleSelector(props) {
       props.setDrawStyle((prevDrawStyle) => ({
         ...prevDrawStyle,
         strokeType: DEFAULT_DRAW_STYLE_SETTINGS.strokeType,
-        lineDash: STROKE_DASHES.get("solid"),
+        lineDash: STROKE_DASHES.get(DEFAULT_DRAW_STYLE_SETTINGS.strokeType),
         strokeColor: {
           ...props.drawStyle.strokeColor,
           a: DEFAULT_DRAW_STYLE_SETTINGS.strokeColor.a,

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
@@ -10,12 +10,11 @@ import FeaturePointSizeAccordion from "./FeatureSizeAccordion";
 import StrokeTypeSelector from "./StrokeTypeSelector";
 
 export default function FeatureStyleSelector(props) {
-  // set the strokeType automatically to the default value "solid" if activeDrawType is not "Circle" or "Polygon"
+  // Since the strokeType value "none" is only available for the activeDrawType "Circle" and "Polygon" we Automatically want to set the strokeType to the default value "solid"
+  // if activeDrawType is neither "Circle" or "Polygon" and strokeType is "none"
   React.useEffect(() => {
-    // Check if activeDrawType is not "Circle" or "Polygon" and strokeType is not already "solid"
     if (
       !["Circle", "Polygon"]?.includes(props.activeDrawType) &&
-      props.drawStyle.strokeType !== "solid" &&
       props.drawStyle.strokeType === "none"
     ) {
       // Update drawStyle with solid strokeType

--- a/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/FeatureStyleSelector.js
@@ -10,26 +10,27 @@ import FeaturePointSizeAccordion from "./FeatureSizeAccordion";
 import StrokeTypeSelector from "./StrokeTypeSelector";
 
 export default function FeatureStyleSelector(props) {
-  // Since the strokeType value "none" is only available for the activeDrawType "Circle" and "Polygon" we Automatically want to set the strokeType to the default value "solid"
-  // if activeDrawType is neither "Circle" or "Polygon" and strokeType is "none"
+  const { activeDrawType, drawStyle, setDrawStyle } = props;
+  // Since the strokeType value "none" is only available for the activeDrawTypes "Circle" and "Polygon"
+  // we automatically want to set the strokeType to the default value "solid"
+  // if the activeDrawType is neither "Circle" or "Polygon" and if the strokeType is "none"
   React.useEffect(() => {
     if (
-      !["Circle", "Polygon"]?.includes(props.activeDrawType) &&
-      props.drawStyle.strokeType === "none"
+      !["Circle", "Polygon"]?.includes(activeDrawType) &&
+      drawStyle.strokeType === "none"
     ) {
       // Update drawStyle with solid strokeType
-      props.setDrawStyle((prevDrawStyle) => ({
+      setDrawStyle((prevDrawStyle) => ({
         ...prevDrawStyle,
         strokeType: DEFAULT_DRAW_STYLE_SETTINGS.strokeType,
         lineDash: STROKE_DASHES.get(DEFAULT_DRAW_STYLE_SETTINGS.strokeType),
         strokeColor: {
-          ...props.drawStyle.strokeColor,
+          ...drawStyle.strokeColor,
           a: DEFAULT_DRAW_STYLE_SETTINGS.strokeColor.a,
         },
       }));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.activeDrawType, props.drawStyle]);
+  }, [activeDrawType, drawStyle, setDrawStyle]);
 
   // We need a handler that can update the stroke-dash setting
   const handleStrokeTypeChange = (e) => {

--- a/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
@@ -4,6 +4,11 @@ import { TextField, Tooltip, Typography } from "@mui/material";
 import { STROKE_TYPES } from "../../constants";
 
 const StrokeTypeSelector = (props) => {
+  const filteredStrokeTypes =
+    props.activeDrawType === "Circle" || props.activeDrawType === "Polygon"
+      ? STROKE_TYPES
+      : STROKE_TYPES.filter((strokeType) => strokeType.type !== "none");
+
   return (
     <Paper
       style={{ padding: props.includeContainer !== false ? 8 : 0 }}
@@ -24,15 +29,17 @@ const StrokeTypeSelector = (props) => {
           value={props.strokeType}
           onChange={props.handleStrokeTypeChange}
         >
-          {STROKE_TYPES.map((option) => (
-            <MenuItem key={option.type} value={option.type}>
-              {
-                <Tooltip disableInteractive title={option.tooltip}>
-                  <span style={{ width: "100%" }}>{option.label}</span>
-                </Tooltip>
-              }
-            </MenuItem>
-          ))}
+          {filteredStrokeTypes.map((option) => {
+            return (
+              <MenuItem key={option.type} value={option.type}>
+                {
+                  <Tooltip disableInteractive title={option.tooltip}>
+                    <span style={{ width: "100%" }}>{option.label}</span>
+                  </Tooltip>
+                }
+              </MenuItem>
+            );
+          })}
         </TextField>
       </Grid>
     </Paper>

--- a/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
@@ -9,6 +9,12 @@ const StrokeTypeSelector = (props) => {
       ? STROKE_TYPES
       : STROKE_TYPES.filter((strokeType) => strokeType.type !== "none");
 
+  const initialStrokeType = filteredStrokeTypes.find(
+    (option) => option.type === props.strokeType
+  )
+    ? props.strokeType
+    : filteredStrokeTypes[0]?.type;
+
   return (
     <Paper
       style={{ padding: props.includeContainer !== false ? 8 : 0 }}
@@ -26,7 +32,7 @@ const StrokeTypeSelector = (props) => {
           variant="outlined"
           size="small"
           select
-          value={props.strokeType}
+          value={initialStrokeType}
           onChange={props.handleStrokeTypeChange}
         >
           {filteredStrokeTypes.map((option) => {

--- a/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
+++ b/new-client/src/plugins/Sketch/components/featureStyle/StrokeTypeSelector.js
@@ -4,11 +4,15 @@ import { TextField, Tooltip, Typography } from "@mui/material";
 import { STROKE_TYPES } from "../../constants";
 
 const StrokeTypeSelector = (props) => {
+  // This filter is used to remove the "none" strokeType from the select when the activeDrawType is anything but "Circle" or "Polygon"
+  // This is because the "none" strokeType is only available for the activeDrawTypes "Circle" and "Polygon"
   const filteredStrokeTypes =
     props.activeDrawType === "Circle" || props.activeDrawType === "Polygon"
       ? STROKE_TYPES
       : STROKE_TYPES.filter((strokeType) => strokeType.type !== "none");
 
+  // We want to set the initial strokeType to the current strokeType if it's available in the filteredStrokeTypes
+  // Otherwise we want to set it to the first available strokeType ("none").
   const initialStrokeType = filteredStrokeTypes.find(
     (option) => option.type === props.strokeType
   )

--- a/new-client/src/plugins/Sketch/constants/index.js
+++ b/new-client/src/plugins/Sketch/constants/index.js
@@ -128,6 +128,11 @@ export const PLUGIN_MARGIN = 10;
 
 export const STROKE_TYPES = [
   {
+    type: "none",
+    label: "Ingen",
+    tooltip: "Ingen linje.",
+  },
+  {
     type: "solid",
     label: "Heldragen",
     tooltip: "Heldragen linje.",
@@ -145,6 +150,7 @@ export const STROKE_TYPES = [
 ];
 
 export const STROKE_DASHES = new Map([
+  ["none", []],
   ["solid", null],
   ["dotted", [2, 7]],
   ["dashed", [12, 7]],

--- a/new-client/src/plugins/Sketch/constants/index.js
+++ b/new-client/src/plugins/Sketch/constants/index.js
@@ -150,7 +150,6 @@ export const STROKE_TYPES = [
 ];
 
 export const STROKE_DASHES = new Map([
-  ["none", []],
   ["solid", null],
   ["dotted", [2, 7]],
   ["dashed", [12, 7]],


### PR DESCRIPTION
Issue: #1177 

Note: Additionally, I've conducted tests to verify the consistency of the stroke value 'none'/stroke style by exporting to a KML file and importing it across various software platforms, aside from Hajk. This was done to ensure alignment with the expected behavior across different environments.