### PR TITLE
fix: set layer ids from 'ladda tema' to local storage, toggle subLayers visibility

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.js
@@ -13,6 +13,9 @@ import { useLayerZoomWarningSnackbar } from "./useLayerZoomWarningSnackbar";
 import { functionalOk as functionalCookieOk } from "../../models/Cookie";
 import LocalStorageHelper from "../../utils/LocalStorageHelper";
 
+export const QUICK_ACCESS_KEY = "quickAccess";
+export const QUICK_ACCESS_LS_KEY = "quickAccessLayers";
+
 const getOlLayerState = (l) => ({
   opacity: l.get("opacity"),
   id: l.get("name"),
@@ -121,6 +124,7 @@ const setOLSubLayers = (olLayer, visibleSubLayersArray) => {
         .join(","),
       CQL_FILTER: null,
     });
+    olLayer.set("subLayers", visibleSubLayersArray);
     olLayer.setVisible(true);
   }
 };
@@ -164,16 +168,12 @@ const getGroupConfigById = (tree, groupId) => {
   }
 };
 
-const QUICK_ACCESS_KEY = "quickAccess";
-const QUICK_ACCESS_LS_KEY = "quickAccessLayers";
-
 const setQuickAccessStateInLocalStorage = (map) => {
   if (functionalCookieOk()) {
     const qaLayers = map
       .getAllLayers()
       .filter((l) => l.get(QUICK_ACCESS_KEY) === true)
       .map((l) => l.get("name"));
-    console.log({ qaLayers });
     LocalStorageHelper.set(QUICK_ACCESS_LS_KEY, qaLayers);
   }
 };
@@ -227,6 +227,7 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
       const sortedCurrentSubLayers = allSubLayers.filter((l) =>
         currentSubLayersSet.has(l)
       );
+
       olLayer.set("subLayers", sortedCurrentSubLayers);
       setOLSubLayers(olLayer, sortedCurrentSubLayers);
     },
@@ -237,7 +238,6 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
       const subLayersToShow = Array.isArray(subLayers)
         ? subLayers
         : allSubLayers;
-
       setOLSubLayers(olLayer, subLayersToShow);
     },
     setGroupVisibility(groupId, visible) {
@@ -473,6 +473,7 @@ const LayerSwitcherProvider = ({
   // layers might have been added to QuickAccess.
   useEffect(() => {
     const ls = LocalStorageHelper.get(QUICK_ACCESS_LS_KEY);
+
     if (!(typeof ls === "object" && ls !== null)) {
       return;
     }

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.js
@@ -32,7 +32,12 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import TopicOutlinedIcon from "@mui/icons-material/TopicOutlined";
 
 import HajkToolTip from "../../../components/HajkToolTip";
-import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
+import {
+  QUICK_ACCESS_KEY,
+  QUICK_ACCESS_LS_KEY,
+  useLayerSwitcherDispatch,
+} from "../LayerSwitcherProvider";
+import LocalStorageHelper from "../../../utils/LocalStorageHelper";
 
 function QuickAccessPresets({
   display,
@@ -114,12 +119,12 @@ function QuickAccessPresets({
     let lpInfo = infoType
       ? { ...loadLpInfoConfirmation }
       : { ...loadLpConfirmation };
-
     setLoadLpConfirmation(null);
     setLoadLpInfoConfirmation(null);
 
     // Check if layers from layerpackage exists in map
     const missingLayers = checkForMissingLayers(lpInfo.layers);
+
     if (missingLayers.length > 0) {
       // Show missing layers dialog
       setMissingLayersConfirmation({
@@ -141,6 +146,10 @@ function QuickAccessPresets({
     const allMapLayers = map.getAllLayers();
     layers.forEach((l) => {
       const layer = allMapLayers.find((la) => la.get("name") === l.id);
+      const loadedLayerIds = allMapLayers
+        .filter((l) => l.get(QUICK_ACCESS_KEY) === true)
+        .map((l) => l.get("name"));
+      LocalStorageHelper.set(QUICK_ACCESS_LS_KEY, loadedLayerIds);
       if (layer) {
         // Set quickaccess property
         if (layer.get("layerType") !== "base") {


### PR DESCRIPTION
I sat with @Hallbergs and discussed some cases regarding this commit. My guess would be that if a user decides to load a 'tema' , the layers that are stored in 'Snabbåtkomst' after the 'tema' has been loaded should be stored in local storage as they currently do when a user uses the 'Lägg till tända lager' function.

Another fix ensures that when loading a 'tema' using a grouplayer the specified sublayers will be toggled.

---

Bug: right now all sublayers within the grouplayer will be toggeled when loading layers using  'Ladda tema', even if only two of them are specified  inside the quickAccessPresets as shown _here:_

`  "quickAccessPresets": [layer:[{ "id": "n0ehiv",
                "visible": true,
                "subLayers": [
                  "Motortrafikled",
                  "Gastvag"
                ],
                "opacity": 1,
                "drawOrder": 1000}]]
`

![tema grplayer-fix](https://github.com/user-attachments/assets/76f4017a-46e5-4b6a-9ffd-8a6000828117)

`olLayer.set("subLayers", visibleSubLayersArray);` fixes this inside the LayerSwitcherProvider.js component

Another thing that i notices is that when you load the layers using 'Ladda tema' with a grouplayer, all sublayers are toggled as described above. However, if you manually untoggle the sublayers and then load the 'tema' again, the sublayers remain unchecked, unlike the first time.

Can you take a look at this @karljakoblarsson and test if this solves the issues
