### PR TITLE
Measurement segments

### DIFF
--- a/apps/client/src/models/DrawModel.js
+++ b/apps/client/src/models/DrawModel.js
@@ -2241,6 +2241,25 @@ class DrawModel {
         payLoad: feature,
       });
     }
+
+    // Check if we have used Segments.
+    // If the feature has the MEASUREMENT_ID, find and remove the referenced segment measure points too.
+    const userDrawnFeatures = this.#drawSource
+      .getFeatures()
+      .filter((f) => f.get("USER_DRAWN"));
+    if (feature.get("MEASUREMENT_ID")) {
+      const parentId = feature.get("MEASUREMENT_ID");
+      const referencedFeatures = userDrawnFeatures.filter((f) => {
+        const fId = f.get("MEASUREMENT_ID");
+        // We remove the segment points if they contain the parent id, but the parent should not be removed here.
+        if (fId) {
+          if (fId.includes(parentId) && !f.get("MEASUREMENT_PARENT")) {
+            return f;
+          }
+        }
+      });
+      referencedFeatures.forEach((f) => this.#drawSource.removeFeature(f));
+    }
   };
 
   // Accepts an RGBA-object containing r-, g-, b-, and a-properties, or an array

--- a/apps/client/src/models/DrawModel.js
+++ b/apps/client/src/models/DrawModel.js
@@ -2254,9 +2254,11 @@ class DrawModel {
         // We remove the segment points if they contain the parent id, but the parent should not be removed here.
         if (fId) {
           if (fId.includes(parentId) && !f.get("MEASUREMENT_PARENT")) {
+            // Return matching feature, in this case labels for this segment.
             return f;
           }
         }
+        return null;
       });
       referencedFeatures.forEach((f) => this.#drawSource.removeFeature(f));
     }

--- a/apps/client/src/plugins/Measurer/Measurer.js
+++ b/apps/client/src/plugins/Measurer/Measurer.js
@@ -266,13 +266,11 @@ function Measurer(props) {
     restoreHoveredFeature();
     angleSnapping.setActive(false);
     angleSnapping.clearSnapGuides();
-    // segments.setEnabled(false);
     setPluginShown(false);
   };
 
   const onWindowShow = () => {
     angleSnapping.setActive(true);
-    // segments.setEnabled(true);
     setPluginShown(true);
   };
 

--- a/apps/client/src/plugins/Measurer/Measurer.js
+++ b/apps/client/src/plugins/Measurer/Measurer.js
@@ -12,11 +12,13 @@ import DrawModel from "../../models/DrawModel";
 import { Circle, Fill, RegularShape, Stroke, Style } from "ol/style";
 import HelpIcon from "@mui/icons-material/Help";
 import AngleSnapping from "./AngleSnapping";
+import Segment from "./Segment";
 
 function Measurer(props) {
   const { map, app } = props;
   const [state] = React.useState({});
   const currentHoverFeature = useRef(null);
+  const [segmentsEnabled, setSegmentsEnabled] = useState(false);
   const [localObserver] = React.useState(Observer());
   const [drawType, setDrawType] = useState("LineString"); // default to LineString as previous Measure tool
   const [pluginShown, setPluginShown] = React.useState(
@@ -59,14 +61,21 @@ function Measurer(props) {
     return new AngleSnapping(drawModel, map);
   }, [drawModel, map]);
 
+  const segments = useMemo(() => {
+    return new Segment(drawModel, map);
+  }, [drawModel, map]);
+
   angleSnapping.setActive(true);
+  segments.setEnabled(segmentsEnabled);
 
   const handleDrawStart = useCallback(
     (e) => {
       // Forward drawstart event etc. to angle snapper.
       angleSnapping.handleDrawStartEvent(e, map, drawModel);
+      // And forward events to segments
+      segments.handleDrawStartEvent(e, map, drawModel);
     },
-    [angleSnapping, map, drawModel]
+    [angleSnapping, segments, map, drawModel]
   );
 
   const handleAddFeature = useCallback(
@@ -93,8 +102,19 @@ function Measurer(props) {
       if (remove) {
         drawModel.removeFeature(feature);
       }
+
+      // If the measurer creates a LineString or a polygon give it an ID so we can
+      // check in the drawmodel later if it's being removed, and remove the segment points aswell
+      if (type === "LineString" || type === "Polygon") {
+        const addedFeatureId = Math.random().toString(36).substring(2, 15);
+        feature.set("MEASUREMENT_ID", addedFeatureId);
+        // Indicate that this feature is a parent to the measurement points
+        feature.set("MEASUREMENT_PARENT", true);
+        // Update the Segment instance tracker of this id
+        segments.setLastPlacedFeatureId(addedFeatureId);
+      }
     },
-    [drawModel]
+    [drawModel, segments]
   );
 
   const handleDrawEnd = useCallback(
@@ -131,8 +151,9 @@ function Measurer(props) {
       }
 
       feature.setStyle(style);
+      segments.handleDrawEndEvent(e, map, drawModel);
     },
-    [angleSnapping]
+    [drawModel, map, angleSnapping, segments]
   );
 
   const startInteractionWithDrawType = useCallback(
@@ -245,11 +266,13 @@ function Measurer(props) {
     restoreHoveredFeature();
     angleSnapping.setActive(false);
     angleSnapping.clearSnapGuides();
+    // segments.setEnabled(false);
     setPluginShown(false);
   };
 
   const onWindowShow = () => {
     angleSnapping.setActive(true);
+    // segments.setEnabled(true);
     setPluginShown(true);
   };
 
@@ -263,7 +286,10 @@ function Measurer(props) {
     },
   ];
 
