### PR TITLE
bug: set cookie checkboxes to stored values after refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore cross-platform build for NodeJS backend. [#1484](https://github.com/hajkmap/Hajk/pull/1484)
 - Bug fix associated to #1468. [#1485](https://github.com/hajkmap/Hajk/pull/1485)
 - Admin UI is now compatible with the correct HTTP verbs (`DELETE` and `PUT`). [#1501](https://github.com/hajkmap/Hajk/pull/1501)
+- Cookie: Cookie Notice updated after browser refresh. Fix to PR: [#1509](https://github.com/hajkmap/Hajk/pull/1509)
 
 ### Security
 

--- a/apps/client/src/components/CookieNotice.js
+++ b/apps/client/src/components/CookieNotice.js
@@ -12,7 +12,12 @@ import {
   Slide,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { setLevel, shouldShowNotice } from "../models/Cookie";
+import {
+  functionalOk,
+  setLevel,
+  shouldShowNotice,
+  thirdPartyOk,
+} from "../models/Cookie";
 
 // Default settings for the cookie-notice text and url if none is supplied from the configuration.
 const DEFAULT_MESSAGE =
@@ -55,8 +60,9 @@ function CookieNotice({ globalObserver, appModel }) {
 
   // We should initialize the dialog:s open-state to whatever the manager states.
   const [open, setOpen] = React.useState(shouldShowNotice());
-  const [functionalChecked, setFunctionalChecked] = React.useState(false);
-  const [thirdPartChecked, setThirdPartChecked] = React.useState(false);
+  const [functionalChecked, setFunctionalChecked] =
+    React.useState(functionalOk);
+  const [thirdPartChecked, setThirdPartChecked] = React.useState(thirdPartyOk);
 
   const defaultCookieNoticeMessage =
     config?.mapConfig?.map?.defaultCookieNoticeMessage || DEFAULT_MESSAGE;


### PR DESCRIPTION
The cookie checkboxes are now set to local storage values after browser refresh instead of always false.

To reproduce: Before this fix if cookies was set and you refresh your browser window and the pressed the cookie button the cookie notice showed no cookies marked.

After this fix and after refresh the cookie checkboxes are set as your previous choice stored in local storage.