### PR TITLE
Closes #1788

### DIFF
--- a/apps/client/src/components/Drawer/DrawerToggleButtons.jsx
+++ b/apps/client/src/components/Drawer/DrawerToggleButtons.jsx
@@ -110,14 +110,8 @@ function DrawerToggleButtons({
     );
   };
 
-  // Check if all buttons are hidden on md screens and above.
-  const areAllButtonsHiddenOnMdAndAbove = drawerButtons.every(
-    (b) => b.hideOnMdScreensAndAbove
-  );
-
   return (
-    drawerButtons.length > 0 &&
-    !areAllButtonsHiddenOnMdAndAbove && (
+    drawerButtons.length > 0 && (
       <StyledPaper>
         <StyledToggleButtonGroup
           id="drawer-toggle-button-group"

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -230,12 +230,14 @@ class AppModel {
    * have a way to determine whether the Drawer toggle button should be
    * rendered. It's not as easy as checking for Drawer plugins only (i.e.
    * those with target=toolbar) - this simple logic gets complicated by
-   * the fact that Widget plugins (target=left|right) also render Drawer
-   * buttons on small screens.
+   * the fact that Widget plugins (target=left|right) and Control buttons (target=control)
+   * also render Drawer buttons on small screens.
    */
   getPluginsThatMightRenderInDrawer() {
     return this.getPlugins().filter((plugin) => {
-      return ["toolbar", "left", "right"].includes(plugin.options.target);
+      return ["toolbar", "left", "right", "control"].includes(
+        plugin.options.target
+      );
     });
   }
 

--- a/apps/client/src/plugins/BaseWindowPlugin.jsx
+++ b/apps/client/src/plugins/BaseWindowPlugin.jsx
@@ -109,6 +109,10 @@ class BaseWindowPlugin extends React.PureComponent {
     return ["left", "right"].includes(target);
   }
 
+  pluginIsControlButton(target) {
+    return target === "control";
+  }
+
   handleButtonClick = (e) => {
     this.showWindow({
       hideOtherPluginWindows: true,
@@ -263,7 +267,7 @@ class BaseWindowPlugin extends React.PureComponent {
    * but it will also render Widget and Control plugins - given some special condition.
    *
    * Those special conditions are small screens, where there's no screen
-   * estate to render the Widget button in Map Overlay.
+   * estate to render the Widget or Control button in Map Overlay.
    */
   renderDrawerButton() {
     return createPortal(
@@ -271,7 +275,7 @@ class BaseWindowPlugin extends React.PureComponent {
         sx={{
           display:
             this.pluginIsWidget(this.props.options.target) ||
-            this.props.options.target === "control"
+            this.pluginIsControlButton(this.props.options.target)
               ? { xs: "block", md: "none" }
               : "initial",
         }}
@@ -310,18 +314,14 @@ class BaseWindowPlugin extends React.PureComponent {
   }
 
   renderControlButton() {
-    // Special case: if there are no plugins with target "toolbar", we want to render the Control button on small screens
-    const hasToolbarTarget = this.props.app.config.mapConfig.tools.filter(
-      (tool) => tool.options && tool.options.target === "toolbar"
-    );
-
+    // Control buttons should only be rendered as control buttons on md+ screens.
+    // On xs screens they should be rendered as drawer buttons (check renderDrawerButton for more details)
     return createPortal(
-      // Hide Control button on small screens, see renderDrawerButton too
       <Box
         sx={{
           display: {
             xs: "none",
-            md: hasToolbarTarget.length > 0 ? "block" : "none",
+            md: "block",
           },
         }}
       >


### PR DESCRIPTION
Fixes missing control buttons on md+ screens when no tools with `taget="toolbar"` is present