### PR TITLE
Quick fix for #1507 - make sure Rnd component doesn't get "dynamic" a…

### DIFF
--- a/apps/client/src/components/Window.js
+++ b/apps/client/src/components/Window.js
@@ -528,13 +528,13 @@ class Window extends React.PureComponent {
         minHeight={this.state.mode === "minimized" ? 42 : 100}
         size={{
           width: width,
-          height: height,
+          height: height === "dynamic" ? "auto" : height, // 1507 - Quick fix, make sure Rnd component doesn't get "dynamic" as input
         }}
         default={{
           x: left,
           y: top,
           width: width,
-          height: height,
+          height: height === "dynamic" ? "auto" : height, // 1507 - Quick fix, make sure Rnd component doesn't get "dynamic" as input
         }}
       >
         <PanelContent


### PR DESCRIPTION
This fix closes #1507 

I can't see there could be any negative effect with this one, only positive.

Already running live i Varberg,