### PR TITLE
bugfix: disable the circle geomtype in sketch buffer, reformat styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Measurer: The measurer now allows for selecting objects by clicking them to get measurement information (area and circumference). PR: [#1532](https://github.com/hajkmap/Hajk/pull/1532).
 - Backend (Node): Added (very) limited userDetails to response when using the AD Header approach (for example NodeHoster). [#1534](https://github.com/hajkmap/Hajk/pull/1534)
 
+### Fixed
+
+- Bug fix associated to #1460. [#1536](https://github.com/hajkmap/Hajk/pull/1536)
+
 ### Changed
 
 - Replaced the module used by the Plausible tracker in order to support some new features and fix bugs with the official tracker. See discussion in [#1535](https://github.com/hajkmap/Hajk/issues/1535).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bug fix associated to #1460. [#1536](https://github.com/hajkmap/Hajk/pull/1536)
+- Bug fix associated to the issue #1310 and PR #1460. [#1536](https://github.com/hajkmap/Hajk/pull/1536)
 
 ### Changed
 

--- a/apps/client/src/plugins/Sketch/components/SketchBuffer/BufferModel.js
+++ b/apps/client/src/plugins/Sketch/components/SketchBuffer/BufferModel.js
@@ -25,7 +25,7 @@ const BufferModel = (props) => {
     () =>
       new Style({
         fill: new Fill({
-          color: "rgba(255, 168, 231, 0.7)",
+          color: "rgba(255, 168, 231, 0.47)",
         }),
         stroke: new Stroke({
           color: "rgba(255, 168, 231, 1)",
@@ -47,7 +47,7 @@ const BufferModel = (props) => {
   // The default style for a buffered feature.
   const bufferStyle = new Style({
     fill: new Fill({
-      color: "rgba(255, 255, 255, 0.5)",
+      color: "rgba(255, 255, 255, 0.6)",
     }),
     stroke:
       drawStyle.strokeType === "none"
@@ -56,7 +56,7 @@ const BufferModel = (props) => {
             width: 4,
           })
         : new Stroke({
-            color: "rgba(75, 100, 115, 2)",
+            color: "rgba(75, 100, 115, 1.5)",
             width: 4,
           }),
     image: new Circle({
@@ -120,7 +120,7 @@ const BufferModel = (props) => {
 
             // We can't buffer Circle features and we don't want to buffer
             // around existing buffer features - let's exclude them.
-            if (!f.get("bufferedFeature") || geometryType !== "Circle") {
+            if (!f.get("bufferedFeature") && geometryType !== "Circle") {
               const clonedFeature = f.clone();
               clonedFeature.setStyle(highlightStyle);
               bufferState.highlightSource.addFeature(clonedFeature);


### PR DESCRIPTION
This fixes an issue from one of my previously merged PRs (#1460 ), which made it possible for the user to buffer from the Sketch plugin. The user should not be able to buffer the geometry type 'Circle,' and this PR addresses that problem.

Additionally, I changed some styling for the highlighted and buffered features to make it consistent with the Buffer plugin.

