### PR TITLE
Feature: List layers in Quick access presets infobox

### DIFF
--- a/apps/backend/App_Data/map_1.json
+++ b/apps/backend/App_Data/map_1.json
@@ -665,7 +665,36 @@
             "infobox": ""
           }
         ],
-        "quickLayersPresets": [],
+        "enableQuickAccessPresets": true,
+        "quickAccessPresets": [
+          {
+            "id": "sensate-data",
+            "title": "Senaste data",
+            "author": "Hajks kodgrupp",
+            "Description": "Det här är en grupp av den senaste datan där vi har flera olika år.",
+            "keywords": ["naturvårdsverket", "2019", "scb", "2023" ],
+            "layers": [
+              {
+                "id": "1",
+                "drawOrder": 3,
+                "visible": true,
+                "opacity": 1
+              },
+              {
+                "id": "toimzo",
+                "drawOrder": 3,
+                "visible": true,
+                "opacity": 1
+              },
+              {
+                "id": "vzjhpz",
+                "drawOrder": 3,
+                "visible": true,
+                "opacity": 1
+              }
+            ]
+          }
+        ],
         "active": true,
         "visibleAtStart": false,
         "visibleAtStartMobile": false,

--- a/apps/backend/App_Data/map_1.json
+++ b/apps/backend/App_Data/map_1.json
@@ -688,9 +688,7 @@
               },
               {
                 "id": "vzjhpz",
-                "drawOrder": 3,
-                "visible": true,
-                "opacity": 1
+                "visible": true
               }
             ]
           }

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -285,6 +285,19 @@ function QuickAccessPresets({
     return backgroundLayerName;
   };
 
+  const getLayerNames = (layers) => {
+    const layerNames = [];
+    layers?.forEach((layer) => {
+      const mapLayer = map
+        .getAllLayers()
+        .find((l) => l.get("name") === layer.id);
+      if (mapLayer && mapLayer.get("layerType") !== "base") {
+        layerNames.push(mapLayer.get("caption"));
+      }
+    });
+    return layerNames;
+  };
+
   // Render layerpackage keywords
   const renderKeywords = (keywords) => {
     // Check if keywords is an array and if it contains any items
@@ -339,8 +352,15 @@ function QuickAccessPresets({
             <PublicOutlinedIcon fontSize="small"></PublicOutlinedIcon>
             <Typography>
               {loadLpInfoConfirmation &&
-                getBaseLayerName(loadLpInfoConfirmation.layers)}
+                getBaseLayerName(loadLpInfoConfirmation?.layers)}
             </Typography>
+          </Stack>
+          <DialogContentText sx={{ mt: 2, mb: 1 }}>Lager</DialogContentText>
+          <Stack direction="row" useFlexGap spacing={2}>
+            {loadLpInfoConfirmation &&
+              getLayerNames(loadLpInfoConfirmation?.layers).map((n) => (
+                <Typography>{n}</Typography>
+              ))}
           </Stack>
           <Divider sx={{ mt: 2 }} />
           <Typography sx={{ mt: 2, mb: 1 }}>

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -139,14 +139,18 @@ function QuickAccessPresets({
     layers.forEach((l) => {
       const layer = allMapLayers.find((la) => la.get("name") === l.id);
       if (layer) {
+        const opacity = l?.opacity ?? 1;
+        const drawOrder = l?.drawOrder ?? 1;
+        const visible = l?.visible ?? true;
+
         // Set quickaccess property
         if (layer.get("layerType") !== "base") {
           layer.set("quickAccess", true);
         }
         // Set drawOrder (zIndex)
-        layer.setZIndex(l.drawOrder);
+        layer.setZIndex(drawOrder);
         // Set opacity
-        layer.setOpacity(l.opacity);
+        layer.setOpacity(opacity);
         // Special handling for layerGroups and baselayers
         if (layer.get("layerType") === "group") {
           if (l.visible === true) {
@@ -165,9 +169,9 @@ function QuickAccessPresets({
             layer.get("name")
           );
           // Set visibility
-          layer.set("visible", l.visible);
+          layer.set("visible", visible);
         } else {
-          layer.set("visible", l.visible);
+          layer.set("visible", visible);
         }
       } else if (l.id < 0) {
         // A fake maplayer is in the package


### PR DESCRIPTION
<img width="905" alt="Screenshot 2025-02-24 at 11 47 37" src="https://github.com/user-attachments/assets/4e3f6a10-33fb-44b0-b41f-7842354a946d" />

Show the layers in the Quick Access Preset in the Infobox. 

@jacobwod had this idea in: https://github.com/hajkmap/Hajk/discussions/1596#discussioncomment-12276132

Also add a example QuickAccess Preset to the default map config.