### PR TITLE
fix: Consistent Draw Order of Sublayers

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -107,7 +107,6 @@ const setOLSubLayers = (olLayer, visibleSubLayersArray) => {
     // Hide the layer in OL
     olLayer.setVisible(false);
   } else {
-    olLayer.setVisible(true);
     // Set LAYERS and STYLES so that the exact sublayers that are needed
     // will be visible
     olLayer.getSource().updateParams({
@@ -122,6 +121,7 @@ const setOLSubLayers = (olLayer, visibleSubLayersArray) => {
         .join(","),
       CQL_FILTER: null,
     });
+    olLayer.setVisible(true);
   }
 };
 
@@ -220,9 +220,15 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
         currentSubLayers.delete(subLayerId);
       }
 
-      const currentSubLayersArray = Array.from(currentSubLayers);
-      olLayer.set("subLayers", currentSubLayersArray);
-      setOLSubLayers(olLayer, currentSubLayersArray);
+      const currentSubLayersSet = new Set(currentSubLayers);
+      // Sort the sublayers in the order they are defined. So that the order is
+      // consistent regardless of the order the sublayers are toggled in.
+      const allSubLayers = staticLayerConfig[layerId]?.allSubLayers;
+      const sortedCurrentSubLayers = allSubLayers.filter((l) =>
+        currentSubLayersSet.has(l)
+      );
+      olLayer.set("subLayers", sortedCurrentSubLayers);
+      setOLSubLayers(olLayer, sortedCurrentSubLayers);
     },
     setGroupVisibility(groupId, visible) {
       const groupTree = getGroupConfigById(staticLayerTree, groupId);


### PR DESCRIPTION
A bug fix for a bug found by Stadsbyggnadsförvaltningen in Göteborg.

I previous versions the draw order of sublayers was in the order they were activated. The last activated sublayer was always drawn on top. The PR fixes that so that the sublayers are always drawn in their defined order, regardless of activation.