### PR TITLE
PR Feature/1570-layercomparerselection

### DIFF
--- a/apps/admin/src/views/components/LayerComparerLayerList.jsx
+++ b/apps/admin/src/views/components/LayerComparerLayerList.jsx
@@ -130,7 +130,7 @@ class LayerComparerLayerList extends React.Component {
             Sortera {sortAsc ? "A-Ö" : "Ö-A"}
           </button>
           <button type="button" onClick={this.selectAllLayers}>
-            Välj alla
+            Välj alla / rensa alla
           </button>
         </div>
 
@@ -145,7 +145,7 @@ class LayerComparerLayerList extends React.Component {
                     checked={isChecked}
                     onChange={() => this.handleLayerToggle(layer)}
                   />{" "}
-                  {layer.caption || layer.name || layer.id}
+                  {layer.caption || layer.id}
                 </li>
               );
             })}

--- a/apps/admin/src/views/components/LayerComparerLayerList.jsx
+++ b/apps/admin/src/views/components/LayerComparerLayerList.jsx
@@ -49,13 +49,13 @@ class LayerComparerLayerList extends React.Component {
 
     const filteredLayers = allLayers
       .filter((layer) =>
-        (layer.caption || layer.name || layer.id || "")
+        (layer.caption || layer.id || "")
           .toLowerCase()
           .includes(filterText.toLowerCase())
       )
       .sort((a, b) => {
-        const aVal = (a.caption || a.name || a.id || "").toLowerCase();
-        const bVal = (b.caption || b.name || b.id || "").toLowerCase();
+        const aVal = (a.caption || a.id || "").toLowerCase();
+        const bVal = (b.caption || b.id || "").toLowerCase();
         if (aVal < bVal) return sortAsc ? -1 : 1;
         if (aVal > bVal) return sortAsc ? 1 : -1;
         return 0;

--- a/apps/admin/src/views/components/LayerComparerLayerList.jsx
+++ b/apps/admin/src/views/components/LayerComparerLayerList.jsx
@@ -123,12 +123,15 @@ class LayerComparerLayerList extends React.Component {
             style={{ marginRight: "10px", width: "80%" }}
           />
           <button
+            type="button"
             onClick={this.handleSortToggle}
             style={{ marginRight: "10px" }}
           >
             Sortera {sortAsc ? "A-Ö" : "Ö-A"}
           </button>
-          <button onClick={this.selectAllLayers}>Välj alla</button>
+          <button type="button" onClick={this.selectAllLayers}>
+            Välj alla
+          </button>
         </div>
 
         <div style={listContainerStyle}>

--- a/apps/admin/src/views/components/LayerComparerLayerList.jsx
+++ b/apps/admin/src/views/components/LayerComparerLayerList.jsx
@@ -1,0 +1,156 @@
+import React from "react";
+
+class LayerComparerLayerList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      filterText: "",
+      sortAsc: true,
+      chosenLayers: this.props.chosenLayers || [],
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.chosenLayers !== this.props.chosenLayers) {
+      this.setState({ chosenLayers: this.props.chosenLayers });
+    }
+  }
+
+  handleFilterChange = (e) => {
+    this.setState({ filterText: e.target.value });
+  };
+
+  handleSortToggle = () => {
+    this.setState((prevState) => ({ sortAsc: !prevState.sortAsc }));
+  };
+
+  handleLayerToggle = (layer) => {
+    this.setState((prevState) => {
+      const { chosenLayers } = prevState;
+      const exists = chosenLayers.some((l) => l.id === layer.id);
+      let updated;
+      if (exists) {
+        updated = chosenLayers.filter((l) => l.id !== layer.id);
+      } else {
+        updated = [...chosenLayers, layer];
+      }
+
+      if (this.props.onChosenLayersChange) {
+        this.props.onChosenLayersChange(updated);
+      }
+
+      return { chosenLayers: updated };
+    });
+  };
+
+  getFilteredAndSortedLayers() {
+    const { allLayers = [] } = this.props;
+    const { filterText, sortAsc } = this.state;
+
+    const filteredLayers = allLayers
+      .filter((layer) =>
+        (layer.caption || layer.name || layer.id || "")
+          .toLowerCase()
+          .includes(filterText.toLowerCase())
+      )
+      .sort((a, b) => {
+        const aVal = (a.caption || a.name || a.id || "").toLowerCase();
+        const bVal = (b.caption || b.name || b.id || "").toLowerCase();
+        if (aVal < bVal) return sortAsc ? -1 : 1;
+        if (aVal > bVal) return sortAsc ? 1 : -1;
+        return 0;
+      });
+
+    return filteredLayers;
+  }
+
+  selectAllLayers = () => {
+    const filteredLayers = this.getFilteredAndSortedLayers();
+    const { chosenLayers } = this.state;
+
+    const allSelected =
+      filteredLayers.length > 0 &&
+      filteredLayers.every((layer) =>
+        chosenLayers.some((chosen) => chosen.id === layer.id)
+      );
+
+    let updated;
+    if (allSelected) {
+      updated = chosenLayers.filter(
+        (chosen) => !filteredLayers.some((fLayer) => fLayer.id === chosen.id)
+      );
+    } else {
+      const missing = filteredLayers.filter(
+        (l) => !chosenLayers.some((chosen) => chosen.id === l.id)
+      );
+      updated = [...chosenLayers, ...missing];
+    }
+
+    this.setState({ chosenLayers: updated });
+    if (this.props.onChosenLayersChange) {
+      this.props.onChosenLayersChange(updated);
+    }
+  };
+
+  render() {
+    const { chosenLayers, filterText, sortAsc } = this.state;
+    const filteredLayers = this.getFilteredAndSortedLayers();
+
+    const containerStyle = {
+      maxWidth: "600px",
+      border: "1px solid #ccc",
+      padding: "10px",
+      textAlign: "left",
+    };
+
+    const listContainerStyle = {
+      maxHeight: "200px",
+      overflowY: "auto",
+      border: "1px solid #ddd",
+      padding: "5px",
+      marginTop: "10px",
+    };
+
+    return (
+      <div style={containerStyle}>
+        <h3>Lager</h3>
+        <div style={{ marginBottom: "10px" }}>
+          <input
+            type="text"
+            placeholder="Filtrera"
+            value={filterText}
+            onChange={this.handleFilterChange}
+            style={{ marginRight: "10px", width: "80%" }}
+          />
+          <button
+            onClick={this.handleSortToggle}
+            style={{ marginRight: "10px" }}
+          >
+            Sortera {sortAsc ? "A-Ö" : "Ö-A"}
+          </button>
+          <button onClick={this.selectAllLayers}>Välj alla</button>
+        </div>
+
+        <div style={listContainerStyle}>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {filteredLayers.map((layer) => {
+              const isChecked = chosenLayers.some((l) => l.id === layer.id);
+              return (
+                <li key={layer.id} style={{ marginBottom: "5px" }}>
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => this.handleLayerToggle(layer)}
+                  />{" "}
+                  {layer.caption || layer.name || layer.id}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default LayerComparerLayerList;

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -120,25 +120,22 @@ class LayerComparer extends Component {
 
     const allLayers = this.props.model.get("layers");
 
-    const comparedLayers = layerSwitcherLayers.map((lsLayer) => {
-      const realLayer = allLayers.find((al) => al.id === lsLayer.id);
+    const comparedLayers = layerSwitcherLayers
+      .map((lsLayer) => {
+        const realLayer = allLayers.find((al) => al.id === lsLayer.id);
 
-      if (realLayer) {
-        return {
-          id: realLayer.id,
-          caption: realLayer.caption || "Okänt lager",
-          layerType: realLayer.type || "unknown",
-          visibleAtStart: lsLayer.visibleAtStart,
-        };
-      } else {
-        return {
-          id: lsLayer.id,
-          caption: "Inaktivt lager",
-          layerType: "unknown",
-          visibleAtStart: lsLayer.visibleAtStart,
-        };
-      }
-    });
+        if (realLayer) {
+          return {
+            id: realLayer.id,
+            caption: realLayer.caption || "Okänt lager",
+            layerType: realLayer.type || "unknown",
+            visibleAtStart: lsLayer.visibleAtStart,
+          };
+        } else {
+          return null;
+        }
+      })
+      .filter((layer) => layer !== null);
 
     this.setState({ layers: comparedLayers });
   }

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -121,19 +121,14 @@ class LayerComparer extends Component {
     const allLayers = this.props.model.get("layers");
 
     const comparedLayers = layerSwitcherLayers
+      .filter((lsLayer) => allLayers.some((al) => al.id === lsLayer.id))
       .map((lsLayer) => {
         const realLayer = allLayers.find((al) => al.id === lsLayer.id);
-
-        if (realLayer) {
-          return {
-            id: realLayer.id,
-            caption: realLayer.caption || "Okänt lager",
-          };
-        } else {
-          return null;
-        }
-      })
-      .filter((layer) => layer !== null);
+        return {
+          id: realLayer.id,
+          caption: realLayer.caption || "Okänt lager",
+        };
+      });
 
     this.setState({ layers: comparedLayers });
   }

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -367,7 +367,6 @@ class LayerComparer extends Component {
             </label>
           </div>
           <div>
-            <label>Välj lager</label>
             {this.state.selectChosenLayers && (
               <LayerComparerLayerList
                 allLayers={allLayers}

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -128,8 +128,6 @@ class LayerComparer extends Component {
           return {
             id: realLayer.id,
             caption: realLayer.caption || "Okänt lager",
-            layerType: realLayer.type || "unknown",
-            visibleAtStart: lsLayer.visibleAtStart,
           };
         } else {
           return null;

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -80,6 +80,14 @@ class LayerComparer extends Component {
     }
   };
 
+  /* Extracts all layers from the provided options, including both grouped layers and baselayers.
+ Initializes an empty array to store the collected layers.
+ Defines a helper function to recursively collect layers from each group.
+ If a group contains layers, those layers are added to the layers array.
+ If a group contains subgroups, the helper function is called recursively for each subgroup.
+ Iterates over each group in options.groups and collects their layers using the helper function.
+ Adds all baselayers from options.baselayers to the layers array.
+ Returns the complete array of collected layers.*/
   getLayersFromGroupsAndBaselayers(options) {
     const layers = [];
 
@@ -103,24 +111,29 @@ class LayerComparer extends Component {
     return layers;
   }
 
+  /*
+   * Loads layers based on the current map configuration.
+   * 1. Retrieves the layer menu configuration from the model.
+   * 2. Logs an error and exits if the configuration is missing.
+   * 3. Extracts layers from groups and baselayers using a helper method.
+   * 4. Retrieves all available layers from the model.
+   * 5. Filters and maps the extracted layers to match the available layers.
+   * 6. Updates the component's state with the filtered layers.
+   */
   loadLayers() {
-    const toolConfig = this.props.model.get("toolConfig");
-    const layerswitcherTool = toolConfig.find(
-      (tool) => tool.type === "layerswitcher"
-    );
+    const mapConfig = this.props.model.get("layerMenuConfig");
 
-    if (!layerswitcherTool) {
-      console.error("LayerSwitcher not found in toolConfig.");
+    if (!mapConfig) {
+      console.error("Map configuration could not be loaded.");
       return;
     }
 
-    const layerSwitcherLayers = this.getLayersFromGroupsAndBaselayers(
-      layerswitcherTool.options
-    );
+    const layerMenuConfigLayers =
+      this.getLayersFromGroupsAndBaselayers(mapConfig);
 
     const allLayers = this.props.model.get("layers");
 
-    const comparedLayers = layerSwitcherLayers
+    const comparedLayers = layerMenuConfigLayers
       .filter((lsLayer) => allLayers.some((al) => al.id === lsLayer.id))
       .map((lsLayer) => {
         const realLayer = allLayers.find((al) => al.id === lsLayer.id);

--- a/apps/admin/src/views/tools/layercomparer.jsx
+++ b/apps/admin/src/views/tools/layercomparer.jsx
@@ -4,6 +4,7 @@ import Button from "@material-ui/core/Button";
 import SaveIcon from "@material-ui/icons/SaveSharp";
 import { withStyles } from "@material-ui/core/styles";
 import { blue } from "@material-ui/core/colors";
+import LayerComparerLayerList from "../components/LayerComparerLayerList";
 
 const ColorButtonBlue = withStyles((theme) => ({
   root: {
@@ -82,41 +83,6 @@ class LayerComparer extends Component {
         };
       }
     });
-  }
-
-  renderLayersList() {
-    const allLayers = this.props.model.get("layers");
-    const { chosenLayers, selectChosenLayers } = this.state;
-
-    if (!allLayers || !Array.isArray(allLayers)) {
-      return <div>Inga lager tillgängliga.</div>;
-    }
-
-    return (
-      <>
-        <h3>Välj lager:</h3>
-        <ul>
-          {allLayers.map((layer) => {
-            const isChecked = chosenLayers.some(
-              (chosenLayer) => chosenLayer.id === layer.id
-            );
-            return (
-              <li key={layer.id}>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={isChecked}
-                    disabled={!selectChosenLayers}
-                    onChange={() => this.handleLayerToggle(layer)}
-                  />
-                  {layer.caption || layer.name || layer.id}
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-      </>
-    );
   }
 
   /**
@@ -266,6 +232,7 @@ class LayerComparer extends Component {
    *
    */
   render() {
+    const allLayers = this.props.model.get("layers");
     return (
       <div>
         <form>
@@ -350,6 +317,7 @@ class LayerComparer extends Component {
                 this.handleInputChange(e);
               }}
               checked={this.state.showNonBaseLayersInSelect}
+              disabled={this.state.selectChosenLayers}
             />
             &nbsp;
             <label
@@ -389,12 +357,26 @@ class LayerComparer extends Component {
                   this.setState((prevState) => ({
                     selectChosenLayers: checked,
                     chosenLayers: checked ? prevState.chosenLayers : [],
+                    showNonBaseLayersInSelect: checked
+                      ? false
+                      : prevState.showNonBaseLayersInSelect,
                   }));
                 }}
               />
               Aktivera "Välj lager"
             </label>
-            {this.renderLayersList()}
+          </div>
+          <div>
+            <label>Välj lager</label>
+            {this.state.selectChosenLayers && (
+              <LayerComparerLayerList
+                allLayers={allLayers}
+                chosenLayers={this.state.chosenLayers}
+                onChosenLayersChange={(updatedLayers) =>
+                  this.setState({ chosenLayers: updatedLayers })
+                }
+              />
+            )}
           </div>
 
           {this.renderVisibleForGroups()}

--- a/apps/backend/server/apis/v2/services/settings.service.js
+++ b/apps/backend/server/apis/v2/services/settings.service.js
@@ -196,6 +196,24 @@ class SettingsService {
       return group;
     };
 
+    const removeLayerIdFromLayerComparer = (layerComparerOptions) => {
+      // Remove the layerId from the chosenLayers array
+      if (Array.isArray(layerComparerOptions.chosenLayers)) {
+        const initialLength = layerComparerOptions.chosenLayers.length;
+        layerComparerOptions.chosenLayers =
+          layerComparerOptions.chosenLayers.filter(
+            (layer) => layer.id !== layerId
+          );
+
+        // If any layers were removed, mark as modified
+        if (layerComparerOptions.chosenLayers.length !== initialLength) {
+          modified = true;
+        }
+      }
+
+      return layerComparerOptions;
+    };
+
     // Helper function, used to remove references to a layer from Search tool's options
     const removeLayerIdFromSearchSources = (searchSources) => {
       const index = searchSources.findIndex((l) => l === layerId);
@@ -249,6 +267,17 @@ class SettingsService {
       searchOptions.selectedSources = removeLayerIdFromSearchSources(
         searchOptions.selectedSources
       );
+    }
+
+    // LayerComparer processing
+    const layerComparerToolIndex = json.tools.findIndex(
+      (t) => t.type === "layercomparer"
+    );
+    const layerComparerOptions = json.tools[layerComparerToolIndex]?.options;
+
+    if (layerComparerOptions) {
+      json.tools[layerComparerToolIndex].options =
+        removeLayerIdFromLayerComparer(layerComparerOptions);
     }
 
     // If any of the above resulted in modified file, write the changes.

--- a/apps/client/src/plugins/LayerComparer/LayerComparer.js
+++ b/apps/client/src/plugins/LayerComparer/LayerComparer.js
@@ -45,26 +45,19 @@ const LayerComparer = (props) => {
 
     if (props.options.selectChosenLayers) {
       const finalChosenLayers = (props.options.chosenLayers || [])
+        .filter((chosen) =>
+          allLayers.some((al) => al.get("name") === chosen.id)
+        )
         .map((chosen) => {
           const realLayer = allLayers.find(
             (al) => al.get("name") === chosen.id
           );
-
-          if (realLayer) {
-            return {
-              id: realLayer.ol_uid,
-              label: realLayer.get("caption"),
-              layerType: realLayer.get("layerType"),
-            };
-          } else {
-            console.warn(
-              `Ingen matchning för lager med ID "${chosen.id}". Kontrollera om lagret existerar i allLayers.`
-            );
-
-            return null;
-          }
-        })
-        .filter((layer) => layer !== null);
+          return {
+            id: realLayer.ol_uid,
+            label: realLayer.get("caption"),
+            layerType: realLayer.get("layerType"),
+          };
+        });
 
       setChosenLayers(finalChosenLayers);
     } else {

--- a/apps/client/src/plugins/LayerComparer/LayerComparer.js
+++ b/apps/client/src/plugins/LayerComparer/LayerComparer.js
@@ -44,8 +44,8 @@ const LayerComparer = (props) => {
     const allLayers = props.map.getAllLayers();
 
     if (props.options.selectChosenLayers) {
-      const finalChosenLayers = (props.options.chosenLayers || []).map(
-        (chosen) => {
+      const finalChosenLayers = (props.options.chosenLayers || [])
+        .map((chosen) => {
           const realLayer = allLayers.find(
             (al) => al.get("name") === chosen.id
           );
@@ -61,14 +61,10 @@ const LayerComparer = (props) => {
               `Ingen matchning för lager med ID "${chosen.id}". Kontrollera om lagret existerar i allLayers.`
             );
 
-            return {
-              id: chosen.id,
-              label: chosen.caption,
-              layerType: "unknown",
-            };
+            return null;
           }
-        }
-      );
+        })
+        .filter((layer) => layer !== null);
 
       setChosenLayers(finalChosenLayers);
     } else {

--- a/apps/client/src/plugins/LayerComparer/LayerComparer.js
+++ b/apps/client/src/plugins/LayerComparer/LayerComparer.js
@@ -46,13 +46,9 @@ const LayerComparer = (props) => {
     if (props.options.selectChosenLayers) {
       const finalChosenLayers = (props.options.chosenLayers || []).map(
         (chosen) => {
-          let realLayer = allLayers.find((al) => al.ol_uid === chosen.id);
-
-          if (!realLayer && chosen.caption) {
-            realLayer = allLayers.find(
-              (al) => al.get("caption") === chosen.caption
-            );
-          }
+          const realLayer = allLayers.find(
+            (al) => al.get("name") === chosen.id
+          );
 
           if (realLayer) {
             return {
@@ -61,6 +57,10 @@ const LayerComparer = (props) => {
               layerType: realLayer.get("layerType"),
             };
           } else {
+            console.warn(
+              `Ingen matchning för lager med ID "${chosen.id}". Kontrollera om lagret existerar i allLayers.`
+            );
+
             return {
               id: chosen.id,
               label: chosen.caption,

--- a/apps/client/src/plugins/LayerComparer/LayerComparer.js
+++ b/apps/client/src/plugins/LayerComparer/LayerComparer.js
@@ -40,6 +40,20 @@ const LayerComparer = (props) => {
   // By doing it in this useEffect, we do it once and for all,
   // which is a good idea, as such filter/map can be considered
   // an expensive operation.
+  /* useEffect hook to manage layer selection based on component props.
+   * 1. Retrieves all layers from the map.
+   * 2. Checks if selecting chosen layers is enabled.
+   *    a. Filters and maps the chosen layers to match available layers.
+   *    b. Updates the state with the final chosen layers.
+   * 3. If selecting chosen layers is not enabled:
+   *    a. Filters and maps base layers and updates the baseLayers state.
+   *    b. If showing non-base layers in the selection is enabled:
+   *       i. Filters and maps non-base layers and updates the layers state.
+   *    c. Otherwise, clears the layers state.
+   *    d. Clears the chosenLayers state.
+   * 4. The effect runs whenever the map or relevant options change.
+   */
+
   useEffect(() => {
     const allLayers = props.map.getAllLayers();
 

--- a/apps/client/src/plugins/LayerComparer/LayerComparer.js
+++ b/apps/client/src/plugins/LayerComparer/LayerComparer.js
@@ -71,8 +71,6 @@ const LayerComparer = (props) => {
       );
 
       setChosenLayers(finalChosenLayers);
-      setLayers([]);
-      setBaseLayers([]);
     } else {
       const baseLayers = allLayers
         .filter((l) => l.get("layerType") === "base")

--- a/apps/client/src/plugins/LayerComparer/SelectDropdown.js
+++ b/apps/client/src/plugins/LayerComparer/SelectDropdown.js
@@ -43,7 +43,7 @@ const SelectDropdown = (props) => {
 
           {chosenBaseLayers.length > 0 && [
             <ListSubheader key="chosen-base-header">
-              Valda Bakgrundslager
+              Bakgrundslager
             </ListSubheader>,
             ...chosenBaseLayers.map((l, i) => (
               <MenuItem
@@ -57,9 +57,7 @@ const SelectDropdown = (props) => {
           ]}
 
           {chosenRegularLayers.length > 0 && [
-            <ListSubheader key="chosen-layer-header">
-              Valda Lager
-            </ListSubheader>,
+            <ListSubheader key="chosen-layer-header">Lager</ListSubheader>,
             ...chosenRegularLayers.map((l, i) => (
               <MenuItem
                 key={`chosen-layer-${i}`}

--- a/apps/client/src/plugins/LayerComparer/SelectDropdown.js
+++ b/apps/client/src/plugins/LayerComparer/SelectDropdown.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import {
   Box,
   FormControl,
@@ -10,44 +9,93 @@ import {
 } from "@mui/material";
 
 const SelectDropdown = (props) => {
-  const { setter, value, counterValue, baseLayers, layers, label } = props;
+  const {
+    setter,
+    value,
+    counterValue,
+    baseLayers = [],
+    layers = [],
+    chosenLayers = [],
+    label,
+  } = props;
 
   const handleChange = (setter, value) => {
     setter(value);
   };
 
+  const chosenBaseLayers = chosenLayers.filter((l) => l.layerType === "base");
+  const chosenRegularLayers = chosenLayers.filter((l) =>
+    ["layer", "group"].includes(l.layerType)
+  );
+
   return (
     <Box sx={{ minWidth: 120 }}>
       <FormControl fullWidth>
-        <InputLabel id="layer-1-label">{label}</InputLabel>
+        <InputLabel id="layer-select-label">{label}</InputLabel>
         <Select
-          labelId="layer-1-label"
-          id="layer-1-select"
-          label="Lager 1"
+          labelId="layer-select-label"
+          id="layer-select"
+          label={label}
           value={value}
           onChange={(e) => handleChange(setter, e.target.value)}
         >
           <MenuItem value="">Inget lager valt</MenuItem>
-          {baseLayers.length > 0 && layers.length > 0 && (
-            <ListSubheader>Bakgrundslager</ListSubheader>
-          )}
-          {baseLayers.map((l, i) => {
-            return (
-              <MenuItem key={i} value={l.id} disabled={l.id === counterValue}>
+
+          {chosenBaseLayers.length > 0 && [
+            <ListSubheader key="chosen-base-header">
+              Valda Bakgrundslager
+            </ListSubheader>,
+            ...chosenBaseLayers.map((l, i) => (
+              <MenuItem
+                key={`chosen-base-${i}`}
+                value={l.id}
+                disabled={l.id === counterValue}
+              >
                 {l.label}
               </MenuItem>
-            );
-          })}
-          {baseLayers.length > 0 && layers.length > 0 && (
-            <ListSubheader>Lager</ListSubheader>
-          )}
-          {layers.map((l, i) => {
-            return (
-              <MenuItem key={i} value={l.id}>
+            )),
+          ]}
+
+          {chosenRegularLayers.length > 0 && [
+            <ListSubheader key="chosen-layer-header">
+              Valda Lager
+            </ListSubheader>,
+            ...chosenRegularLayers.map((l, i) => (
+              <MenuItem
+                key={`chosen-layer-${i}`}
+                value={l.id}
+                disabled={l.id === counterValue}
+              >
                 {l.label}
               </MenuItem>
-            );
-          })}
+            )),
+          ]}
+
+          {baseLayers.length > 0 && [
+            <ListSubheader key="base-header">Bakgrundslager</ListSubheader>,
+            ...baseLayers.map((l, i) => (
+              <MenuItem
+                key={`base-${i}`}
+                value={l.id}
+                disabled={l.id === counterValue}
+              >
+                {l.label}
+              </MenuItem>
+            )),
+          ]}
+
+          {layers.length > 0 && [
+            <ListSubheader key="layer-header">Lager</ListSubheader>,
+            ...layers.map((l, i) => (
+              <MenuItem
+                key={`layer-${i}`}
+                value={l.id}
+                disabled={l.id === counterValue}
+              >
+                {l.label}
+              </MenuItem>
+            )),
+          ]}
         </Select>
       </FormControl>
     </Box>


### PR DESCRIPTION
This pull request introduces the ability to dynamically select layers for comparison in the LayerComparer component. Key features include:

Layer Selection: Users can now choose specific layers to compare directly in the admin interface.
Dynamic Updates: The component stays in sync with changes to the layerMenuConfig configuration, ensuring the list of layers reflects the current state.
Improved Usability: Added safeguards to handle inactive or missing layers gracefully, reducing potential errors and confusion.

Please review and test the changes to ensure seamless integration with the existing functionality.