### PR TITLE
Fix for "LayerSwitcher: new LayerSwitcher, filtering for layers in a group where some layers match the filter returns erroneus visibility of layers and info."

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -190,7 +190,13 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
     },
     setSubLayerVisibility(layerId, subLayerId, visible) {
       const olLayer = map.getAllLayers().find((l) => l.get("name") === layerId);
-      const currentSubLayers = new Set(olLayer.get("subLayers"));
+
+      let currentSubLayers;
+      if (olLayer.get("visible")) {
+        currentSubLayers = new Set(olLayer.get("subLayers"));
+      } else {
+        currentSubLayers = new Set();
+      }
 
       if (visible) {
         currentSubLayers.add(subLayerId);

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
@@ -112,13 +112,12 @@ function GroupLayer({
       subLayersSection={
         <Collapse in={showSublayers || isSubLayerFilterHit} unmountOnExit>
           <Box sx={{ marginLeft: 3 }}>
-            {subLayersToShow?.map((subLayer, index) => (
+            {subLayersToShow?.map((subLayer) => (
               <SubLayerItem
                 key={subLayer}
                 subLayer={subLayer}
-                subLayerIndex={index}
                 layerId={layerConfig.layerId}
-                layersInfo={layerConfig.layerInfo.layersInfo}
+                layerConfig={layerConfig}
                 toggleable={toggleable}
                 globalObserver={globalObserver}
                 visible={visibleSubLayers.some((s) => s === subLayer)}

--- a/apps/client/src/plugins/LayerSwitcher/components/SubLayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/SubLayerItem.js
@@ -17,16 +17,20 @@ import FormatListBulletedOutlinedIcon from "@mui/icons-material/FormatListBullet
 
 export default function SubLayerItem({
   layerId,
-  layersInfo,
+  layerConfig,
   subLayer,
   toggleable,
   globalObserver,
   visible,
   toggleSubLayer,
-  subLayerIndex,
   zoomVisible,
 }) {
+  const layersInfo = layerConfig.layerInfo.layersInfo;
   const subLayerInfo = layersInfo[subLayer];
+
+  const subLayerIndex = layerConfig.allSubLayers.findIndex(
+    (sl) => sl === subLayer
+  );
 
   // State that toggles legend collapse
   const [legendIsActive, setLegendIsActive] = useState(false);


### PR DESCRIPTION
Bug fixes for #1580 See the issue for details.