### PR TITLE
Fix: Handle missing layer config in LayerSwitcher

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -307,6 +307,17 @@ const getLayerNodes = (groups, olLayerMap) =>
 
     const olLayer = olLayerMap[node.id];
 
+    // If we're looking at a "normal layer" (not a group) and the OpenLayers
+    // object is missing that means that the layer configured in the
+    // LayerSwitcher options but is missing or misconfigured in the
+    // `layersConfig`. In that case we should ignore the layer and don't show
+    // it in the LayerSwitcher
+    if (!isGroup && olLayer === undefined) {
+      // A non group layer should not have any children so it's okay to return
+      // the empty array here.
+      return [];
+    }
+
     const isGroupLayer = olLayer?.get("layerType") === "group";
 
     let layerType = node.layerType;
@@ -321,9 +332,9 @@ const getLayerNodes = (groups, olLayerMap) =>
       {
         id: node.id,
         layerId: node.id,
-        caption: olLayerMap[node.id]?.get("caption") ?? node.name,
-        layerCaption: olLayerMap[node.id]?.get("caption") ?? node.name,
-        allSubLayers: olLayerMap[node.id]?.get("subLayers"),
+        caption: olLayer?.get("caption") ?? node.name,
+        layerCaption: olLayer?.get("caption") ?? node.name,
+        allSubLayers: olLayer?.get("subLayers"),
         initiallyExpanded: node.expanded,
         initiallyToggled: node.toggled,
         initialDrawOrder: node.drawOrder,

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -302,8 +302,7 @@ const getLayerNodes = (groups, olLayerMap) =>
 
     const children = [...(layers ?? []), ...(subgroups ?? [])];
 
-    // A group should have both defined
-    const isGroup = !!(node.groups && node.layers);
+    const isGroup = !!(node.groups || node.layers);
 
     const olLayer = olLayerMap[node.id];
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -156,19 +156,19 @@ const LayerGroup = ({
   const groupId = staticGroupTree.id;
   const groupConfig = staticLayerConfig[groupId];
 
-  const groupName = groupConfig.caption;
-  const name = groupConfig.caption;
+  const groupName = groupConfig?.caption;
+  const name = groupConfig?.caption;
 
-  const groupIsFiltered = groupConfig.isFiltered;
+  const groupIsFiltered = groupConfig?.isFiltered;
   const groupIsExpanded = staticGroupTree.defaultExpanded;
   const groupIsToggable = staticGroupTree.groupIsToggable;
 
-  const infogrouptitle = groupConfig.infogrouptitle;
-  const infogrouptext = groupConfig.infogrouptext;
-  const infogroupurl = groupConfig.infogroupurl;
-  const infogroupurltext = groupConfig.infogroupurltext;
-  const infogroupopendatalink = groupConfig.infogroupopendatalink;
-  const infogroupowner = groupConfig.infogroupowner;
+  const infogrouptitle = groupConfig?.infogrouptitle;
+  const infogrouptext = groupConfig?.infogrouptext;
+  const infogroupurl = groupConfig?.infogroupurl;
+  const infogroupurltext = groupConfig?.infogroupurltext;
+  const infogroupopendatalink = groupConfig?.infogroupopendatalink;
+  const infogroupowner = groupConfig?.infogroupowner;
 
   const [infoVisible, setInfoVisible] = useState(false);
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -127,7 +127,7 @@ function LayerItem({
   const theme = useTheme();
   const mapZoom = useMapZoom();
 
-  const { layerIsToggled } = layerState;
+  const { layerIsToggled } = layerState ?? {};
 
   const {
     layerId,
@@ -140,7 +140,7 @@ function LayerItem({
     allSubLayers,
     layerInfo,
     layerLegendIcon,
-  } = layerConfig;
+  } = layerConfig ?? {};
 
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
 
@@ -349,7 +349,7 @@ function LayerItem({
       {layerShouldShowLegendIcon(layerType, layerIsFakeMapLayer) ? null : (
         <LegendImage
           comment="TODO Fix the mess below"
-          src={Array.isArray(layerInfo.legend) && layerInfo.legend[0]?.url}
+          src={Array.isArray(layerInfo?.legend) && layerInfo?.legend[0]?.url}
           open={legendIsActive}
         ></LegendImage>
       )}


### PR DESCRIPTION
@jacobwod found a bug in the LayerSwitcher to other day.

If a layer is configured in the layer switcher settings, but is missing or misconfigured in the `layersConfig` the LayerSwitcher crashed.

The desired behavior is that we ignore any layer that is missing from the layers config. This PR adds that check to the LayerSwitcher initialization. And also makes the `LayerItem` component a bit more robust agains missing data.