### PR TITLE
fix: Show sublayers in QuickAccess

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/LayersTab.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayersTab.js
@@ -166,6 +166,7 @@ const LayersTab = ({
             favoritesInfoText={userQuickAccessFavoritesInfoText}
             filterValue={filterValue}
             layersState={layersState}
+            staticLayerConfig={staticLayerConfig}
           />
         )}
         {staticLayerTree.map((group) => (

--- a/apps/client/src/plugins/LayerSwitcher/components/LayersTabActionsMenu.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayersTabActionsMenu.js
@@ -51,7 +51,7 @@ const LayersTabActionsMenu = ({ scrollToTop, scrollToBottom }) => {
         aria-expanded={menuIsOpen ? "true" : undefined}
         onClick={handleShowMoreOptionsClick}
       >
-        <Tooltip title="Fler val för snabbåtkomst">
+        <Tooltip title="Fler funktioner för Lagerhanteraren">
           <MoreVertOutlinedIcon />
         </Tooltip>
       </IconButton>

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessLayers.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessLayers.js
@@ -9,6 +9,8 @@ export default function QuickAccessLayers({
   globalObserver,
   map,
   filterValue,
+  layersState,
+  staticLayerConfig,
 }) {
   // State that contains the layers that are currently visible
   const [quickAccessLayers, setQuickAccessLayers] = useState([]);
@@ -98,23 +100,13 @@ export default function QuickAccessLayers({
       }}
     >
       {quickAccessLayers.map((l) => {
-        const layerState = {
-          layerIsToggled: l.get("visible"),
-          visibleSubLayers: l.get("subLayers"),
-        };
+        const layerId = l.get("name");
+        const layerState = layersState[layerId];
 
-        const layerConfig = {
-          layerId: l.get("name"),
-          layerCaption: l.get("caption"),
-          layerType: l.get("layerType"),
-
-          layerIsFakeMapLayer: l.isFakeMapLayer,
-          layerMinZoom: l.get("minZoom"),
-          layerMaxZoom: l.get("maxZoom"),
-          numberOfSubLayers: l.subLayers?.length,
-          layerInfo: l.get("layerInfo"),
-          layerLegendIcon: l.get("legendIcon"),
-        };
+        const layerConfig = staticLayerConfig[layerId];
+        if (!layerConfig) {
+          return null;
+        }
 
         return l.get("layerType") === "base" ? (
           <BackgroundLayer

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessView.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessView.js
@@ -38,6 +38,7 @@ const QuickAccessView = ({
   filterValue,
   enqueueSnackbar,
   layersState,
+  staticLayerConfig,
 }) => {
   const qaLayers = Object.values(layersState).filter((obj) => obj.quickAccess);
   const hasVisibleLayers = qaLayers.some((l) => l.visible);
@@ -167,6 +168,8 @@ const QuickAccessView = ({
             filterValue={filterValue}
             map={map}
             globalObserver={globalObserver}
+            layersState={layersState}
+            staticLayerConfig={staticLayerConfig}
           ></QuickAccessLayers>
         </Box>
       </Collapse>


### PR DESCRIPTION
@jacobwod found a bug while reviewing #1601

> An additional problem (which should perhaps be handled in a separate issue?) is the group layer (id rycfnb) does not show its children in the Quick Access portion (but it works well in the regular group, see the screenshot):

This PR fixes this issue. So that sublayers are shown correctly in QuickAccess.