### PR TITLE
Fix for QuickAccess to not render when config says it should't.

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessView.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessView.js
@@ -41,6 +41,7 @@ const QuickAccessView = ({
   const qaLayers = Object.values(layersState).filter((obj) => obj.quickAccess);
   const hasVisibleLayers = qaLayers.some((l) => l.visible);
 
+  const showQuickAccess = show || false;
   const [quickAccessSectionExpanded, setQuickAccessSectionExpanded] =
     useState(false);
 
@@ -77,123 +78,125 @@ const QuickAccessView = ({
   };
 
   return (
-    <Box
-      sx={(theme) => ({
-        borderBottom: `${theme.spacing(quickAccessSectionExpanded ? 0.2 : 0.0)} solid ${theme.palette.divider}`,
-      })}
-    >
-      <ListItemButton
-        disableRipple
-        onClick={() => {
-          if (!quickAccessSectionExpanded && qaLayers?.length === 0) {
-            return;
-          }
-          setQuickAccessSectionExpanded(!quickAccessSectionExpanded);
-        }}
+    showQuickAccess && (
+      <Box
         sx={(theme) => ({
-          p: 0,
-          borderBottom: `${theme.spacing(0.2)} solid ${theme.palette.divider}`,
+          borderBottom: `${theme.spacing(quickAccessSectionExpanded ? 0.2 : 0.0)} solid ${theme.palette.divider}`,
         })}
-        dense
       >
-        <LsIconButton
-          size="small"
-          sx={[
-            {
-              pr: 0,
-            },
-            qaLayers?.length > 0
-              ? {
-                  visibility: "visible",
-                }
-              : {
-                  visibility: "hidden",
-                },
-          ]}
+        <ListItemButton
           disableRipple
-        >
-          <KeyboardArrowRightOutlinedIcon
-            style={{
-              transform: quickAccessSectionExpanded ? "rotate(90deg)" : "",
-              transition: "transform 300ms ease",
-            }}
-          ></KeyboardArrowRightOutlinedIcon>
-        </LsIconButton>
-        <Box
-          sx={{
-            display: "flex",
-            position: "relative",
-            width: "100%",
-            alignItems: "center",
-            py: 0.5,
-            pr: 1,
+          onClick={() => {
+            if (!quickAccessSectionExpanded && qaLayers?.length === 0) {
+              return;
+            }
+            setQuickAccessSectionExpanded(!quickAccessSectionExpanded);
           }}
+          sx={(theme) => ({
+            p: 0,
+            borderBottom: `${theme.spacing(0.2)} solid ${theme.palette.divider}`,
+          })}
+          dense
         >
-          <LsIconButton sx={{ pl: 0 }} disableRipple size="small">
-            <StarOutlineOutlinedIcon />
-          </LsIconButton>
-
-          <ListItemText
-            primary="Snabbåtkomst"
-            slotProps={{
-              primary: {
-                variant: "body1",
-                fontWeight: hasVisibleLayers ? "bold" : "inherit",
+          <LsIconButton
+            size="small"
+            sx={[
+              {
+                pr: 0,
               },
+              qaLayers?.length > 0
+                ? {
+                    visibility: "visible",
+                  }
+                : {
+                    visibility: "hidden",
+                  },
+            ]}
+            disableRipple
+          >
+            <KeyboardArrowRightOutlinedIcon
+              style={{
+                transform: quickAccessSectionExpanded ? "rotate(90deg)" : "",
+                transition: "transform 300ms ease",
+              }}
+            ></KeyboardArrowRightOutlinedIcon>
+          </LsIconButton>
+          <Box
+            sx={{
+              display: "flex",
+              position: "relative",
+              width: "100%",
+              alignItems: "center",
+              py: 0.5,
+              pr: 1,
             }}
-          />
+          >
+            <LsIconButton sx={{ pl: 0 }} disableRipple size="small">
+              <StarOutlineOutlinedIcon />
+            </LsIconButton>
 
-          <ListItemSecondaryAction sx={{ right: "4px" }}>
-            {enableQuickAccessPresets && (
-              <HajkTooltip title="Teman">
-                <LsIconButton onClick={handleQuickAccessPresetsToggle}>
-                  <TopicOutlinedIcon fontSize="small"></TopicOutlinedIcon>
-                </LsIconButton>
-              </HajkTooltip>
-            )}
-            {enableUserQuickAccessFavorites && (
-              <Favorites
-                favoriteViewDisplay={favoritesViewDisplay}
-                app={app}
-                map={map}
-                handleFavoritesViewToggle={handleFavoritesViewToggle}
-                globalObserver={globalObserver}
-                favoritesInfoText={favoritesInfoText}
-                handleQuickAccessSectionExpanded={() => {
-                  setQuickAccessSectionExpanded(true);
-                }}
-              ></Favorites>
-            )}
-            <QuickAccessOptions
-              handleAddLayersToQuickAccess={handleAddLayersToQuickAccess}
-              handleClearQuickAccessLayers={handleShowDeleteConfirmation}
-            ></QuickAccessOptions>
-          </ListItemSecondaryAction>
-        </Box>
-      </ListItemButton>
-      <Collapse in={quickAccessSectionExpanded}>
-        <Box sx={{ marginLeft: "31px" }}>
-          <QuickAccessLayers
-            filterValue={filterValue}
-            map={map}
-            globalObserver={globalObserver}
-            layersState={layersState}
-            staticLayerConfig={staticLayerConfig}
-          ></QuickAccessLayers>
-        </Box>
-      </Collapse>
-      <ConfirmationDialog
-        open={showDeleteConfirmation === true}
-        titleName="Rensa allt"
-        contentDescription="Alla lager i snabbåtkomst kommer nu att tas bort."
-        cancel="Avbryt"
-        confirm="Rensa"
-        handleConfirm={handleClearQuickAccessLayers}
-        handleAbort={() => {
-          setShowDeleteConfirmation(false);
-        }}
-      />
-    </Box>
+            <ListItemText
+              primary="Snabbåtkomst"
+              slotProps={{
+                primary: {
+                  variant: "body1",
+                  fontWeight: hasVisibleLayers ? "bold" : "inherit",
+                },
+              }}
+            />
+
+            <ListItemSecondaryAction sx={{ right: "4px" }}>
+              {enableQuickAccessPresets && (
+                <HajkTooltip title="Teman">
+                  <LsIconButton onClick={handleQuickAccessPresetsToggle}>
+                    <TopicOutlinedIcon fontSize="small"></TopicOutlinedIcon>
+                  </LsIconButton>
+                </HajkTooltip>
+              )}
+              {enableUserQuickAccessFavorites && (
+                <Favorites
+                  favoriteViewDisplay={favoritesViewDisplay}
+                  app={app}
+                  map={map}
+                  handleFavoritesViewToggle={handleFavoritesViewToggle}
+                  globalObserver={globalObserver}
+                  favoritesInfoText={favoritesInfoText}
+                  handleQuickAccessSectionExpanded={() => {
+                    setQuickAccessSectionExpanded(true);
+                  }}
+                ></Favorites>
+              )}
+              <QuickAccessOptions
+                handleAddLayersToQuickAccess={handleAddLayersToQuickAccess}
+                handleClearQuickAccessLayers={handleShowDeleteConfirmation}
+              ></QuickAccessOptions>
+            </ListItemSecondaryAction>
+          </Box>
+        </ListItemButton>
+        <Collapse in={quickAccessSectionExpanded}>
+          <Box sx={{ marginLeft: "31px" }}>
+            <QuickAccessLayers
+              filterValue={filterValue}
+              map={map}
+              globalObserver={globalObserver}
+              layersState={layersState}
+              staticLayerConfig={staticLayerConfig}
+            ></QuickAccessLayers>
+          </Box>
+        </Collapse>
+        <ConfirmationDialog
+          open={showDeleteConfirmation === true}
+          titleName="Rensa allt"
+          contentDescription="Alla lager i snabbåtkomst kommer nu att tas bort."
+          cancel="Avbryt"
+          confirm="Rensa"
+          handleConfirm={handleClearQuickAccessLayers}
+          handleAbort={() => {
+            setShowDeleteConfirmation(false);
+          }}
+        />
+      </Box>
+    )
   );
 };
 


### PR DESCRIPTION
If I understood #1688 correctly, this should fix the admin option to not show the QuickAccess and pass the "show" prop along and conditionally render the QuickAccessView component or not.

Maybe it's better to conditionally render the whole component in LayersTab.