### PR TITLE
Fix: Toggle Sublayers when loading Quick Access presets

### DIFF
--- a/apps/backend/App_Data/map_1.json
+++ b/apps/backend/App_Data/map_1.json
@@ -551,6 +551,8 @@
         ],
         "quickAccessPresets": [
           {
+            "title": "Test-grupp",
+            "description": "Ett preset med vanliga lager och ett grupplager",
             "layers": [
               {
                 "id": "0si2ys",
@@ -589,8 +591,12 @@
                 "drawOrder": 0
               }
             ],
-            "title": "Test-grupp",
-            "description": "Ett preset med vanliga lager och ett grupplager"
+            "metadata": {
+              "savedAt": "2025-03-17T06:22:16.974Z",
+              "numberOfLayers": 3,
+              "title": "Test-grupp",
+              "description": "Ett preset med vanliga lager och ett grupplager"
+            }
           }
         ],
         "active": true,

--- a/apps/backend/App_Data/map_1.json
+++ b/apps/backend/App_Data/map_1.json
@@ -549,7 +549,50 @@
             "infobox": ""
           }
         ],
-        "quickAccessPresets": [],
+        "quickAccessPresets": [
+          {
+            "layers": [
+              {
+                "id": "0si2ys",
+                "visible": true,
+                "subLayers": [],
+                "opacity": 1,
+                "drawOrder": 1000
+              },
+              {
+                "id": "4y2nnu",
+                "visible": true,
+                "subLayers": [],
+                "opacity": 1,
+                "drawOrder": 1000
+              },
+              {
+                "id": "n0ehiv",
+                "visible": true,
+                "subLayers": [
+                  "Motorvag",
+                  "Motortrafikled",
+                  "Stamvag",
+                  "Storstadsvag",
+                  "Gastvag",
+                  "GangfartsOmrade",
+                  "Provisoriskvag"
+                ],
+                "opacity": 1,
+                "drawOrder": 1000
+              },
+              {
+                "id": "1",
+                "visible": true,
+                "subLayers": [],
+                "opacity": 1,
+                "drawOrder": 0
+              }
+            ],
+            "title": "Test-grupp",
+            "description": "Ett preset med vanliga lager och ett grupplager"
+          }
+        ],
         "active": true,
         "visibleAtStart": false,
         "visibleAtStartMobile": false,
@@ -563,7 +606,7 @@
         "enableSystemLayersSwitch": true,
         "lockDrawOrderBaselayer": true,
         "drawOrderViewInfoText": "Här kan du ändra ritordning på tända lager i kartan. Dra lagret upp eller ner i listan och släpp på önskad plats.",
-        "enableQuickAccessPresets": false,
+        "enableQuickAccessPresets": true,
         "quickAccessTopicsInfoText": "Här kan du ladda färdiga teman till snabbåtkomst. Teman innehåller tända och släckta lager, samt bakgrund.",
         "enableUserQuickAccessFavorites": true,
         "userQuickAccessFavoritesInfoText": "Här kan du hantera och redigera dina sparade favoriter. Observera att favoriter endast sparas tillfälligt.",

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -230,6 +230,16 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
       olLayer.set("subLayers", sortedCurrentSubLayers);
       setOLSubLayers(olLayer, sortedCurrentSubLayers);
     },
+    setSubLayersVisible(layerId, subLayers) {
+      const olLayer = map.getAllLayers().find((l) => l.get("name") === layerId);
+      const allSubLayers = olLayer.get("allSublayers");
+
+      const subLayersToShow = Array.isArray(subLayers)
+        ? subLayers
+        : allSubLayers;
+
+      setOLSubLayers(olLayer, subLayersToShow);
+    },
     setGroupVisibility(groupId, visible) {
       const groupTree = getGroupConfigById(staticLayerTree, groupId);
       const allLayerIdsInGroup = getAllLayerIdsInGroup(groupTree);

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -249,18 +249,6 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
         olLayer.setVisible(visible);
       });
     },
-    setGroupLayerVisibility(layerId, visible) {
-      const olLayer = map.getAllLayers().find((l) => l.get("name") === layerId);
-      const allSubLayers = new Set(olLayer.get("subLayers"));
-
-      if (visible) {
-        olLayer.set("subLayers", allSubLayers);
-        setOLSubLayers(olLayer, allSubLayers);
-      } else {
-        olLayer.set("subLayers", []);
-        setOLSubLayers(olLayer, []);
-      }
-    },
     setAllLayersInvisible() {
       map.getAllLayers().forEach((l) => {
         const layerType = l.get("layerType");

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -535,11 +535,11 @@ function QuickAccessPresets({
                 )}
               </Typography>
             ) : (
-              filter.list.map((l) => {
+              filter.list.map((l, index) => {
                 return (
                   <ListItemButton
                     dense
-                    key={l.id}
+                    key={l.metadata?.savedAt || index}
                     divider
                     onClick={() => handleLpClick(l)}
                   >

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -32,6 +32,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import TopicOutlinedIcon from "@mui/icons-material/TopicOutlined";
 
 import HajkToolTip from "../../../components/HajkToolTip";
+import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
 
 function QuickAccessPresets({
   display,
@@ -54,6 +55,8 @@ function QuickAccessPresets({
   // When a user clicks back, the tooltip of the button needs to be closed before this view hides.
   // TODO: Needs a better way to handle this
   const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  const layerSwitcherDispatch = useLayerSwitcherDispatch();
 
   const quickAccessPresetsArray = quickAccessPresets || [];
 
@@ -147,13 +150,15 @@ function QuickAccessPresets({
         layer.setZIndex(l.drawOrder);
         // Set opacity
         layer.setOpacity(l.opacity);
+
         // Special handling for layerGroups and baselayers
         if (layer.get("layerType") === "group") {
           if (l.visible === true) {
-            const subLayersToShow = l.subLayers ? l.subLayers : [];
+            layerSwitcherDispatch.setSubLayersVisible(l.id, l.subLayers);
+
             globalObserver.publish("layerswitcher.showLayer", {
               layer,
-              subLayersToShow,
+              subLayersToShow: l.subLayers,
             });
           } else {
             globalObserver.publish("layerswitcher.hideLayer", layer);

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -155,13 +155,6 @@ function QuickAccessPresets({
         if (layer.get("layerType") === "group") {
           if (l.visible === true) {
             layerSwitcherDispatch.setSubLayersVisible(l.id, l.subLayers);
-
-            globalObserver.publish("layerswitcher.showLayer", {
-              layer,
-              subLayersToShow: l.subLayers,
-            });
-          } else {
-            globalObserver.publish("layerswitcher.hideLayer", layer);
           }
         } else if (layer.get("layerType") === "base") {
           // Hide all other background layers


### PR DESCRIPTION
@Albinahmetaj found a bug where GroupLayers weren't toggled when loading QuickAccess presets

https://github.com/hajkmap/Hajk/discussions/1596#discussioncomment-12488549

This PR fixes that bug.
It also adds a example preset config to `map_1`.
And removes some unused code.