### PR TITLE
Fix: Disable LayerItemDetails for system layers in DrawOrder tab

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/CQLFilter.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/CQLFilter.js
@@ -13,10 +13,10 @@ const CQLFilter = ({ layer }) => {
   const [cqlFilter, setCqlFilter] = useState("");
 
   useEffect(() => {
-    const source = layer.getSource();
+    const source = layer?.getSource();
     const currentCqlFilterValue =
-      (typeof source.getParams === "function" &&
-        source.getParams()?.CQL_FILTER) ||
+      (typeof source?.getParams === "function" &&
+        source?.getParams()?.CQL_FILTER) ||
       "";
     setCqlFilter(currentCqlFilterValue);
   }, [layer]);
@@ -24,7 +24,7 @@ const CQLFilter = ({ layer }) => {
   const updateFilter = () => {
     let filter = cqlFilter.trim();
     if (filter.length === 0) filter = undefined; // If length === 0, unset filter.
-    layer.getSource().updateParams({ CQL_FILTER: filter });
+    layer?.getSource().updateParams({ CQL_FILTER: filter });
   };
 
   return (

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -333,7 +333,7 @@ function LayerItem({
                   </Tooltip>
                 </IconButton>
               ) : null}
-              {layerIsFakeMapLayer !== true && (
+              {layerIsFakeMapLayer !== true && layerType !== "system" && (
                 <IconButton size="small" onClick={(e) => showLayerDetails(e)}>
                   <KeyboardArrowRightOutlinedIcon
                     sx={{

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
@@ -63,7 +63,7 @@ function LayerItemDetails({
 
   // TODO Is this correct? Should it not be shown for group layers?
   const showLegend =
-    layerItemDetails?.layer.get("layerType") === "group" &&
+    layerItemDetails?.layer?.get("layerType") === "group" &&
     subLayerIndex === null
       ? false
       : true;
@@ -88,14 +88,14 @@ function LayerItemDetails({
     if (layerItemDetails?.layer) {
       // Register a listener: when layer's opacity changes make sure
       // to update opacity state. Not applicable for fakeMapLayers
-      if (!layerItemDetails.layer.isFakeMapLayer) {
-        setOpacity(layerItemDetails.layer.get("opacity"));
-        setQuickAccess(layerItemDetails.layer.get("quickAccess"));
-        layerItemDetails.layer.on("change:opacity", setOpacityCallback);
+      if (!layerItemDetails?.layer?.isFakeMapLayer) {
+        setOpacity(layerItemDetails?.layer?.get("opacity"));
+        setQuickAccess(layerItemDetails?.layer?.get("quickAccess"));
+        layerItemDetails?.layer?.on("change:opacity", setOpacityCallback);
       }
     }
     return function () {
-      layerItemDetails?.layer.un("change:opacity", setOpacityCallback);
+      layerItemDetails?.layer?.un("change:opacity", setOpacityCallback);
     };
   }, [layerItemDetails]);
 
@@ -126,16 +126,16 @@ function LayerItemDetails({
   // Checks if layer is enabled for options
   const hasListItemOptions = () => {
     return (
-      layerItemDetails.layer.get("layerType") !== "system" &&
-      layerItemDetails.layer.isFakeMapLayer !== true
+      layerItemDetails?.layer?.get("layerType") !== "system" &&
+      layerItemDetails?.layer?.isFakeMapLayer !== true
     );
   };
 
   // Check that layer is elligible for quickAccess option
   const isQuickAccessEnabled = () => {
     return (
-      layerItemDetails.layer.get("layerType") !== "base" &&
-      layerItemDetails.layer.get("layerType") !== "system" && // Exclude system layers
+      layerItemDetails?.layer?.get("layerType") !== "base" &&
+      layerItemDetails?.layer?.get("layerType") !== "system" && // Exclude system layers
       subLayerIndex === null &&
       showQuickAccess
     );
@@ -144,7 +144,7 @@ function LayerItemDetails({
   // Add a check for CQL filter visibility and exclude system layers
   const isCqlFilterEnabled = () => {
     return (
-      cqlFilterVisible && layerItemDetails.layer.get("layerType") !== "system" // Exclude system layers
+      cqlFilterVisible && layerItemDetails?.layer?.get("layerType") !== "system" // Exclude system layers
     );
   };
 
@@ -174,7 +174,7 @@ function LayerItemDetails({
         layerItemDetails.layer.subLayers[subLayerIndex]
       ].caption;
     } else {
-      return layerItemDetails.layer.get("caption");
+      return layerItemDetails?.layer?.get("caption");
     }
   };
 
@@ -332,7 +332,7 @@ function LayerItemDetails({
                 <CQLFilter layer={layerItemDetails.layer} />
               </Box>
             )}
-            {layerItemDetails.layer.getProperties().filterable && (
+            {layerItemDetails?.layer?.getProperties().filterable && (
               <>
                 <Divider />
                 <Stack direction="row" alignItems="center">

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemInfo.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemInfo.js
@@ -5,18 +5,18 @@ import { Box, Button, List, Typography } from "@mui/material";
 import CallMadeIcon from "@mui/icons-material/CallMade";
 
 export default function LayerItemInfo({ layer, app, chapters }) {
-  const layerInfo = layer.get("layerInfo") || {};
+  const layerInfo = layer?.get("layerInfo") || {};
 
   const hasInfo = () => {
-    const chaptersWithLayer = findChapters(layer.get("name"), chapters);
+    const chaptersWithLayer = findChapters(layer?.get("name"), chapters);
     return (
-      layerInfo.infoCaption ||
+      layerInfo?.infoCaption ||
       "" ||
-      layerInfo.infoUrl ||
+      layerInfo?.infoUrl ||
       "" ||
-      layerInfo.infoOwner ||
+      layerInfo?.infoOwner ||
       "" ||
-      layerInfo.infoText ||
+      layerInfo?.infoText ||
       "" ||
       chaptersWithLayer.length > 0
     );

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemOptions.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemOptions.js
@@ -25,7 +25,7 @@ export default function LayerItemOptions({
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const optionsMenuIsOpen = Boolean(anchorEl);
-  const layerInfo = layer.get("layerInfo");
+  const layerInfo = layer?.get("layerInfo");
 
   // Show the options menu by setting an anchor element
   const handleShowMoreOptionsClick = (e) => {
@@ -120,7 +120,7 @@ export default function LayerItemOptions({
     }
   };
 
-  return !layerInfo.showAttributeTableButton && !isDownloadable() ? null : (
+  return !layerInfo?.showAttributeTableButton && !isDownloadable() ? null : (
     <>
       <IconButton
         size="small"


### PR DESCRIPTION
@Albinahmetaj found a bug the other day.

The LayerItemDetails view crashed for system layers. (Which can be shown in the DrawOrder tab)

This PR fixes that issues in two ways:

- It improves the error handling in LayerItemDetails such that it does not crash. But it does not really show any useful info for most system layers.
- It disables the arrow button to open the LayerItemDetails for system layers.