### PR TITLE
feat: Toggle only filtered layers in Groups

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
@@ -55,9 +55,9 @@ function GroupLayer({
 
   const handleLayerItemClick = () => {
     if (layerIsToggled) {
-      layerSwitcherDispatch.setLayerVisibility(layerId, false);
+      layerSwitcherDispatch.setLayerVisibility(layerId, false, subLayersToShow);
     } else {
-      layerSwitcherDispatch.setLayerVisibility(layerId, true);
+      layerSwitcherDispatch.setLayerVisibility(layerId, true, subLayersToShow);
     }
   };
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -226,9 +226,17 @@ const LayerGroup = ({
           toggleState={toggleState}
           clickHandler={() => {
             if (isToggled) {
-              layerSwitcherDispatch.setGroupVisibility(groupId, false);
+              layerSwitcherDispatch.setGroupVisibility(
+                groupId,
+                false,
+                filterHits
+              );
             } else {
-              layerSwitcherDispatch.setGroupVisibility(groupId, true);
+              layerSwitcherDispatch.setGroupVisibility(
+                groupId,
+                true,
+                filterHits
+              );
             }
           }}
         />


### PR DESCRIPTION
This PR is a implementation/fix for #1586 

If there is a active filter/search in the LayerSwitcher and the user enables a Group of GroupLayer we only toggles the layers which are search hits.

