### PR TITLE
fix: enable scroll in LayerItemDetails

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
@@ -184,13 +184,17 @@ function LayerItemDetails({
         <Box
           sx={{
             display: display ? "block" : "none",
-            minHeight: "15em",
             top: 0,
             left: 0,
             right: 0,
             bottom: 0,
             backgroundColor: (theme) =>
               theme.palette.mode === "dark" ? "rgb(18,18,18)" : "#fff",
+            position: "relative",
+            overflowY: "auto",
+            height: "inherit",
+            minHeight: "15em",
+            maxHeight: "inherit",
           }}
         >
           <Box


### PR DESCRIPTION
Make the LayerItemDetails view scroll if the Legend is too long