### PR TITLE
Improve custom styling ability

### DIFF
--- a/apps/client/src/components/FeatureInfo/FeatureInfoContainer.js
+++ b/apps/client/src/components/FeatureInfo/FeatureInfoContainer.js
@@ -230,13 +230,19 @@ class FeatureInfoContainer extends React.PureComponent {
     const { features } = this.props;
     const featureInfoLoaded = this.isReadyToShowInfo();
     return (
-      <InfoContainer alignContent="flex-start" container spacing={1}>
+      <InfoContainer
+        className="hajk-featureinfo-body"
+        alignContent="flex-start"
+        container
+        spacing={1}
+      >
         {features.length > 1 && (
-          <Grid xs={12} item>
+          <Grid className="hajk-featureinfo-navigation" xs={12} item>
             {this.getToggler()}
           </Grid>
         )}
         <Grid
+          className="hajk-featureinfo-content"
           justifyContent="center"
           alignContent={featureInfoLoaded ? "flex-start" : "center"}
           sx={{ flex: "auto" }}

--- a/apps/client/src/components/Window.js
+++ b/apps/client/src/components/Window.js
@@ -480,6 +480,7 @@ class Window extends React.PureComponent {
     this.bringToFront();
     return (
       <StyledRnd
+        className="hajk-window"
         onMouseDown={(e) => {
           this.bringToFront();
         }}

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
@@ -308,14 +308,6 @@ class LayerGroupItem extends Component {
     );
   }
 
-  renderLegendImage() {
-    const src =
-      this.state.legend[0] && this.state.legend[0].url
-        ? this.state.legend[0].url
-        : "";
-    return src ? <img width="60" alt="legend" src={src} /> : null;
-  }
-
   openInformative = (chapter) => (e) => {
     this.props.onOpenChapter(chapter);
   };
@@ -684,8 +676,9 @@ class LayerGroupItem extends Component {
             alignItems="center"
             wrap="nowrap"
             onClick={this.toggleLayerVisible(subLayer)}
+            className="hajk-layerswitcher-sublayer-grid"
           >
-            <CheckBoxWrapper>
+            <CheckBoxWrapper className="hajk-layerswitcher-layer-toggle">
               {!visible ? (
                 <CheckBoxOutlineBlankIcon />
               ) : (
@@ -704,7 +697,7 @@ class LayerGroupItem extends Component {
               {layer.layersInfo[subLayer].caption}
             </Caption>
           </Grid>
-          <SummaryButtonsContainer>
+          <SummaryButtonsContainer className="hajk-layerswitcher-summary-buttons">
             <SummaryButtonWrapper>
               <DownloadLink
                 index={index}
@@ -953,7 +946,7 @@ class LayerGroupItem extends Component {
     const { layer } = this.props;
     const { visible, visibleSubLayers } = this.state;
     return (
-      <CheckBoxWrapper>
+      <CheckBoxWrapper className="hajk-layerswitcher-layer-toggle">
         {!visible ? (
           <CheckBoxOutlineBlankIcon />
         ) : visibleSubLayers.length !== layer.subLayers.length ? (

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroupItem.js
@@ -993,7 +993,7 @@ class LayerGroupItem extends Component {
                   {layer.get("caption")}
                 </Caption>
               </Grid>
-              <SummaryButtonsContainer>
+              <SummaryButtonsContainer className="hajk-layerswitcher-layer-buttons">
                 {this.renderStatus()}
                 {this.renderInfoToggler()}
                 <SummaryButtonWrapper>

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -402,14 +402,6 @@ class LayerItem extends React.PureComponent {
     );
   };
 
-  renderLegendImage() {
-    const src =
-      this.legend && this.legend[0] && this.legend[0].url
-        ? this.legend[0].url
-        : "";
-    return src ? <img width="30" alt="legend" src={src} /> : null;
-  }
-
   isInfoEmpty() {
     let chaptersWithLayer = this.findChapters(this.name, this.props.chapters);
     return !(
@@ -606,7 +598,11 @@ class LayerItem extends React.PureComponent {
     ) : (
       <CheckBoxOutlineBlankIcon />
     );
-    return <LayerTogglerButtonWrapper>{icon}</LayerTogglerButtonWrapper>;
+    return (
+      <LayerTogglerButtonWrapper className="hajk-layerswitcher-layer-toggle">
+        {icon}
+      </LayerTogglerButtonWrapper>
+    );
   };
 
   #showAttributeTable = async () => {
@@ -707,7 +703,7 @@ class LayerItem extends React.PureComponent {
               {this.caption}
             </Caption>
           </Grid>
-          <LayerButtonsContainer>
+          <LayerButtonsContainer className="hajk-layerswitcher-layer-buttons">
             {layer.isFakeMapLayer ? null : (
               <DownloadLink
                 layer={this.props.layer}


### PR DESCRIPTION
* Improve Hajk custom styling with CSS "class hints"
* Base implementation of idea #1481 (room for expansion of the same concept)
* Make it possible to distinguish Hajk specific components between generic MUI dito
* Add custom CSS classes as "hints" for custom Hajk styling, beyond what is already possible with MUI theming.
* LayerGroupItem/LayerItem: Remove dead code: "renderLegendImage" function (not used anymore)