### PR TITLE
Fixes visibility toggle on drag-n-dropped `kml` and `gpx` files

### DIFF
--- a/apps/client/src/models/GpxModel.js
+++ b/apps/client/src/models/GpxModel.js
@@ -27,6 +27,7 @@ class GpxModel {
   #map;
   #layerName;
   #drawModel;
+  #observer;
   #gpxSource;
   #gpxLayer;
   #parser;
@@ -42,7 +43,7 @@ class GpxModel {
     this.#map = settings.map;
     this.#layerName = settings.layerName;
     this.#drawModel = settings.drawModel || null;
-
+    this.#observer = settings.observer || null;
     // If a setting to enable drag-and-drop has been passed, we have to initiate
     // the listeners for that.
     settings.enableDragAndDrop && this.#addMapDropListeners();
@@ -120,6 +121,11 @@ class GpxModel {
         zoomToExtent: true,
         setProperties: { GPX_ID: id },
       });
+      // We also want to publish an event on the observer so that we can update potential views.
+      this.#observer &&
+        this.#observer.publish("gpxModel.fileImported", {
+          id,
+        });
     };
     reader.readAsText(file);
   };

--- a/apps/client/src/plugins/Sketch/views/SketchView.jsx
+++ b/apps/client/src/plugins/Sketch/views/SketchView.jsx
@@ -26,6 +26,12 @@ import { useSnackbar } from "notistack";
 import { Vector as VectorSource } from "ol/source";
 import { Vector as VectorLayer } from "ol/layer";
 
+// Beware! In the view we only use kml and gpx, even if the actual file type might be application/vnd.google-earth.kml+xml or application/gpx+xml etc.
+const FILE_TYPES = {
+  KML: "kml",
+  GPX: "gpx",
+};
+
 // The SketchView is the main view for the Sketch-plugin.
 const SketchView = (props) => {
   // We want to render the ActivityMenu on the same side as the plugin
@@ -166,14 +172,15 @@ const SketchView = (props) => {
     [model, removedFeatures]
   );
 
-  // Handles when a kml-file has been added to the map via the drag-and-drop
+  // Handles when a kml/gpx-file has been added to the map via the drag-and-drop
   // functionality. Makes sure to update the state containing the uploaded files.
-  const handleKmlFileImported = React.useCallback(
-    ({ id }) => {
+  const handleFileImported = React.useCallback(
+    (id, type) => {
       setUploadedFiles((files) => [
         ...files,
         {
           id,
+          type,
           title: model.getDateTimeString({
             hour: "numeric",
             minute: "numeric",
@@ -244,12 +251,18 @@ const SketchView = (props) => {
     localObserver.subscribe("drawModel.featureRemoved", handleFeatureRemoved);
     localObserver.subscribe("drawModel.featuresRemoved", handleFeaturesRemoved);
     localObserver.subscribe("drawModel.featureAdded", handleFeatureAdded);
-    localObserver.subscribe("kmlModel.fileImported", handleKmlFileImported);
+    localObserver.subscribe("kmlModel.fileImported", ({ id }) =>
+      handleFileImported(id, FILE_TYPES.KML)
+    );
+    localObserver.subscribe("gpxModel.fileImported", ({ id }) =>
+      handleFileImported(id, FILE_TYPES.GPX)
+    );
     return () => {
       localObserver.unsubscribe("drawModel.featureRemoved");
       localObserver.unsubscribe("drawModel.featuresRemoved");
       localObserver.unsubscribe("drawModel.featureAdded");
       localObserver.unsubscribe("kmlModel.fileImported");
+      localObserver.unsubscribe("gpxModel.fileImported");
     };
   }, [
     activityId,
@@ -257,7 +270,7 @@ const SketchView = (props) => {
     handleFeatureRemoved,
     handleFeaturesRemoved,
     handleFeatureAdded,
-    handleKmlFileImported,
+    handleFileImported,
   ]);
 
   /* State object for the buffer sketch component


### PR DESCRIPTION
When drag and dropping files we we're not able to toggle the visibility of the imported files. 

Added a fix so that both `kml` and `gpx` files can be toggled.

<img width="429" height="556" alt="Screenshot 2026-04-13 at 09 32 09" src="https://github.com/user-attachments/assets/78011568-5e59-46f1-bf96-ebdf1fba2a1e" />
