### PR TITLE
fix: "new LayerSwitcher, Hajk crashes when Openstreetmap details are shown"

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
@@ -56,6 +56,8 @@ const setSpecialBackground = (id) => {
     SPECIAL_BACKGROUND_COLORS[id];
 };
 
+export const OSM_LAYER_ID = "osm-layer";
+
 const BackgroundSwitcher = ({
   backgroundSwitcherBlack,
   backgroundSwitcherWhite,
@@ -81,7 +83,7 @@ const BackgroundSwitcher = ({
           zIndex: -1,
           layerType: "base",
           rotateMap: "n", // OpenStreetMap should be rotated to North
-          name: "osm-layer",
+          name: OSM_LAYER_ID,
           caption: "OpenStreetMap",
           layerInfo: {
             caption: "OpenStreetMap",


### PR DESCRIPTION
This is a bug fix for #1582 

I'm not happy with this workaround. The OpenStreetMap layer is handled very differently by HAJK, so it needed some special handling for the LayerItemDetails. I would like to refactor the `LayerItemDetails` which would remove the need for this fix.

But it fixes the issue without to much complications.