### PR TITLE
fix: add map rotation

### DIFF
--- a/apps/client/src/components/App.js
+++ b/apps/client/src/components/App.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import { styled } from "@mui/material/styles";
 import Observer from "react-event-observer";
 import { isMobile } from "../utils/IsMobile";
+import { mapDirectionToAngle } from "../utils/mapDirectionToAngle";
 import { getMergedSearchAndHashParams } from "../utils/getMergedSearchAndHashParams";
 import SrShortcuts from "../components/SrShortcuts/SrShortcuts";
 import Analytics from "../models/Analytics";
@@ -804,18 +805,29 @@ class App extends React.PureComponent {
       .getArray()
       .forEach((layer) => {
         layer.on("change:visible", (e) => {
+          const olLayer = e.target;
           // If the Analytics object exists, let's track layer visibility
-          if (this.analytics && e.target.get("visible") === true) {
+          if (this.analytics && olLayer.get("visible") === true) {
             const opts = {
               eventName: "layerShown",
               activeMap: this.props.config.activeMap,
-              layerId: e.target.get("name"),
-              layerName: e.target.get("caption"),
+              layerId: olLayer.get("name"),
+              layerName: olLayer.get("caption"),
             };
             // Send a custom event to the Analytics model
             this.globalObserver.publish("analytics.trackEvent", opts);
           }
 
+          // If the layer becomes visible, set the map rotation to match
+          if (olLayer.get("visible")) {
+            const map = this.appModel.getMap();
+            const direction = olLayer.get("rotateMap");
+
+            const angle = mapDirectionToAngle(direction);
+            if (angle !== null) {
+              map.getView().setRotation(angle);
+            }
+          }
           // Not related to Analytics: send an event on the global observer
           // to anyone wanting to act on layer visibility change.
           this.globalObserver.publish("core.layerVisibilityChanged", e);

--- a/apps/client/src/components/App.js
+++ b/apps/client/src/components/App.js
@@ -818,15 +818,16 @@ class App extends React.PureComponent {
             this.globalObserver.publish("analytics.trackEvent", opts);
           }
 
-          // If the layer becomes visible, set the map rotation to match
-          if (olLayer.get("visible")) {
+          // If a base layer becomes visible, set the map rotation to match.
+          // When this runs the OpenStreetMap layer (if enable) don't exist
+          // yet. As a workaround this code is duplicated in:
+          // `plugins/LayerSwitcher/components/BackgroundSwitcher.js`
+          if (olLayer.get("visible") && olLayer.get("layerType") === "base") {
             const map = this.appModel.getMap();
             const direction = olLayer.get("rotateMap");
 
             const angle = mapDirectionToAngle(direction);
-            if (angle !== null) {
-              map.getView().setRotation(angle);
-            }
+            map.getView().setRotation(angle);
           }
           // Not related to Analytics: send an event on the global observer
           // to anyone wanting to act on layer visibility change.

--- a/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from "react";
 import { isValidLayerId } from "../../../utils/Validator";
+import { mapDirectionToAngle } from "../../../utils/mapDirectionToAngle";
 import OSM from "ol/source/OSM";
 import TileLayer from "ol/layer/Tile";
 import BackgroundLayerItem from "./BackgroundLayerItem";
@@ -58,6 +59,42 @@ const setSpecialBackground = (id) => {
 
 export const OSM_LAYER_ID = "osm-layer";
 
+const createOSMLayer = (map) => {
+  const osmLayer = new TileLayer({
+    visible: false,
+    source: new OSM({
+      reprojectionErrorThreshold: 5,
+    }),
+    zIndex: -1,
+    layerType: "base",
+    rotateMap: "n", // OpenStreetMap should be rotated to North
+    name: OSM_LAYER_ID,
+    caption: "OpenStreetMap",
+    layerInfo: {
+      caption: "OpenStreetMap",
+      layerType: "base",
+    },
+  });
+
+  // This layer does not exist on the map when we setup the listener that
+  // rotates the map when a base layer is activated. The listener in
+  // `src/components/App.js`.
+  // Therefore we need to setup the same check here.
+  osmLayer.on("change:visible", (e) => {
+    const olLayer = e.target;
+
+    // If the layer becomes visible, set the map rotation to match
+    if (olLayer.get("visible")) {
+      const direction = olLayer.get("rotateMap");
+
+      const angle = mapDirectionToAngle(direction);
+      map.getView().setRotation(angle);
+    }
+  });
+
+  return osmLayer;
+};
+
 const BackgroundSwitcher = ({
   backgroundSwitcherBlack,
   backgroundSwitcherWhite,
@@ -73,25 +110,7 @@ const BackgroundSwitcher = ({
 
   const layerSwitcherDispatch = useLayerSwitcherDispatch();
 
-  const osmLayerRef = useRef(
-    enableOSM
-      ? new TileLayer({
-          visible: false,
-          source: new OSM({
-            reprojectionErrorThreshold: 5,
-          }),
-          zIndex: -1,
-          layerType: "base",
-          rotateMap: "n", // OpenStreetMap should be rotated to North
-          name: OSM_LAYER_ID,
-          caption: "OpenStreetMap",
-          layerInfo: {
-            caption: "OpenStreetMap",
-            layerType: "base",
-          },
-        })
-      : null
-  );
+  const osmLayerRef = useRef(enableOSM ? createOSMLayer(map) : null);
 
   useEffect(() => {
     if (enableOSM) {

--- a/apps/client/src/plugins/LayerSwitcher/components/Favorites/Favorites.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/Favorites/Favorites.js
@@ -285,7 +285,7 @@ function Favorites({
     // First, we try to get the map's name. We can't be certain that this exists (not
     // all maps have the userSpecificMaps property), so we must be careful.
     const mapName =
-      Array.isArray(app.config.userSpecificMaps) &&
+      Array.isArray(app?.config?.userSpecificMaps) &&
       app.config.userSpecificMaps.find(
         (m) => m.mapConfigurationName === app.config.activeMap
       )?.mapConfigurationTitle;

--- a/apps/client/src/utils/mapDirectionToAngle.js
+++ b/apps/client/src/utils/mapDirectionToAngle.js
@@ -1,0 +1,26 @@
+export const mapDirectionToAngle = (direction) => {
+  if (!direction) {
+    return null;
+  }
+
+  switch (direction) {
+    case "n":
+      return 0;
+    case "ne":
+      return Math.PI / 8;
+    case "e":
+      return Math.PI / 4;
+    case "se":
+      return 3 * (Math.PI / 8);
+    case "s":
+      return Math.PI / 2;
+    case "sw":
+      return 5 * (Math.PI / 8);
+    case "w":
+      return 3 * (Math.PI / 4);
+    case "nw":
+      return 7 * (Math.PI / 8);
+    default:
+      return 0;
+  }
+};

--- a/apps/client/src/utils/mapDirectionToAngle.js
+++ b/apps/client/src/utils/mapDirectionToAngle.js
@@ -1,26 +1,24 @@
 export const mapDirectionToAngle = (direction) => {
-  if (!direction) {
-    return null;
-  }
-
+  // the return is given in radians.
   switch (direction) {
     case "n":
       return 0;
     case "ne":
-      return Math.PI / 8;
-    case "e":
       return Math.PI / 4;
-    case "se":
-      return 3 * (Math.PI / 8);
-    case "s":
+    case "e":
       return Math.PI / 2;
-    case "sw":
-      return 5 * (Math.PI / 8);
-    case "w":
+    case "se":
       return 3 * (Math.PI / 4);
+    case "s":
+      return Math.PI;
+    case "sw":
+      return 5 * (Math.PI / 4);
+    case "w":
+      return 3 * (Math.PI / 2);
     case "nw":
-      return 7 * (Math.PI / 8);
+      return 7 * (Math.PI / 4);
     default:
+      // If the direction is unset we rotate the map to north
       return 0;
   }
 };


### PR DESCRIPTION
https://github.com/hajkmap/Hajk/discussions/1596#discussioncomment-12412108

The new LayerSwitcher accidentally removed the feature to rotate the map when a layer is activated. If the `rotateMap` property is set. This PR re-adds that feature.

@jacobwod I have a few questions about the details in this feature:

- Should the map reset to north is a layer without the `rotateMap` setting. Or should it keep in the current rotation.
- Is this feature only for base layers or any layer?