### PR TITLE
chore: consistent texts in LS action menu

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/LayersTabActionsMenu.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayersTabActionsMenu.js
@@ -72,7 +72,7 @@ const LayersTabActionsMenu = ({ scrollToTop, scrollToBottom }) => {
           <ListItemIcon>
             <VisibilityOffIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Släck alla lager</ListItemText>
+          <ListItemText>Dölj alla aktiva lager</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={(e) => {
@@ -85,7 +85,7 @@ const LayersTabActionsMenu = ({ scrollToTop, scrollToBottom }) => {
           <ListItemIcon>
             <KeyboardDoubleArrowUpIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>Skrolla till toppen</ListItemText>
+          <ListItemText>Scrolla till toppen</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={(e) => {


### PR DESCRIPTION
Title says it all.

We could have a discussion if "scrolla", "skrolla" or "rulla is more correct. SAOL seems to think "skrolla" is correct. https://svenska.se/saol/?sok=scrolla&pz=1 But I will argue that "Scrolla" is the most common.