### PR TITLE
fix: Show all sublayer legends for group layers

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.js
@@ -244,6 +244,9 @@ function LayerItem({
     return `${theme.spacing(0.2)} solid ${theme.palette.divider}`;
   };
 
+  const legendUrls =
+    Array.isArray(layerInfo?.legend) && layerInfo?.legend.map((l) => l?.url);
+
   return (
     <div
       className="layer-item"
@@ -347,11 +350,7 @@ function LayerItem({
         </ListItemButton>
       </Box>
       {layerShouldShowLegendIcon(layerType, layerIsFakeMapLayer) ? null : (
-        <LegendImage
-          comment="TODO Fix the mess below"
-          src={Array.isArray(layerInfo?.legend) && layerInfo?.legend[0]?.url}
-          open={legendIsActive}
-        ></LegendImage>
+        <LegendImage src={legendUrls} open={legendIsActive}></LegendImage>
       )}
       {subLayersSection && subLayersSection}
     </div>

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItemDetails.js
@@ -61,17 +61,19 @@ function LayerItemDetails({
       : layerItemDetails?.subLayerIndex;
   const showOpacity = subLayerIndex !== null ? false : true;
 
-  // TODO Is this correct? Should it not be shown for group layers?
-  const showLegend =
-    layerItemDetails?.layer?.get("layerType") === "group" &&
-    subLayerIndex === null
-      ? false
-      : true;
-
   const layerInfo = layerItemDetails?.layer?.get("layerInfo");
-  const legendInfo =
-    layerInfo?.legend?.length > 0 && layerInfo?.legend[subLayerIndex ?? 0];
-  const legendUrl = legendInfo?.url;
+
+  // Only show legend for actual OL layers.
+  // This check is probably not needed but LayerItemDetails can be passed
+  // several different things and we don't want to crash in any case.
+  // Proper typing of the props would remove the need for this check.
+  const showLegend = layerItemDetails?.layer?.get("layerType");
+
+  const legendInfo = layerInfo?.legend;
+  const legendUrl =
+    showLegend && subLayerIndex === null
+      ? legendInfo?.map((l) => l?.url)
+      : Array.isArray(legendInfo) && legendInfo[subLayerIndex]?.url;
 
   // Handle opacity slider changes
   const handleOpacitySliderChange = (_, newValue) => {

--- a/apps/client/src/plugins/LayerSwitcher/components/LegendImage.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LegendImage.js
@@ -1,22 +1,36 @@
 import { Collapse } from "@mui/material";
+import { styled } from "@mui/material/styles";
 
-// TODO Handle collapse state inside this component
+const ColumnContainer = styled("div")(() => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "start",
+  gap: "0.25em",
+}));
+
+const Image = styled("img")(() => ({
+  objectFit: "none",
+  maxWidth: "250px",
+}));
+
 export default function LegendImage({ open, src }) {
-  return src ? (
+  if (!src) {
+    return null;
+  }
+
+  const urlArray = Array.isArray(src) ? src : [src];
+  return (
     <Collapse
-      sx={{ pt: open ? 1 : 0, ml: 4 }}
+      sx={{ py: open ? 1 : 0, ml: 4 }}
       in={open}
       timeout={50}
       unmountOnExit
     >
-      <div>
-        <img
-          loading="lazy"
-          style={{ maxWidth: "250px" }}
-          alt="Teckenförklaring"
-          src={src}
-        />
-      </div>
+      <ColumnContainer>
+        {urlArray.map((url) => (
+          <Image key={url} loading="lazy" alt="Teckenförklaring" src={url} />
+        ))}
+      </ColumnContainer>
     </Collapse>
-  ) : null;
+  );
 }


### PR DESCRIPTION
@Hallbergs found a bug in the new LayerSwitcher. For GroupLayers (layers with sublayers) only the legend image from the first sublayer was shown as the legend for the entire GroupLayers.

This PR fixes this so that the legend images for all sublayers are shown as the legen for the LayerGroup. For both the inline legend and the legend in LayerItemDetails.

This behaviour is different from the previous version of the LayerSwitcher which didn't show legends for GroupLayers at all.

![Screenshot 2025-02-27 at 10 58 31](https://github.com/user-attachments/assets/bc077442-9f05-4b55-b232-c9896641bbf4)

![Screenshot 2025-02-27 at 10 58 45](https://github.com/user-attachments/assets/cc401110-621b-4e23-aa0f-68880ea9aba0)
