### PR TITLE
Fixed url param bug from commit f24052cd2dbf5f170e2d125af141616fc108e1ad

### DIFF
--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -502,7 +502,7 @@ class AppModel {
     // sets the real colors based on matching the name.
     const whiteLayer = new VectorLayer({
       visible: false,
-      source: null,
+      source: new VectorSource(),
       zIndex: -1,
       layerType: "base",
       rotateMap: "n",
@@ -527,7 +527,7 @@ class AppModel {
     // sets the real colors based on matching the name.
     const blackLayer = new VectorLayer({
       visible: false,
-      source: null,
+      source: new VectorSource(),
       zIndex: -1,
       layerType: "base",
       rotateMap: "n",

--- a/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.js
@@ -25,7 +25,7 @@ const BackgroundSwitcher = ({
       setSelectedLayerId(backgroundVisibleFromStart.name);
       handleMapBackgroundColor(backgroundVisibleFromStart.name);
     }
-  }, [layers]);
+  }, []);
 
   useEffect(() => {
     // Ensure that BackgroundSwitcher correctly selects visible layer,
@@ -105,7 +105,6 @@ const BackgroundSwitcher = ({
   // If the static layers b/w and osm should be shown last in the bg-layer list
   // reorder the array to accomodate that.
   if (renderSpecialBackgroundsAtBottom) {
-    console.log("rendering at bottom");
     const staticLayersRange = ["-1", "-2", "-3"];
     const staticLayersToMove = layersToShow.filter((layer) =>
       staticLayersRange.includes(layer.name)


### PR DESCRIPTION
Discovered that a bug was introduced from the previous fix for issue 1649.
The url params was updated correctly for backgroundlayers, but normal layers and layergroups were not being added when the layer/layergroups were toggled on/off. Except when a map change was triggered my ex zoom-in/out.

- Solved url parameter bug by giving b/w vectorlayers a source in appmodel.
- Removed unused console.log
- Removed useEffect dep in BackgroundSwitcher since we only want the effect to run once on component mount to set the correct background color.