### PR TITLE
fix: hide sublayers when searching hideExpandArrow

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.js
@@ -74,6 +74,18 @@ function GroupLayer({
   const layerIsVisibleAtZoom =
     mapZoom >= layerMinZoom && mapZoom <= layerMaxZoom;
 
+  // if `hideExpandArrow` option is set then no sublayers should be shown when
+  // searching.
+  const subLayerSectionOpen =
+    layerInfo?.hideExpandArrow === true
+      ? false
+      : showSublayers || isSubLayerFilterHit;
+
+  // If there is an active search we don't want to show the expand arrow since
+  // it does not do anything.
+  const showExpandArrow =
+    layerInfo.hideExpandArrow !== true && !isSubLayerFilterHit;
+
   return (
     <LayerItem
       display={display}
@@ -86,7 +98,7 @@ function GroupLayer({
       clickCallback={handleLayerItemClick}
       visibleSubLayers={visibleSubLayers}
       expandableSection={
-        layerInfo.hideExpandArrow !== true && (
+        showExpandArrow && (
           <Box>
             <IconButton
               sx={{
@@ -110,7 +122,7 @@ function GroupLayer({
         )
       }
       subLayersSection={
-        <Collapse in={showSublayers || isSubLayerFilterHit} unmountOnExit>
+        <Collapse in={subLayerSectionOpen} unmountOnExit>
           <Box sx={{ marginLeft: 3 }}>
             {subLayersToShow?.map((subLayer) => (
               <SubLayerItem


### PR DESCRIPTION
@jesade-vbg found a bug in the layer switcher

> When searching/filtering "hideExpandArrow": true is ignored showing "hidden" layers.

https://github.com/hajkmap/Hajk/discussions/1596#discussioncomment-12423761

This PR fixes that bug.