-  //
+  const toggleSegmentsEnabled = (enabled) => {
+    setSegmentsEnabled(enabled);
+  };
+
   return (
     <BaseWindowPlugin
       {...props}
@@ -273,7 +299,7 @@ function Measurer(props) {
         title: state.title || "Mät",
         description: "Mät längder och ytor",
         height: "dynamic",
-        width: 400,
+        width: 500,
         customPanelHeaderButtons: customHeaderButtons,
 
         onWindowHide: onWindowHide,
@@ -285,6 +311,8 @@ function Measurer(props) {
         localObserver={localObserver}
         drawType={drawType}
         drawModel={drawModel}
+        segmentsEnabled={segmentsEnabled}
+        toggleSegmentsEnabled={(enabled) => toggleSegmentsEnabled(enabled)}
         handleDrawTypeChange={handleDrawTypeChange}
       />
     </BaseWindowPlugin>

--- a/apps/client/src/plugins/Measurer/MeasurerIcons.js
+++ b/apps/client/src/plugins/Measurer/MeasurerIcons.js
@@ -84,3 +84,18 @@ export function IconCircle() {
 
   return svg2Base64(svg);
 }
+
+export function IconSegment() {
+  const svg = `<svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g>
+      <rect x="0" y="-0" width="24" height="24" style="fill:#f00;fill-opacity:0;" />
+      <g>
+        <path d="M5.278,18.804l13.438,-13.438" style="fill:none;stroke:#000;stroke-width:1.4px;" />
+              <polygon points="10,11, 7,10 9,8" style="fill:#000;stroke:#000;stroke-width:1.4px;" />
+      </g>
+    </g>
+  </svg>
+  `;
+
+  return svg2Base64(svg);
+}

--- a/apps/client/src/plugins/Measurer/MeasurerView.js
+++ b/apps/client/src/plugins/Measurer/MeasurerView.js
@@ -9,6 +9,7 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Zoom,
 } from "@mui/material";
 
 import {
@@ -123,11 +124,20 @@ function MeasurerView(props) {
   } = props;
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [showSegmentButton, setShowSegmentButton] = useState(true);
 
   const deleteAll = () => {
     setShowDeleteConfirmation(false);
     drawModel.removeDrawnFeatures();
   };
+
+  useEffect(() => {
+    if (drawType === "LineString" || drawType === "Polygon") {
+      setShowSegmentButton(true);
+    } else {
+      setShowSegmentButton(false);
+    }
+  }, [drawType]);
 
   useEffect(() => {
     props.localObserver.subscribe("show-help", () => {
@@ -188,13 +198,15 @@ function MeasurerView(props) {
         </Grid>
         <Grid item xs={2}>
           <HajkToolTip title="Rita del-längder av mätningar">
-            <StyledSingleToggleButton
-              value="Segments"
-              selected={segmentsEnabled}
-              onClick={() => handleSegmentsToggle()}
-            >
-              <SvgImg src={IconSegment()} />
-            </StyledSingleToggleButton>
+            <Zoom in={showSegmentButton}>
+              <StyledSingleToggleButton
+                value="Segments"
+                selected={segmentsEnabled}
+                onClick={() => handleSegmentsToggle()}
+              >
+                <SvgImg src={IconSegment()} />
+              </StyledSingleToggleButton>
+            </Zoom>
           </HajkToolTip>
         </Grid>
         <Grid item xs={3}>

--- a/apps/client/src/plugins/Measurer/MeasurerView.js
+++ b/apps/client/src/plugins/Measurer/MeasurerView.js
@@ -11,7 +11,13 @@ import {
   DialogTitle,
 } from "@mui/material";
 
-import { IconPolygon, IconPoint, IconLine, IconCircle } from "./MeasurerIcons";
+import {
+  IconPolygon,
+  IconPoint,
+  IconLine,
+  IconCircle,
+  IconSegment,
+} from "./MeasurerIcons";
 import DeleteIcon from "@mui/icons-material/Delete";
 import TouchAppIcon from "@mui/icons-material/TouchApp";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
@@ -34,6 +40,13 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
     },
     borderBottom: `3px solid ${theme.palette.primary.main}`,
   },
+}));
+
+const StyledSingleToggleButton = styled(StyledToggleButton)(({ theme }) => ({
+  border: "2px solid white",
+  borderColor: theme.palette.divider,
+  marginLeft: "4px",
+  marginRight: "4px",
 }));
 
 const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
@@ -101,7 +114,13 @@ function HelpDialog(props) {
 }
 
 function MeasurerView(props) {
-  const { handleDrawTypeChange, drawType, drawModel } = props;
+  const {
+    handleDrawTypeChange,
+    drawType,
+    drawModel,
+    segmentsEnabled,
+    toggleSegmentsEnabled,
+  } = props;
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
 
@@ -119,10 +138,14 @@ function MeasurerView(props) {
     };
   }, [props.localObserver]);
 
+  const handleSegmentsToggle = () => {
+    toggleSegmentsEnabled(!segmentsEnabled);
+  };
+
   return (
     <>
       <Grid container spacing={1} alignItems="center">
-        <Grid item xs={9}>
+        <Grid item xs={7}>
           <StyledToggleButtonGroup
             exclusive
             value={drawType}
@@ -162,6 +185,17 @@ function MeasurerView(props) {
               </StyledToggleButton>
             </HajkToolTip>
           </StyledToggleButtonGroup>
+        </Grid>
+        <Grid item xs={2}>
+          <HajkToolTip title="Rita del-längder av mätningar">
+            <StyledSingleToggleButton
+              value="Segments"
+              selected={segmentsEnabled}
+              onClick={() => handleSegmentsToggle()}
+            >
+              <SvgImg src={IconSegment()} />
+            </StyledSingleToggleButton>
+          </HajkToolTip>
         </Grid>
         <Grid item xs={3}>
           <HajkToolTip title="Rensa bort alla mätningar">

--- a/apps/client/src/plugins/Measurer/Segment.js
+++ b/apps/client/src/plugins/Measurer/Segment.js
@@ -1,0 +1,289 @@
+import { Style, Text } from "ol/style";
+import { Feature } from "ol";
+import { LineString, Point, Polygon } from "ol/geom";
+
+export default class Segment {
+  #enabled;
+  #drawModel;
+  #currentSegmentLength;
+  #polygonFirstAndLast;
+  #currentCenter;
+  #measureFeature;
+  #map;
+  #currentFeatureSavedId;
+  #currentPoint;
+
+  constructor(drawModel, map, enabled) {
+    this.#enabled = enabled | false;
+    this.#drawModel = drawModel;
+    this.#currentSegmentLength = null;
+    this.#polygonFirstAndLast = [];
+    this.#currentCenter = null;
+    this.#measureFeature = { type: "LineString", numCoordinates: 0 };
+    this.#map = map;
+    this.#currentFeatureSavedId = null;
+    this.#currentPoint = null;
+  }
+
+  setEnabled = (enabled) => {
+    this.#enabled = enabled;
+  };
+
+  setLastPlacedFeatureId = (id) => {
+    // Due to timing we cant assign the points to the feature id before the feature is complete.
+    // We need to save them and update them at a later time to be able to also remove them when
+    // the feature is removed.
+    this.#currentFeatureSavedId = id;
+    // Update the saved points to reference this feature with MEASUREMENT_ID
+    this.#updateMeasurementReferences();
+  };
+
+  // Useful to remove the extra points created by "double clicks" for ending the measurement.
+  #allreadyExists = (coordinate) => {
+    let exists = false;
+    // Get all user drawn measurements that are not parents, ie only the segment points.
+    const allDrawnFeatures = this.#drawModel
+      .getAllDrawnFeatures()
+      .filter(
+        (f) => f.get("USER_DRAWN") === true && !f.get("MEASUREMENT_PARENT")
+      );
+    // If we find a point with the same coordinate as the one we are checking, return true.
+    allDrawnFeatures.forEach((f) => {
+      if (
+        JSON.stringify(f.getGeometry().getCoordinates()) ===
+        JSON.stringify(coordinate)
+      ) {
+        exists = true;
+      }
+    });
+    return exists;
+  };
+
+  #formatLength = (line) => {
+    const length = line.getLength();
+    let output;
+    if (length > 1000) {
+      // Convert and format the length to 1 decimal rounded up if longer than 1 km
+      output = Math.round((length / 1000) * 10) / 10 + " km";
+    } else {
+      // Otherwise show meters with 1 decimal
+      output = Math.round(length * 100) / 100 + " m";
+    }
+    return output;
+  };
+
+  #updateMeasurementReferences = () => {
+    // Update the source features
+    const allDrawnFeatures = this.#drawModel
+      .getAllDrawnFeatures()
+      .filter((f) => f.get("USER_DRAWN") === true);
+    allDrawnFeatures.forEach((f) => {
+      if (f.getGeometry().getType() === "Point") {
+        const featureWithMeasurementId = f.get("MEASUREMENT_ID");
+        // Check that the feature has the correct attribute, and that it allready belongs to another feature.
+        if (
+          featureWithMeasurementId &&
+          !featureWithMeasurementId.includes("-")
+        ) {
+          const childID = f.get("MEASUREMENT_ID");
+          // We prefix these segment points with the measured objects MEASUREMENT_ID, and check that it's not a parent.
+          if (
+            childID !== this.#currentFeatureSavedId &&
+            !f.get("MEASUREMENT_PARENT")
+          ) {
+            f.set(
+              "MEASUREMENT_ID",
+              this.#currentFeatureSavedId + "-" + childID
+            );
+          }
+        }
+      }
+    });
+  };
+
+  #applyTextStyle = (length) => {
+    // Setting font to italic, underline styling not possible with RichText
+    return [`${length}`, "italic 11px Roboto, Helvetica, Arial, sans-serif"];
+  };
+
+  #createPoint = () => {
+    // Dont create point if the currentCenter is not set
+    if (this.#currentCenter !== null) {
+      // Check if this coordinate allready has a measurement, the
+      if (!this.#allreadyExists(this.#currentCenter)) {
+        const segmentPoint = new Point(this.#currentCenter);
+        const id = Math.random().toString(36).substring(2, 15);
+        const f = new Feature({
+          geometry: segmentPoint,
+        });
+        // Generate a random ID for the feature
+        f.setId(id);
+        // Create the style and set the features parameters
+        const segmentPointStyle = new Style({
+          // Indicate that we are using text.
+          text: new Text(),
+          zIndex: 5000,
+        });
+        f.setStyle(segmentPointStyle);
+        f.set("EXTRACTED_STYLE", this.#drawModel.extractFeatureStyleInfo(f));
+        f.set("DRAW_METHOD", "Text");
+        f.set("USER_DRAWN", true);
+        f.set("MEASUREMENT_ID", id);
+        // Assign the measured and formatted length of the segment
+        f.set("USER_TEXT", this.#applyTextStyle(this.#currentSegmentLength));
+        f.set("TEXT_SETTINGS", {
+          backgroundColor: "#000000",
+          foregroundColor: "#FFFFFF",
+          // size: 10,
+        });
+
+        this.#currentPoint = f.clone();
+        // Draw the point
+        this.#drawModel.addFeature(f);
+      }
+    }
+  };
+
+  #handleSingleClick = (e) => {
+    // Dont place a point until we have more than 2 coordinates in the LineString measurement.
+    // Or 3 coordinates if we measure a Polygon.
+    if (
+      (this.#measureFeature.type === "LineString" &&
+        this.#measureFeature.numCoordinates > 2) ||
+      (this.#measureFeature.type === "Polygon" &&
+        this.#measureFeature.numCoordinates > 3)
+    ) {
+      this.#createPoint();
+    }
+  };
+
+  handleDrawStartEvent = (e) => {
+    // Do nothing if segments is not enabled
+    if (!this.#enabled) {
+      return;
+    }
+
+    const feature = e.feature;
+    const geometry = feature.getGeometry();
+    // We only handle LineString and Polygon
+    if (!(geometry instanceof LineString || geometry instanceof Polygon)) {
+      return;
+    }
+
+    this.#map.getViewport().addEventListener("click", this.#handleSingleClick);
+    // Forward the change event
+    feature.on("change", this.#handleFeatureChange);
+  };
+
+  handleDrawEndEvent = (e) => {
+    const feature = e.feature;
+    const geometry = feature.getGeometry();
+    const type = geometry.getType();
+    // When measuring a Polygon we need to measure the last segment that we saved
+    if (type === "Polygon") {
+      if (
+        this.#measureFeature.type === "Polygon" &&
+        this.#measureFeature.numCoordinates > 1
+      ) {
+        this.#findCenterPoint(this.#polygonFirstAndLast, Polygon);
+        // Check that we found a centerpoint for the last segment in the polygon.
+        // Also handle the case if you start measuring a polygon and hit esc, resulting
+        // in a 0 measurement length.
+        if (
+          this.#currentCenter.length > 0 &&
+          this.#currentSegmentLength !== "0 m"
+        ) {
+          this.#createPoint();
+        }
+      }
+    }
+    // If we measured a LineString and only have one segment, remove that measurement point,
+    // the total tooltip from DrawModel would overlap otherwise and shows the same length anyway.
+    // Also dont run the remove if there is only 1 coord.
+    if (
+      this.#enabled &&
+      type === "LineString" &&
+      geometry.getCoordinates().length <= 2
+    ) {
+      // The geometry should have more than one coordinate to be removed, otherwise it probably wasnt added.
+      // In the case of LineString and Polygon.
+      if (geometry.getCoordinates().length > 1) {
+        // Remove the segment point.
+        this.#drawModel.removeFeature(this.#currentPoint);
+      }
+    }
+
+    // Cleanup and reset
+    this.#currentCenter = null;
+    this.#currentSegmentLength = null;
+    this.#polygonFirstAndLast = [];
+    this.#currentFeatureSavedId = null;
+    this.#measureFeature = {
+      type: this.#measureFeature.type,
+      numCoordinates: 0,
+    };
+    this.#currentPoint = null;
+    // Remove the click listener
+    this.#map
+      .getViewport()
+      .removeEventListener("click", this.#handleSingleClick);
+  };
+
+  #findCenterPoint = (coords, type) => {
+    let measurementLineString;
+    if (type === LineString) {
+      // Remove the last element in the coordinates array since we only are
+      // interested in the last drawn segment
+      coords.pop();
+      if (coords.length >= 2) {
+        measurementLineString = new LineString([
+          coords[coords.length - 1],
+          coords[coords.length - 2],
+        ]);
+        this.#currentSegmentLength = this.#formatLength(measurementLineString);
+        this.#currentCenter = measurementLineString.getCoordinateAt(0.5);
+      }
+    } else if (type === Polygon) {
+      if (coords.length > 3) {
+        measurementLineString = new LineString([
+          coords[coords.length - 3],
+          coords[coords.length - 4],
+        ]);
+        this.#currentSegmentLength = this.#formatLength(measurementLineString);
+      } else {
+        measurementLineString = new LineString([
+          coords[coords.length - 1],
+          coords[coords.length - 2],
+        ]);
+        this.#currentSegmentLength = this.#formatLength(measurementLineString);
+      }
+      this.#currentCenter = measurementLineString.getCoordinateAt(0.5);
+    }
+  };
+
+  #handleFeatureChange = (e) => {
+    const feature = e.target;
+    const geometry = feature.getGeometry();
+    let allCoordinates;
+    if (geometry instanceof LineString) {
+      allCoordinates = geometry.getCoordinates();
+      this.#measureFeature = {
+        type: "LineString",
+        numCoordinates: allCoordinates.length,
+      };
+      this.#findCenterPoint(allCoordinates, LineString);
+    } else if (geometry instanceof Polygon) {
+      allCoordinates = geometry.getCoordinates()[0];
+      this.#measureFeature = {
+        type: "Polygon",
+        numCoordinates: allCoordinates.length,
+      };
+      // Store the last point to use when the drawEnd is triggered
+      this.#polygonFirstAndLast = [
+        allCoordinates[allCoordinates.length - 1],
+        allCoordinates[allCoordinates.length - 2],
+      ];
+      this.#findCenterPoint(allCoordinates, Polygon);
+    }
+  };
+}

--- a/apps/client/src/plugins/Measurer/Segment.js
+++ b/apps/client/src/plugins/Measurer/Segment.js
@@ -14,7 +14,7 @@ export default class Segment {
   #currentPoint;
 
   constructor(drawModel, map, enabled) {
-    this.#enabled = enabled | false;
+    this.#enabled = enabled ?? false;
     this.#drawModel = drawModel;
     this.#currentSegmentLength = null;
     this.#polygonFirstAndLast = [];


### PR DESCRIPTION
Added segment-measurements of linestrings and polygons to the measurer plugin, and extended some geometry removal functionality in DrawModel.

Should maybe have a admin-option to enable disable segment measurements all together, and hide the button.

![image](https://github.com/user-attachments/assets/0fc6855c-4ff2-4f1b-afb6-421b676b8ea9)

![image](https://github.com/user-attachments/assets/6be1bc22-a6fc-41b9-af1c-63bc1be72847)
