### PR TITLE
Stand-alone GeoWebCache support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Core, Admin: Added support for stand-alone GeoWebCache WMS Server. Issue: [#1469](https://github.com/hajkmap/Hajk/issues/1469)
 - Print/Anchor: It's now possible to generate qr codes in Share and Print [#1482](https://github.com/hajkmap/Hajk/issues/1482)
 - Sketch: It's now possible to disable stroke for polygons and circles [#1177](https://github.com/hajkmap/Hajk/issues/1177)
 - Backend: The new .NET 6 backend. Issue: [#1210](https://github.com/hajkmap/Hajk/issues/1210). PR: [#1395](https://github.com/hajkmap/Hajk/pull/1395)

--- a/new-admin/public/config.docker.json
+++ b/new-admin/public/config.docker.json
@@ -10,6 +10,7 @@
     "url_wmtslayer_settings": "/api/v1/settings/wmtslayer",
     "url_arcgislayer_settings": "/api/v1/settings/arcgislayer",
     "url_vectorlayer_settings": "/api/v1/settings/vectorlayer",
+    "default_server_type": "geoserver",
     "url_default_server": "https://geoservertest.halmstad.se/geoserver/wms",
     "owner_options": [
       { "value": "SBK", "title": "SBK" },

--- a/new-admin/public/config.json
+++ b/new-admin/public/config.json
@@ -10,6 +10,7 @@
     "url_wmtslayer_settings": "http://localhost:3002/api/v1/settings/wmtslayer",
     "url_arcgislayer_settings": "http://localhost:3002/api/v1/settings/arcgislayer",
     "url_vectorlayer_settings": "http://localhost:3002/api/v1/settings/vectorlayer",
+    "default_server_type": "geoserver",
     "url_default_server": "https://geoservertest.halmstad.se/geoserver/wms",
     "owner_options": [
       { "value": "SBK", "title": "SBK" },

--- a/new-admin/public/config_example.json
+++ b/new-admin/public/config_example.json
@@ -10,6 +10,7 @@
     "url_wmtslayer_settings": "https://YOUR_DOMAIN.COM/mapservice/settings/wmtslayer",
     "url_arcgislayer_settings": "https://YOUR_DOMAIN.COM/mapservice/settings/arcgislayer",
     "url_vectorlayer_settings": "https://YOUR_DOMAIN.COM/mapservice/settings/vectorlayer",
+    "default_server_type": "geoserver",
     "url_default_server": "https://YOUR_MAP_SERVER.COM/geoserver/wms",
     "owner_options": [
       { "value": "SBK", "title": "SBK" },

--- a/new-admin/src/models/layermanager.js
+++ b/new-admin/src/models/layermanager.js
@@ -5,6 +5,18 @@ import $ from "jquery";
 import { prepareProxyUrl } from "../utils/ProxyHelper";
 import { hfetch } from "utils/FetchWrapper";
 
+const WMS_VERSION_1_3_0 = "1.3.0";
+const WMS_VERSION_1_1_1 = "1.1.1";
+const WMS_VERSION_1_1_0 = "1.1.0";
+const WMS_VERSION_1_0_0 = "1.0.0";
+
+const defaultVersions = [
+  WMS_VERSION_1_3_0,
+  WMS_VERSION_1_1_1,
+  WMS_VERSION_1_1_0,
+  WMS_VERSION_1_0_0
+];
+
 var manager = Model.extend({
   defaults: {
     layers: [],
@@ -33,7 +45,7 @@ var manager = Model.extend({
           hfetch(url).then((res) => {
             // JSONify, filter just for one tool (layerswitcher), and then use first element (it's an array…)
             res.json().then((d) => {
-              let layerswitcherConfig = d.tools.filter(
+              let layerswitcherConfig = d.tools?.filter(
                 (tool) => tool.type === "layerswitcher"
               )[0];
 
@@ -41,10 +53,10 @@ var manager = Model.extend({
               // This will be used for filtering.
               let washed = {
                 mapFilename: data[i],
-                mapTitle: d.map.title,
+                mapTitle: d.map?.title,
                 layers: {
-                  baseLayers: layerswitcherConfig.options.baselayers,
-                  groups: layerswitcherConfig.options.groups,
+                  baseLayers: layerswitcherConfig?.options.baselayers,
+                  groups: layerswitcherConfig?.options.groups,
                 },
               };
 
@@ -89,23 +101,30 @@ var manager = Model.extend({
     $.ajax(prepareProxyUrl(url, this.get("config").url_proxy), {
       success: (data) => {
         var layers = [];
-        data.wmslayers.forEach((l) => {
-          l.type = "WMS";
-        });
-        data.wmtslayers.forEach((l) => {
-          l.type = "WMTS";
-        });
-        data.arcgislayers.forEach((l) => {
-          l.type = "ArcGIS";
-        });
-        data.vectorlayers.forEach((l) => {
-          l.type = "Vector";
-        });
-
-        layers = data.wmslayers
-          .concat(data.wmtslayers)
-          .concat(data.arcgislayers)
-          .concat(data.vectorlayers);
+        if (data && Array.isArray(data.wmslayers)) {
+          data.wmslayers.forEach((l) => {
+            l.type = "WMS";
+          });
+          layers = layers.concat(data.wmslayers);
+        }
+        if (data && Array.isArray(data.wmtslayers)) {
+          data.wmtslayers.forEach((l) => {
+            l.type = "WMTS";
+          });
+          layers = layers.concat(data.wmtslayers);
+        }
+        if (data && Array.isArray(data.arcgislayers)) {
+          data.arcgislayers.forEach((l) => {
+            l.type = "ArcGIS";
+          });
+          layers = layers.concat(data.arcgislayers);
+        }
+        if (data && Array.isArray(data.vectorlayers)) {
+          data.vectorlayers.forEach((l) => {
+            l.type = "Vector";
+          });
+          layers = layers.concat(data.vectorlayers);
+        }
 
         layers.sort((a, b) => {
           var d1 = parseInt(a.date, 10),
@@ -380,7 +399,7 @@ var manager = Model.extend({
     });
   },
 
-  getAllWMSCapabilities: function (url) {
+  getAllWMSCapabilities: function (url, versions = defaultVersions) {
     var promises = [];
 
     var xmlParser = new X2JS({
@@ -392,8 +411,6 @@ var manager = Model.extend({
         "WMT_MS_Capabilities.Capability.Layer.Layer.Style",
       ],
     });
-
-    var versions = ["1.3.0", "1.1.1", "1.1.0", "1.0.0"];
 
     versions.forEach((version) => {
       promises.push(
@@ -426,6 +443,10 @@ var manager = Model.extend({
           // WMS_Capabilities or WMT_MS_Capabilities
           // First key in JSON
           var capabilitiesKey = Object.keys(json)[0];
+          // A HTML document returned is an error but e.g. dev servers can return this on server found, erroneously with HTTP/200 OK
+          if (capabilitiesKey === "html") {
+            throw new Error("Server returns HTML instead of expected WMS GetCapabilities response, check contents for e.g. proxy errors");
+          }
 
           return json[capabilitiesKey];
         })
@@ -458,4 +479,4 @@ var manager = Model.extend({
   },
 });
 
-export default manager;
+export { manager as default, WMS_VERSION_1_0_0, WMS_VERSION_1_1_0, WMS_VERSION_1_1_1, WMS_VERSION_1_3_0 };

--- a/new-admin/src/views/layerforms/wmslayerform.jsx
+++ b/new-admin/src/views/layerforms/wmslayerform.jsx
@@ -2,8 +2,21 @@ import React from "react";
 import { Component } from "react";
 import $ from "jquery";
 import { hfetch } from "utils/FetchWrapper";
+import { WMS_VERSION_1_1_0, WMS_VERSION_1_1_1, WMS_VERSION_1_3_0 } from "models/layermanager";
 
 var solpop;
+
+// Suported Hajk WMS Server types, in the client is this re-mapped to support OpenLayers server types:
+//  GeoServer
+const SERVERTYPE_GEOSERVER = "geoserver";
+//  GeoWebCache, #1469: Stand-Alone, without GeoServer's REST API, i.e. no automatic workspace listing. (client --> GeoServer)
+const SERVERTYPE_GWC_STANDALONE = "geowebcache-standalone";
+//  QGIS Server
+const SERVERTYPE_QGIS = "qgis";
+//  MapServer
+const SERVERTYPE_MAPSERVER = "mapserver";
+//  ESRI ArcGIS Server (client --> MapServer)
+const SERVERTYPE_ARCGIS = "arcgis";
 
 const defaultState = {
   load: false,
@@ -39,7 +52,8 @@ const defaultState = {
   ],
   customRatio: 0,
   imageFormat: "",
-  serverType: "geoserver",
+  serverType: "", // #1469: Don't use a default, trigger state change in componentDidMount (for the now optional workspace selector)
+  workspaceSelectorVisible: false,
   drawOrder: 1,
   layerType: "WMS",
   attribution: "",
@@ -55,7 +69,7 @@ const defaultState = {
   timeSliderEnd: "",
   solpopup: solpop,
   capabilitiesList: [],
-  version: "1.1.0",
+  version: WMS_VERSION_1_1_0,
   projection: "",
   infoFormat: "",
   infoClickSortProperty: "",
@@ -113,6 +127,7 @@ class WMSLayerForm extends Component {
   componentDidMount() {
     let _state = { ...defaultState };
     _state.url = this.props.url;
+    _state.serverType = this.props.serverType || SERVERTYPE_GEOSERVER;
     this.setState(_state);
 
     this.props.model.on("change:select-image", () => {
@@ -127,6 +142,16 @@ class WMSLayerForm extends Component {
       });
       this.validateField("select-legend-icon");
     });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.serverType !== this.state.serverType) {
+      let newState = {
+        workspaceSelectorVisible: this.state.serverType === SERVERTYPE_GEOSERVER
+      };
+      newState.tiled = this.state.serverType === SERVERTYPE_GWC_STANDALONE ? true : defaultState.tiled;
+      this.setState(newState);
+    }
   }
 
   componentWillUnmount() {
@@ -470,7 +495,7 @@ class WMSLayerForm extends Component {
           </div>
         </div>
 
-        <div className="separator">Infoclick</div>
+        <div className="separator">Infoklick</div>
 
         <div className="form-row split0">
           <div>
@@ -498,7 +523,7 @@ class WMSLayerForm extends Component {
         </div>
         <div className="form-row split0">
           <div>
-            <label>Infoclick-ikon</label> (
+            <label>Infoklick-ikon</label> (
             <a
               href="https://fonts.google.com/icons?selected=Material+Icons"
               target="_blank"
@@ -532,7 +557,7 @@ class WMSLayerForm extends Component {
           </div>
         </div>
 
-        <div className="separator">Infoclick och sökning</div>
+        <div className="separator">Infoklick och sökning</div>
 
         <div className="form-row split50">
           <div>
@@ -940,7 +965,7 @@ class WMSLayerForm extends Component {
       // previous implementation of WMS in Hajk2 assumed it was "1.1.1"
       // and did not add "version" property.
 
-      layer.version = layer.version || "1.1.1";
+      layer.version = layer.version || WMS_VERSION_1_1_1;
 
       var addedLayersInfo = {};
       var capabilities = this.state.capabilitiesList.find(
@@ -975,7 +1000,7 @@ class WMSLayerForm extends Component {
           addedLayersInfo: addedLayersInfo,
           capabilities,
           projection: layer.projection,
-          version: capabilities.version,
+          version: capabilities?.version,
           infoFormat: layer.infoFormat,
           infoClickSortProperty: layer.infoClickSortProperty ?? "",
           infoClickSortType: layer.infoClickSortType ?? "string",
@@ -1007,6 +1032,9 @@ class WMSLayerForm extends Component {
     // Previously this was done while rendering.
 
     let layerOpts = {};
+    if (!capabilities || !capabilities.Capability) {
+      return;
+    }
     capabilities.Capability.Layer.Layer.forEach((_layer) => {
       let trueTitle = _layer.hasOwnProperty("Title") ? _layer.Title : "";
       let abstract = _layer.hasOwnProperty("Abstract") ? _layer.Abstract : "";
@@ -1047,8 +1075,11 @@ class WMSLayerForm extends Component {
         });
     }
 
+    // #1469: Stand-Alone GeoWebCache only support v1.1.1 but will (confusingly) answer when called with e.g. ?VERSION=1.3.0,
+    // avoiding parsing such version-inconsistent replies by narrowing down WMS versions used for querying server to specifically v1.1.1
+    var versions = this.state.serverType === SERVERTYPE_GWC_STANDALONE ? [ WMS_VERSION_1_1_1 ] : undefined;
     var capabilitiesPromise = this.props.model.getAllWMSCapabilities(
-      this.state.url
+      this.state.url, versions
     );
 
     capabilitiesPromise
@@ -1078,10 +1109,14 @@ class WMSLayerForm extends Component {
         );
       })
       .catch((err) => {
-        if (this.props.parentView) {
-          this.props.parentView.setState({
+        this.setState({
+          load: false,
+          capabilitiesList: []
+        });
+        if (this.props.parent) {
+          this.props.parent.setState({
             alert: true,
-            alertMessage: "Servern svarar inte. Försök med en annan URL.",
+            alertMessage: "Servern svarar inte eller blockeras av CORS.\nFörsök med en annan URL.",
           });
         }
       });
@@ -1140,45 +1175,54 @@ class WMSLayerForm extends Component {
         this.state.capabilities.Capability.Request.GetFeatureInfo.Format;
     }
     if (formats && formats.indexOf("application/geojson") > -1) {
-      this.setState({ serverType: "arcgis" });
+      this.setState({ serverType: SERVERTYPE_ARCGIS });
     }
   }
 
   setProjections() {
     let projections;
-    if (
-      this.state.capabilities &&
-      this.state.capabilities.Capability &&
-      this.state.capabilities.Capability.Layer
-    ) {
-      var RS = this.state.version === "1.3.0" ? "CRS" : "SRS";
-      projections = this.state.capabilities.Capability.Layer[RS];
+    const RS = this.state.version === WMS_VERSION_1_3_0 ? "CRS" : "SRS";  
+    const capabilities = this.state.capabilities;
+    if (capabilities && capabilities.Capability && capabilities.Capability.Layer) {
+      // #1469: Projection metadata can be present on the parent or child Layer element of GetCapabilities
+      // both are valid for e.g. OGC WMS v1.1.1 DTD.
+      const layers = capabilities.Capability.Layer.Layer;
+      if (capabilities.Capability.Layer[RS]) {
+        // If there is a direct RS property on the Layer, use it (assuming it's an array)
+        projections = [...new Set(capabilities.Capability.Layer[RS])];
+      } else if (layers) {
+        // Otherwise, iterate over the child layers
+        projections = layers.flatMap((layer) => {
+          // Ensure we always return an array from flatMap by concatenating the layer[RS] if it exists or returning an empty array if not
+          return layer[RS] ? [].concat(layer[RS]) : [];
+        });      
+        // Create a Set from the array to remove duplicates, convert it back to an array, and filter out any falsy values (like undefined or null)
+        projections = [...new Set(projections)].filter(Boolean);      
+        // If there are no projections left after filtering, set to null
+        if (!projections.length) {
+          projections = null;
+        }
+      }
     }
 
-    // We expect projections to be an array,
-    // but are also ready for a string (see below).
+    // Handle projections, if existing, as either string (single CRS/SRS) or array of strings
     if (projections) {
-      // First, ensure we have an array, see #1352
+      // Ensure we always have an internal array, see #1352
       if (!Array.isArray(projections)) {
         projections = [projections];
       }
 
-      projections = projections.map((projection) => {
-        return projection.toUpperCase();
-      });
+      projections = projections.map(projection => projection ? projection.toUpperCase() : null);
     }
 
-    let projEles = projections
-      ? supportedProjections.map((proj, i) => {
-          if (projections.indexOf(proj) > -1) {
-            return <option key={i}>{proj}</option>;
-          } else {
-            return "";
-          }
-        })
-      : "";
-
-    return projEles;
+    return projections ? projections.map((proj, i) => {
+      if (supportedProjections.includes(proj)) {
+        return <option key={i}>{proj}</option>;
+      } else {
+        console.log("Unsupported spatial reference system found in WMS capabilities document, ignoring:", proj);
+        return null;
+      }
+    }) : null;
   }
 
   setInfoFormats() {
@@ -1457,28 +1501,41 @@ class WMSLayerForm extends Component {
   }
 
   getWorkspaces = async (url) => {
-    //
-    url = url.substring(0, url.lastIndexOf("/")) + "/rest/workspaces";
-    //
-    const res = await hfetch(url);
-    //
-    const json = await res.json();
-    //
-    //this.setState({ workspaceList: json.workspaces.workspace });
-    //
-    var sortedWorksapes = json.workspaces.workspace.sort(GetSortOrder("name")); //Pass the attribute to be sorted on
+    try {
+      if (url.endsWith("/")) {
+        url = url.slice(0, -1);
+      }
+      url = url.substring(0, url.lastIndexOf("/")) + "/rest/workspaces";
+      const res = await hfetch(url);
+      if (!res.ok) {
+        // Handle non-successful responses, e.g. HTTP/404 when REST API is not exposed
+        throw new Error('Failed to fetch workspaces: ' + res.status);
+      }
+      const json = await res.json();
+      var sortedWorkspaces = json.workspaces.workspace.sort(GetSortOrder("name")); //Pass the attribute to be sorted on
 
-    function GetSortOrder(prop) {
-      return function (a, b) {
-        if (a[prop] > b[prop]) {
-          return 1;
-        } else if (a[prop] < b[prop]) {
-          return -1;
-        }
-        return 0;
-      };
+      function GetSortOrder(prop) {
+        return function (a, b) {
+          if (a[prop] > b[prop]) {
+            return 1;
+          } else if (a[prop] < b[prop]) {
+            return -1;
+          }
+          return 0;
+        };
+      }
+      this.setState({ workspaceList: sortedWorkspaces });
+    } catch (error) {
+      if (this.props.parent) {
+        this.props.parent.setState({
+          alert: true,
+          alertMessage: "Workspace-listan kan inte hämtas från denna server, välj \"Alla\".",
+        });
+      } else {
+        console.warn("Workspace fetch from REST API failed.");
+      }
+      this.setState({ workspaceList: [] });
     }
-    this.setState({ workspaceList: sortedWorksapes });
   };
 
   updateDpiList(e, kv, key) {
@@ -1524,7 +1581,7 @@ class WMSLayerForm extends Component {
       ? "tooltip-timeSlider"
       : "hidden";
 
-    const version = this.state.version || "1.1.1";
+    const version = this.state.version || WMS_VERSION_1_1_1;
     const infoFormat = this.state.infoFormat || "";
 
     return (
@@ -1539,21 +1596,13 @@ class WMSLayerForm extends Component {
             value={this.state.serverType}
             onChange={(e) => {
               this.setState({ serverType: e.target.value });
-              if (
-                e.target.value === "geoserver"
-                  ? (document.getElementById(
-                      "availableWorkspaces"
-                    ).style.display = "unset")
-                  : (document.getElementById(
-                      "availableWorkspaces"
-                    ).style.display = "none")
-              );
             }}
           >
-            <option>geoserver</option>
-            <option>mapserver</option>
-            <option>qgis</option>
-            <option>arcgis</option>
+            <option>{SERVERTYPE_GEOSERVER}</option>
+            <option>{SERVERTYPE_MAPSERVER}</option>
+            <option>{SERVERTYPE_QGIS}</option>
+            <option>{SERVERTYPE_GWC_STANDALONE}</option>
+            <option>{SERVERTYPE_ARCGIS}</option>
           </select>
         </div>
         <div>
@@ -1568,7 +1617,7 @@ class WMSLayerForm extends Component {
             }}
             className={this.getValidationClass("url")}
           />
-          {this.state.serverType === "geoserver" ? (
+          {this.state.workspaceSelectorVisible ? (
             <span
               onClick={(e) => {
                 this.getWorkspaces(this.state.url);
@@ -1589,46 +1638,48 @@ class WMSLayerForm extends Component {
           )}
         </div>
 
-        <div id="availableWorkspaces">
-          <label>Välj workspace</label>
-          <select
-            className="control-fixed-width"
-            ref="input_workspaceName"
-            value={this.state.workspaceName}
-            onChange={(e) =>
-              this.setState({
-                url:
-                  this.state.url.substring(
-                    0,
-                    this.state.url.lastIndexOf("geoserver/") + 10
-                  ) + e.target.value,
-              })
-            }
-          >
-            <option key="wms" value="wms">
-              Alla
-            </option>
-            {this.state.workspaceList.map((workspace) => {
-              return (
-                <option
-                  key={workspace.name + "/wms"}
-                  value={workspace.name + "/wms"}
-                >
-                  {workspace.name}
-                </option>
-              );
-            })}
-          </select>
-          &nbsp;
-          <span
-            onClick={(e) => {
-              this.loadWMSCapabilities(e);
-            }}
-            className="btn btn-default"
-          >
-            Hämta lager {loader}
-          </span>
-        </div>
+        {this.state.workspaceSelectorVisible && (
+          <div id="availableWorkspaces">
+            <label>Välj workspace</label>
+            <select
+              className="control-fixed-width"
+              ref="input_workspaceName"
+              value={this.state.workspaceName}
+              onChange={(e) =>
+                this.setState({
+                  url:
+                    this.state.url.substring(
+                      0,
+                      this.state.url.lastIndexOf("geoserver/") + 10
+                    ) + e.target.value,
+                })
+              }
+            >
+              <option key="wms" value="wms">
+                Alla
+              </option>
+              {this.state.workspaceList.map((workspace) => {
+                return (
+                  <option
+                    key={workspace.name + "/wms"}
+                    value={workspace.name + "/wms"}
+                  >
+                    {workspace.name}
+                  </option>
+                );
+              })}
+            </select>
+            &nbsp;
+            <span
+              onClick={(e) => {
+                this.loadWMSCapabilities(e);
+              }}
+              className="btn btn-default"
+            >
+              Hämta lager {loader}
+            </span>
+          </div>
+        )}
 
         <div className="separator">Inställningar för request</div>
         <div>
@@ -1835,7 +1886,7 @@ class WMSLayerForm extends Component {
             checked={this.state.tiled}
           />
           &nbsp;
-          <label htmlFor="input_tiled">GeoWebCache</label>
+          <label htmlFor="input_tiled">Rutindelad (tiled)</label>
         </div>
         <div>
           <input
@@ -1874,7 +1925,7 @@ class WMSLayerForm extends Component {
                 <td>Titel</td>
                 <td>Namn</td>
                 <td>Grupp</td>
-                <td>Infoclick</td>
+                <td>Infoklick</td>
               </tr>
             </thead>
             {this.renderLayerList()}

--- a/new-admin/src/views/layermanager.jsx
+++ b/new-admin/src/views/layermanager.jsx
@@ -673,6 +673,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "WMTS":
@@ -683,6 +684,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "ArcGIS":
@@ -693,6 +695,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       case "Vector":
@@ -703,6 +706,7 @@ class Manager extends Component {
             layer={this.state.layer}
             parent={this}
             url={this.props.config.url_default_server}
+            serverType={this.props.config.default_server_type}
           />
         );
       default:

--- a/new-client/src/utils/ConfigMapper.js
+++ b/new-client/src/utils/ConfigMapper.js
@@ -74,6 +74,27 @@ export default class ConfigMapper {
       });
     }
 
+    /**
+     * Returns OpenLayers server type string, given Hajk server type as input.
+     * Certain Hajk server types are used only for admin interface and configuration switching,
+     * but being treated as a common OL server-type in the client.
+     * @param hajkServerType Hajk server type from config
+     * @returns OpenLayers server type as string
+     */
+    function getOpenLayersServerType(hajkServerType) {
+      if (!hajkServerType) {
+        return null;
+      }
+      switch (hajkServerType) {
+        case "geowebcache-standalone":
+          return "geoserver";
+        case "arcgis":
+          return "mapserver";
+        default:
+          return hajkServerType;
+      }
+    }
+
     function mapLayersInfo(layersInfo, infobox) {
       if (Array.isArray(layersInfo)) {
         return layersInfo.reduce((layersInfoObject, layerInfo) => {
@@ -150,10 +171,7 @@ export default class ConfigMapper {
         customDpiList: args.customDpiList,
         customRatio: args.customRatio,
         imageFormat: args.imageFormat || "image/png",
-        serverType:
-          args.serverType === "arcgis"
-            ? "mapserver"
-            : args.serverType || "geoserver",
+        serverType: getOpenLayersServerType(args.serverType),
         crossOrigin: properties.mapConfig.map.crossOrigin || "anonymous",
         attribution: args.attribution,
         showAttributeTableButton: args.showAttributeTableButton,


### PR DESCRIPTION
* Resolves hajkmap/Hajk#1469
* Add support for new WMS server type "geowebcache-standalone"
* Add optional support for configuring a default server type, as well as existing option for default URL (backwards compatible, falls back to "geoserver" if not present)
* Re-name admin WMS option from "GeoWebCache" to tiled (since WMS-C tiled mode has nothing to do with GeoWebCache and it's now a supported server type, making the old admin title for tiled option very confusing)
* Use constants for WMS versions and server types
* Avoid non-conformant WMS v1.3.0 GetCapabilities for geowebcache-standalone server type
* Automatically default to tiled loading for geowebcache-standalone server type
* Spellcheck admin sv-SE labels for queryable layers ("klick")

More robust WMS admin, guard against GetCapabilties load failures or format errors
* Console warning if unsupported spatial reference system found in WMS capabilities
* Fix: Async load could crash WMS admin if clicking too fast on layers/capabilities, not ready for projections update
* Fix: Do not reference undefined objects in admin after failed GetCapabilities
* Fix: Handle failed net requests e.g. due to CORS-block, instead of crashing admin
* Fix: Handle API failures for getting layers config gracefully (e.g. API endpoint version mismatch), instead of crashing admin
* Fix: Handle HTML responses with 200/OK for failed GetCapabilities (like e.g. Hajk development mode and GeoServer proxy)