### PR TITLE
fix: handle sublayers in hash state

### DIFF
--- a/apps/client/src/models/layers/WMSLayer.js
+++ b/apps/client/src/models/layers/WMSLayer.js
@@ -113,6 +113,7 @@ class WMSLayer {
 
     this.layer.layersInfo = config.layersInfo;
     this.layer.subLayers = this.subLayers;
+    this.layer.set("allSubLayers", this.subLayers);
     this.layer.visibleAtStartSubLayers = config.visibleAtStartSubLayers;
     this.layer.set(
       "subLayers",

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -341,7 +341,7 @@ const getLayerNodes = (groups, olLayerMap) =>
         layerId: node.id,
         caption: olLayer?.get("caption") ?? node.name,
         layerCaption: olLayer?.get("caption") ?? node.name,
-        allSubLayers: olLayer?.get("subLayers"),
+        allSubLayers: olLayer?.get("allSubLayers"),
         initiallyExpanded: node.expanded,
         initiallyToggled: node.toggled,
         initialDrawOrder: node.drawOrder,

--- a/apps/client/src/plugins/LayerSwitcher/components/DrawOrder.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/DrawOrder.js
@@ -280,7 +280,7 @@ function DrawOrder({ display, app, map, localObserver, options }) {
 
                 // layerIsFakeMapLayer: l.isFakeMapLayer,
                 layerIsFakeMapLayer: false, // TODO Check this mapLayer.isFakeMapLayer,
-                allSubLayers: l.get("subLayers"),
+                allSubLayers: l.get("allSubLayers"),
                 layerMinZoom: l.get("minZoom"),
                 layerMaxZoom: l.get("maxZoom"),
                 numberOfSubLayers: l.subLayers?.length,


### PR DESCRIPTION
@FredrikEkstrom79 found a bug in the new LayerSwitcher. https://github.com/hajkmap/Hajk/discussions/1596#discussioncomment-12323356

If a sublayer is stored in the URL hash state, the other sublayers in the GroupLayer are not loaded correctly in the layerSwitcher on reload.