### PR TITLE
Persist QuickAccess layers in LocalStorage

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -162,6 +162,8 @@ const getGroupConfigById = (tree, groupId) => {
   }
 };
 
+const QUICK_ACCESS_KEY = "quickAccess";
+
 const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
   const olBackgroundLayers = map
     .getLayers()
@@ -240,7 +242,8 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
       layer.setVisible(visible);
     },
     setLayerQuickAccess(layerId, partOfQuickAccess) {
-      // set all other background layers to not visible
+      const layer = map.getAllLayers().find((l) => l.get("name") === layerId);
+      layer.set(QUICK_ACCESS_KEY, partOfQuickAccess);
     },
     addVisibleLayersToQuickAccess() {
       const visibleLayers = map
@@ -251,11 +254,9 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
             l.get("layerType") !== "base" &&
             l.get("layerType") !== "system"
         );
-      const QUICK_ACCESS_KEY = "quickAccess";
       visibleLayers.forEach((l) => l.set(QUICK_ACCESS_KEY, true));
     },
     clearQuickAccess() {
-      const QUICK_ACCESS_KEY = "quickAccess";
       map
         .getAllLayers()
         .filter(

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
@@ -4,6 +4,7 @@ import { useSnackbar } from "notistack";
 import LayerItemOptions from "./LayerItemOptions";
 import VectorFilter from "./VectorFilter";
 import CQLFilter from "./CQLFilter";
+import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
 
 import {
   Button,
@@ -46,6 +47,8 @@ function LayerItemDetails({
   // When a user clicks back, the tooltip of the button needs to be closed before this view hides.
   // TODO: Needs a better way to handle this
   const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  const layerSwitcherDispatch = useLayerSwitcherDispatch();
 
   const layerSwitcherConfig = app.config.mapConfig.tools.find(
     (tool) => tool.type === "layerswitcher"
@@ -158,11 +161,10 @@ function LayerItemDetails({
       anchorOrigin: { vertical: "bottom", horizontal: "center" },
     });
     setQuickAccess(!quickAccess);
+
     // Set quicklayer access flag
-    layerItemDetails.layer.set(
-      "quickAccess",
-      !layerItemDetails.layer.get("quickAccess")
-    );
+    const layerId = layerItemDetails?.layer?.get("name");
+    layerSwitcherDispatch.setLayerQuickAccess(layerId, !quickAccess);
   };
 
   // Render title


### PR DESCRIPTION
Adds the feature to persist/save QuickAccess layers in LocalStorage. If the user has enabled functional cookies.

This feature has no config option and is active whenever the QuickAccess is enabled.
It does not save any layer visibilities in localStorage so the layers in QuickAccess may change state after a reload.