### PR TITLE
Add `referrer` meta tag (`strict-origin-when-cross-origin`)

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -18,6 +18,7 @@
       name="%VITE_APP_NAME%-use-cache-buster"
       content="%VITE_APP_USE_CACHE_BUSTER%"
     />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="apple-touch-icon" href="/logo192.png" />


### PR DESCRIPTION
We've been getting reports on OSM sending error tiles on some browsers when this tag is missing.