### PR TITLE
Fix/layerswitcher legacy info

### DIFF
--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherView.js
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherView.js
@@ -11,6 +11,7 @@ import BreadCrumbs from "./components/BreadCrumbs.js";
 import DrawOrder from "./components/DrawOrder.js";
 import QuickAccessPresets from "./components/QuickAccessPresets.js";
 import LayerItemDetails from "./components/LayerItemDetails.js";
+import GroupDetails from "./components/GroupDetails.js";
 
 const StyledAppBar = styled(AppBar)(() => ({
   zIndex: "1",
@@ -69,6 +70,7 @@ class LayersSwitcherView extends React.PureComponent {
       activeTab: 0,
       displayContentOverlay: null, // 'quickAccessPresets' | 'favorites' | 'layerItemDetails'
       layerItemDetails: null,
+      groupDetails: null,
       scrollPositions: {
         tab0: 0,
         tab1: 0,
@@ -102,25 +104,36 @@ class LayersSwitcherView extends React.PureComponent {
         const currentScrollPosition = this.getScrollPosition();
 
         const layerId = payload.layerId;
-        if (!layerId) {
+        if (layerId) {
+          const layer = this.olLayerMap[layerId];
+
+          // Set scroll position state when layer details is opened
+          const details = {
+            layer,
+            subLayerIndex: payload.subLayerIndex,
+          };
+          this.setState((prevState) => ({
+            layerItemDetails: details,
+            groupDetails: null,
+            displayContentOverlay: "layerItemDetails",
+            scrollPositions: {
+              ...prevState.scrollPositions,
+              [`tab${prevState.activeTab}`]: currentScrollPosition,
+            },
+          }));
+        } else if (payload.infogrouptitle) {
+          this.setState((prevState) => ({
+            layerItemDetails: null,
+            groupDetails: payload,
+            displayContentOverlay: "groupDetails",
+            scrollPositions: {
+              ...prevState.scrollPositions,
+              [`tab${prevState.activeTab}`]: currentScrollPosition,
+            },
+          }));
+        } else {
           return;
         }
-
-        const layer = this.olLayerMap[layerId];
-
-        // Set scroll position state when layer details is opened
-        const details = {
-          layer,
-          subLayerIndex: payload.subLayerIndex,
-        };
-        this.setState((prevState) => ({
-          layerItemDetails: details,
-          displayContentOverlay: "layerItemDetails",
-          scrollPositions: {
-            ...prevState.scrollPositions,
-            [`tab${prevState.activeTab}`]: currentScrollPosition,
-          },
-        }));
       } else {
         this.setState({
           displayContentOverlay: null,
@@ -317,6 +330,11 @@ class LayersSwitcherView extends React.PureComponent {
           showOpacitySlider={this.props.options.enableTransparencySlider}
           showQuickAccess={this.props.options.showQuickAccess}
         ></LayerItemDetails>
+        <GroupDetails
+          display={this.state.displayContentOverlay === "groupDetails"}
+          groupDetails={this.state.groupDetails}
+          app={this.props.app}
+        ></GroupDetails>
         <BackgroundSwitcher
           display={
             this.state.activeTab === 1 &&

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { Box, Typography, Stack } from "@mui/material";
+
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import HajkToolTip from "components/HajkToolTip";
+import LsIconButton from "./LsIconButton";
+
+function GroupDetails({ display, groupDetails, app }) {
+  // Because of a warning in dev console, we need special handling of tooltip for backbutton.
+  // When a user clicks back, the tooltip of the button needs to be closed before this view hides.
+  // TODO: Needs a better way to handle this
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  // Handles click on back button in header
+  const handleBackButtonClick = () => {
+    setTooltipOpen(false);
+    setTimeout(() => {
+      app.globalObserver.publish("setLayerDetails", null);
+    }, 100);
+  };
+
+  // Handles backbutton tooltip close event
+  const handleClose = () => {
+    setTooltipOpen(false);
+  };
+
+  // Handles backbutton tooltip open event
+  const handleOpen = () => {
+    setTooltipOpen(true);
+  };
+
+  return (
+    <>
+      {groupDetails && display && (
+        <Box
+          sx={(theme) => ({
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "#fff",
+            position: "relative",
+            overflowY: "auto",
+            height: "inherit",
+            minHeight: "15em",
+            maxHeight: "inherit",
+            ...theme.applyStyles("dark", {
+              backgroundColor: "rgb(18,18,18)",
+            }),
+          })}
+        >
+          <Box
+            sx={(theme) => ({
+              p: 1,
+              backgroundColor: theme.palette.grey[100],
+              borderBottom: `${theme.spacing(0.2)} solid ${theme.palette.divider}`,
+              ...theme.applyStyles("dark", {
+                backgroundColor: "#373737",
+              }),
+            })}
+          >
+            <Stack direction="row" alignItems="center">
+              <HajkToolTip
+                open={tooltipOpen}
+                onClose={handleClose}
+                onOpen={handleOpen}
+                title="Tillbaka"
+                TransitionProps={{ timeout: 0 }}
+              >
+                <LsIconButton onClick={handleBackButtonClick}>
+                  <ArrowBackIcon />
+                </LsIconButton>
+              </HajkToolTip>
+              <Box sx={{ flexGrow: 1, textAlign: "center" }}>
+                <Typography variant="subtitle1">
+                  {groupDetails.infogroupname}
+                </Typography>
+              </Box>
+            </Stack>
+          </Box>
+          <Box
+            sx={{
+              p: 1,
+            }}
+          >
+            <Typography variant="subtitle1">
+              {groupDetails.infogrouptitle}
+            </Typography>
+            <Typography>{groupDetails.infogrouptext}</Typography>
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+}
+
+export default GroupDetails;

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
@@ -83,10 +83,12 @@ function GroupDetails({ display, groupDetails, app }) {
               p: 1,
             }}
           >
-            <Typography variant="subtitle1">
+            <Typography style={{ marginBottom: "4px" }}>
               {groupDetails.infogrouptitle}
             </Typography>
-            <Typography>{groupDetails.infogrouptext}</Typography>
+            <Typography variant="body2">
+              {groupDetails.infogrouptext}
+            </Typography>
           </Box>
         </Box>
       )}

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
@@ -7,9 +7,12 @@ import {
   List,
   ListItem,
   ListItemText,
+  ListItemIcon,
 } from "@mui/material";
 
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import LinkIcon from "@mui/icons-material/Link";
+import VerifiedUserIcon from "@mui/icons-material/VerifiedUser";
 import HajkToolTip from "components/HajkToolTip";
 import LsIconButton from "./LsIconButton";
 
@@ -98,23 +101,37 @@ function GroupDetails({ display, groupDetails, app }) {
               {groupDetails.infogrouptext}
             </Typography>
             <List>
-              <ListItem>
-                <Link href={groupDetails.infogroupurl}>
-                  {groupDetails.infogroupurltext}
-                </Link>
-              </ListItem>
-              <ListItem>
-                <Link href={groupDetails.infogroupopendatalink}>
-                  Öppna data
-                </Link>
-                {/* <ListItemText
-                    primary="Single-line item"
-                    secondary={secondary ? 'Secondary text' : null}
-                  /> */}
-              </ListItem>
-              <ListItem>
-                <ListItemText primary={groupDetails.infogroupowner} />
-              </ListItem>
+              {groupDetails.infogroupurl && (
+                <ListItem>
+                  <ListItemIcon>
+                    <LinkIcon />
+                  </ListItemIcon>
+                  <Link href={groupDetails.infogroupurl} color="inherit">
+                    {groupDetails.infogroupurltext}
+                  </Link>
+                </ListItem>
+              )}
+              {groupDetails.infogroupopendatalink && (
+                <ListItem>
+                  <ListItemIcon>
+                    <LinkIcon />
+                  </ListItemIcon>
+                  <Link
+                    href={groupDetails.infogroupopendatalink}
+                    color="inherit"
+                  >
+                    Öppna data
+                  </Link>
+                </ListItem>
+              )}
+              {groupDetails.infogroupowner && (
+                <ListItem>
+                  <ListItemIcon>
+                    <VerifiedUserIcon />
+                  </ListItemIcon>
+                  <ListItemText primary={groupDetails.infogroupowner} />
+                </ListItem>
+              )}
             </List>
           </Box>
         </Box>

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupDetails.js
@@ -1,5 +1,13 @@
 import React, { useState } from "react";
-import { Box, Typography, Stack } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Stack,
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
 
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import HajkToolTip from "components/HajkToolTip";
@@ -89,6 +97,25 @@ function GroupDetails({ display, groupDetails, app }) {
             <Typography variant="body2">
               {groupDetails.infogrouptext}
             </Typography>
+            <List>
+              <ListItem>
+                <Link href={groupDetails.infogroupurl}>
+                  {groupDetails.infogroupurltext}
+                </Link>
+              </ListItem>
+              <ListItem>
+                <Link href={groupDetails.infogroupopendatalink}>
+                  Öppna data
+                </Link>
+                {/* <ListItemText
+                    primary="Single-line item"
+                    secondary={secondary ? 'Secondary text' : null}
+                  /> */}
+              </ListItem>
+              <ListItem>
+                <ListItemText primary={groupDetails.infogroupowner} />
+              </ListItem>
+            </List>
           </Box>
         </Box>
       )}

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -11,6 +11,7 @@ import LsCheckBox from "./LsCheckBox";
 
 import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
 import { getIsMobile } from "../LayerSwitcherUtils";
+import BtnShowDetails from "./BtnShowDetails";
 
 /**
  * If Group has "toggleable" property enabled, render the toggle all checkbox.
@@ -32,61 +33,9 @@ const ToggleAllComponent = ({ toggleable, toggleState, clickHandler }) => {
   );
 };
 
-const GroupInfoDetails = ({
-  name,
-  infoVisible,
-  infogrouptitle = "",
-  infogrouptext = "",
-  infogroupurl = "",
-  infogroupurltext = "",
-  infogroupopendatalink = "",
-  infogroupowner = "",
-}) => {
-  if (!infoVisible) {
-    return null;
-  }
-  return (
-    <div>
-      {infogrouptitle && (
-        <Typography variant="subtitle2">{infogrouptitle}</Typography>
-      )}
-      {infogrouptext && (
-        <Typography
-          variant="body2"
-          dangerouslySetInnerHTML={{ __html: infogrouptext }}
-        ></Typography>
-      )}
-      {infogroupurl && (
-        <Typography variant="body2" sx={{ fontWeight: 500, mt: 1, mb: 1 }}>
-          <Link href={infogroupurl || null} target="_blank" rel="noreferrer">
-            {infogroupurltext}
-          </Link>
-        </Typography>
-      )}
-      {infogroupopendatalink && (
-        <Typography variant="body2" sx={{ fontWeight: 500, mt: 1, mb: 1 }}>
-          <Link
-            href={infogroupopendatalink || null}
-            target="_blank"
-            rel="noreferrer"
-          >
-            Öppna data: {name}
-          </Link>
-        </Typography>
-      )}
-      {infogroupowner && (
-        <Typography
-          variant="body2"
-          dangerouslySetInnerHTML={{ __html: infogroupowner }}
-        ></Typography>
-      )}
-    </div>
-  );
-};
-
 const GroupInfoToggler = ({
-  clickHandler,
-  infoVisible,
+  globalObserver,
+  infogroupname = "",
   infogrouptitle = "",
   infogrouptext = "",
   infogroupurl = "",
@@ -106,29 +55,21 @@ const GroupInfoToggler = ({
   ) {
     return null;
   }
-  // Render icons only if one of the states above has a value
+  // If any of the above variables arent mising, render the show details button
   return (
-    <HajkToolTip title="Mer information om gruppen" placement="left">
-      <LsIconButton
-        size="small"
-        sx={{
-          p: 0.25,
-          mt: "1px",
-          mr: "5px",
-          "& .MuiTouchRipple-root": { display: "none" },
-        }}
-        onClick={(e) => {
-          e.stopPropagation();
-          clickHandler();
-        }}
-      >
-        {infoVisible ? (
-          <RemoveCircleIcon fontSize="small" />
-        ) : (
-          <InfoIcon fontSize="small" />
-        )}
-      </LsIconButton>
-    </HajkToolTip>
+    <BtnShowDetails
+      onClick={() => {
+        globalObserver.publish("setLayerDetails", {
+          infogroupname,
+          infogrouptitle,
+          infogrouptext,
+          infogroupurl,
+          infogroupurltext,
+          infogroupopendatalink,
+          infogroupowner,
+        });
+      }}
+    />
   );
 };
 
@@ -199,10 +140,6 @@ const LayerGroup = ({
   const isToggled = hasAllLayersVisible;
   const isSemiToggled = hasVisibleLayer && !hasAllLayersVisible;
 
-  const toggleInfo = () => {
-    setInfoVisible(!infoVisible);
-  };
-
   // TODO Refactor the expand close to state
   let groupsExpanded = false;
   // if (subGroups?.length === 1 && subGroups[0].expanded) {
@@ -216,37 +153,28 @@ const LayerGroup = ({
       : "unchecked";
 
   return (
-    <LayerGroupAccordion
-      display={groupIsFiltered ? "none" : "block"}
-      toggleable={groupIsToggable}
-      expanded={filterActiveAndHasHits || groupIsExpanded}
-      toggleDetails={
-        <ToggleAllComponent
-          toggleable={groupIsToggable}
-          toggleState={toggleState}
-          clickHandler={() => {
-            if (isToggled) {
-              layerSwitcherDispatch.setGroupVisibility(groupId, false);
-            } else {
-              layerSwitcherDispatch.setGroupVisibility(groupId, true);
-            }
-          }}
-        />
-      }
-      layerGroupTitle={
-        <div>
-          <div style={{ display: "flex", flexDirection: "row" }}>
-            <GroupInfoToggler
-              clickHandler={() => toggleInfo()}
-              infoVisible={infoVisible}
-              infogrouptitle={infogrouptitle}
-              infogrouptext={infogrouptext}
-              infogroupurl={infogroupurl}
-              infogroupurltext={infogroupurltext}
-              infogroupopendatalink={infogroupopendatalink}
-              infogroupowner={infogroupowner}
-            />
+    <div>
+      <LayerGroupAccordion
+        display={groupIsFiltered ? "none" : "block"}
+        toggleable={groupIsToggable}
+        expanded={filterActiveAndHasHits || groupIsExpanded}
+        toggleDetails={
+          <ToggleAllComponent
+            toggleable={groupIsToggable}
+            toggleState={toggleState}
+            clickHandler={() => {
+              if (isToggled) {
+                layerSwitcherDispatch.setGroupVisibility(groupId, false);
+              } else {
+                layerSwitcherDispatch.setGroupVisibility(groupId, true);
+              }
+            }}
+          />
+        }
+        layerGroupTitle={
+          <div style={{ width: "100%", display: "flex", flexDirection: "row" }}>
             <ListItemText
+              style={{ flex: 1 }}
               primary={name}
               slotProps={{
                 primary: {
@@ -258,79 +186,80 @@ const LayerGroup = ({
                 },
               }}
             />
+            <GroupInfoToggler
+              globalObserver={globalObserver}
+              infoVisible={infoVisible}
+              infogroupname={groupName}
+              infogrouptitle={infogrouptitle}
+              infogrouptext={infogrouptext}
+              infogroupurl={infogroupurl}
+              infogroupurltext={infogroupurltext}
+              infogroupopendatalink={infogroupopendatalink}
+              infogroupowner={infogroupowner}
+            />
           </div>
-          <GroupInfoDetails
-            name={groupName}
-            infoVisible={infoVisible}
-            infogrouptitle={infogrouptitle}
-            infogrouptext={infogrouptext}
-            infogroupurl={infogroupurl}
-            infogroupurltext={infogroupurltext}
-            infogroupopendatalink={infogroupopendatalink}
-            infogroupowner={infogroupowner}
-          />
-        </div>
-      }
-    >
-      <div>
-        {children?.map((child) => {
-          const layerId = child.id;
+        }
+      >
+        <div>
+          {children?.map((child) => {
+            const layerId = child.id;
 
-          const layerState = layersState[layerId];
+            const layerState = layersState[layerId];
 
-          const layerSettings = staticLayerConfig[layerId];
-          if (!layerSettings) {
-            return null;
-          }
+            const layerSettings = staticLayerConfig[layerId];
+            if (!layerSettings) {
+              return null;
+            }
 
-          if (layerSettings.layerType === "group") {
-            // The LayerGroup components check the filter to see if it should
-            // display itself or not. So we always have to render it regardless
-            // of the filter.
-            return (
-              <LayerGroup
-                expanded={groupsExpanded === layerId}
+            if (layerSettings.layerType === "group") {
+              // The LayerGroup components check the filter to see if it should
+              // display itself or not. So we always have to render it regardless
+              // of the filter.
+              return (
+                <LayerGroup
+                  expanded={groupsExpanded === layerId}
+                  key={layerId}
+                  globalObserver={globalObserver}
+                  staticLayerConfig={staticLayerConfig}
+                  staticGroupTree={children?.find((g) => g?.id === layerId)}
+                  layersState={layersState}
+                  filterHits={filterHits}
+                  filterValue={filterValue}
+                />
+              );
+            }
+
+            if (filterHits && !filterHits.has(layerId)) {
+              // The filter is active and this layer is not a hit.
+              return null;
+            }
+
+            return layerSettings.layerType === "groupLayer" ? (
+              <GroupLayer
                 key={layerId}
+                layerState={layerState}
+                layerConfig={layerSettings}
+                draggable={false}
+                toggleable={true}
                 globalObserver={globalObserver}
-                staticLayerConfig={staticLayerConfig}
-                staticGroupTree={children?.find((g) => g?.id === layerId)}
-                layersState={layersState}
                 filterHits={filterHits}
                 filterValue={filterValue}
               />
+            ) : (
+              <LayerItem
+                key={layerId}
+                layerState={layerState}
+                layerConfig={layerSettings}
+                draggable={false}
+                toggleable={true}
+                globalObserver={globalObserver}
+                filterValue={filterValue}
+              />
             );
-          }
-
-          if (filterHits && !filterHits.has(layerId)) {
-            // The filter is active and this layer is not a hit.
-            return null;
-          }
-
-          return layerSettings.layerType === "groupLayer" ? (
-            <GroupLayer
-              key={layerId}
-              layerState={layerState}
-              layerConfig={layerSettings}
-              draggable={false}
-              toggleable={true}
-              globalObserver={globalObserver}
-              filterHits={filterHits}
-              filterValue={filterValue}
-            />
-          ) : (
-            <LayerItem
-              key={layerId}
-              layerState={layerState}
-              layerConfig={layerSettings}
-              draggable={false}
-              toggleable={true}
-              globalObserver={globalObserver}
-              filterValue={filterValue}
-            />
-          );
-        })}
-      </div>
-    </LayerGroupAccordion>
+          })}
+        </div>
+      </LayerGroupAccordion>
+    </div>
   );
 };
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.js
@@ -58,7 +58,8 @@ const GroupInfoToggler = ({
   // If any of the above variables arent mising, render the show details button
   return (
     <BtnShowDetails
-      onClick={() => {
+      onClick={(e) => {
+        e.stopPropagation();
         globalObserver.publish("setLayerDetails", {
           infogroupname,
           infogrouptitle,


### PR DESCRIPTION
Fix for #1643 to use a new info component similar to LayerItemInfo.

Discovered that "infogroupowner" is not present in the config even if set on a group in the admin-ui, but should probably be it's own issue.

<img width="318" height="325" alt="Screenshot from 2025-09-18 21-00-35" src="https://github.com/user-attachments/assets/fbad484b-9cfe-41f8-abed-54d9e97242a5" />
