### PR TITLE
fix: make every tabbable element has focus style

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -26,7 +26,7 @@ const ToggleAllComponent = ({ toggleable, toggleState, clickHandler }) => {
         clickHandler();
       }}
     >
-      <IconButton sx={{ pl: 0 }} disableRipple size="small">
+      <IconButton disableTouchRipple size="small">
         {
           {
             checked: <CheckBoxIcon />,

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroupAccordion.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroupAccordion.js
@@ -19,7 +19,7 @@ export default function LayerGroupAccordion({
   return (
     <div style={{ display: display }}>
       <ListItemButton
-        disableRipple
+        disableTouchRipple
         onClick={() => setState({ expanded: !state.expanded })}
         sx={{
           p: 0,
@@ -29,7 +29,7 @@ export default function LayerGroupAccordion({
         <IconButton
           size="small"
           sx={{ pl: "3px", pr: "4px", py: 0 }}
-          disableRipple
+          disableTouchRipple
         >
           <KeyboardArrowRightOutlinedIcon
             sx={{

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -327,10 +327,7 @@ function LayerItem({
             <ListItemSecondaryAction>
               {renderStatusIcon()}
               {!toggleable && !draggable ? (
-                <IconButton
-                  size="small"
-                  disableTouchRipple
-                >
+                <IconButton size="small" disableTouchRipple>
                   <Tooltip title="Bakgrundskartan ligger låst längst ner i ritordningen">
                     <LockOutlinedIcon />
                   </Tooltip>

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -46,7 +46,7 @@ const getLayerToggleState = (isToggled, isSemiToggled, isVisibleAtZoom) => {
 
 const LayerToggleComponent = ({ toggleState }) => {
   return (
-    <IconButton disableRipple size="small" sx={{ pl: 0 }}>
+    <IconButton disableTouchRipple size="small">
       {
         {
           checked: <CheckBoxIcon />,
@@ -272,7 +272,7 @@ function LayerItem({
       >
         {draggable && (
           <IconButton
-            disableRipple
+            disableTouchRipple
             sx={{
               px: 0,
               opacity: 0,
@@ -287,7 +287,7 @@ function LayerItem({
         )}
         {expandableSection && expandableSection}
         <ListItemButton
-          disableRipple
+          disableTouchRipple
           onClick={toggleable ? handleLayerItemClick : null}
           sx={{
             p: 0,
@@ -330,8 +330,6 @@ function LayerItem({
                 <IconButton
                   size="small"
                   disableTouchRipple
-                  disableFocusRipple
-                  disableRipple
                 >
                   <Tooltip title="Bakgrundskartan ligger låst längst ner i ritordningen">
                     <LockOutlinedIcon />

--- a/apps/client/src/plugins/LayerSwitcher/components/SubLayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/SubLayerItem.js
@@ -93,7 +93,7 @@ export default function SubLayerItem({
   return (
     <div style={{ marginLeft: "32px" }}>
       <ListItemButton
-        disableRipple
+        disableTouchRipple
         onClick={() => (toggleable ? toggleSubLayer(subLayer, visible) : null)}
         sx={{
           pl: 0,
@@ -106,7 +106,7 @@ export default function SubLayerItem({
       >
         {toggleable && (
           <IconButton
-            disableRipple
+            disableTouchRipple
             size="small"
             sx={{
               pl: 0,


### PR DESCRIPTION
Aid keyboard navigation in the Layer Switcher.

Previous changes removed some focus style for active elements in the Layer Switcher. This PR adds those back so it's possible to operate the LayerSwitcher with the tab-key. (although slow)