### PR TITLE
fix: pass correct prop to QuickAccess Favorites

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherView.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherView.js
@@ -264,10 +264,7 @@ class LayersSwitcherView extends React.PureComponent {
           flex: 1,
         }}
       >
-        <StyledAppBar
-          position="relative" // Does not work in IE11
-          color="default"
-        >
+        <StyledAppBar position="relative" color="default">
           <Tabs
             action={this.handleTabsMounted}
             onChange={this.handleChangeTabs}
@@ -314,7 +311,7 @@ class LayersSwitcherView extends React.PureComponent {
           handleFavoritesViewToggle={this.handleFavoritesViewToggle}
           globalObserver={this.globalObserver}
           map={this.props.map}
-          app={this.app}
+          app={this.props.app}
           scrollContainerRef={this.scrollContainerRef}
         />
         {this.props.options.enableQuickAccessPresets && (


### PR DESCRIPTION
@Hallbergs found a new regression that the QuickAccess Favorites crashed when adding a new set of favorites. This PR fixes that.

And removes an unnecessary comment that I forgot in a previous PR.