### PR TITLE
Feature/toggle label layer

### DIFF
--- a/apps/client/src/models/layers/LayerInfo.js
+++ b/apps/client/src/models/layers/LayerInfo.js
@@ -30,5 +30,6 @@ export default class LayerInfo {
     this.layerType = properties.layerType;
     this.hideExpandArrow = properties.hideExpandArrow;
     this.showAttributeTableButton = properties.showAttributeTableButton;
+    this.hasLabelLayer = properties.hasLabelLayer;
   }
 }

--- a/apps/client/src/models/layers/WMSLayer.jsx
+++ b/apps/client/src/models/layers/WMSLayer.jsx
@@ -18,10 +18,6 @@ class WMSLayer {
     this.attribution = config.attribution;
     this.layerInfo = new LayerInfo(config);
     this.subLayers = config.params["LAYERS"].split(",");
-    this.globalObserver.subscribe(
-      "layer.toggleLabelLayer",
-      this.onToggleLabelLayer
-    );
 
     const source = {
       url: config.url,
@@ -131,20 +127,6 @@ class WMSLayer {
     this.bindHandlers();
   }
 
-  onToggleLabelLayer = ({ layerId }) => {
-    if (layerId !== this.layer.get("name")) return;
-    console.log(layerId);
-    const source = this.layer.getSource();
-    const params = source.getParams();
-
-    const currentStyles = params.STYLES || "";
-    // The naming convention for our wms label layers are "labels"
-    const isLabelActive = currentStyles === "no_labels";
-
-    source.updateParams({
-      STYLES: isLabelActive ? "" : "no_labels",
-    });
-  };
   applyCustomDpiTileLoader(source, config) {
     // Experimental
     //

--- a/apps/client/src/models/layers/WMSLayer.jsx
+++ b/apps/client/src/models/layers/WMSLayer.jsx
@@ -122,6 +122,7 @@ class WMSLayer {
         : this.subLayers
     );
     this.layer.set("hasLabelLayers", config.hasLabelLayers);
+    this.layer.set("showLabelLayer", false);
     this.layer.getSource().set("url", config.url);
     this.type = "wms";
     this.bindHandlers();

--- a/apps/client/src/models/layers/WMSLayer.jsx
+++ b/apps/client/src/models/layers/WMSLayer.jsx
@@ -18,6 +18,10 @@ class WMSLayer {
     this.attribution = config.attribution;
     this.layerInfo = new LayerInfo(config);
     this.subLayers = config.params["LAYERS"].split(",");
+    this.globalObserver.subscribe(
+      "layer.toggleLabelLayer",
+      this.onToggleLabelLayer
+    );
 
     const source = {
       url: config.url,
@@ -121,11 +125,26 @@ class WMSLayer {
         ? config.visibleAtStartSubLayers
         : this.subLayers
     );
+    this.layer.set("hasLabelLayers", config.hasLabelLayers);
     this.layer.getSource().set("url", config.url);
     this.type = "wms";
     this.bindHandlers();
   }
 
+  onToggleLabelLayer = ({ layerId }) => {
+    if (layerId !== this.layer.get("name")) return;
+    console.log(layerId);
+    const source = this.layer.getSource();
+    const params = source.getParams();
+
+    const currentStyles = params.STYLES || "";
+    // The naming convention for our wms label layers are "labels"
+    const isLabelActive = currentStyles === "no_labels";
+
+    source.updateParams({
+      STYLES: isLabelActive ? "" : "no_labels",
+    });
+  };
   applyCustomDpiTileLoader(source, config) {
     // Experimental
     //

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
@@ -29,6 +29,7 @@ const getOlLayerState = (l) => ({
   visibleSubLayers: l.get("visible") ? l.get("subLayers") : [],
   wmsLoadError: l.get("wmsLoadStatus") ?? undefined,
   zIndex: l.get("zIndex"),
+  hasLabelLayers: l.get("hasLabelLayers"),
   // "filterAttribute"
   // "filterComparer"
   // "filterValue"

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
@@ -336,6 +336,7 @@ const getLayerNodes = (groups, olLayerMap) =>
         infogroupurltext: node.infogroupurltext,
         infogroupopendatalink: node.infogroupopendatalink,
         infogroupowner: node.infogroupowner,
+        olLayer: olLayer,
       },
       ...(children?.length === 0 ? [] : children),
     ];

--- a/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
@@ -3,6 +3,13 @@ import LabelIcon from "@mui/icons-material/LabelImportant";
 import LsIconButton from "./LsIconButton";
 
 function BtnToggleLayerLabel({ active, onClick }) {
+  const iconSx = (theme) => ({
+    width: "0.7em",
+    height: "0.7em",
+    marginTop: "1px",
+    color: theme.palette.grey[500],
+  });
+
   return (
     <LsIconButton
       size="small"
@@ -21,9 +28,9 @@ function BtnToggleLayerLabel({ active, onClick }) {
       }}
     >
       {active ? (
-        <LabelIcon className="ls-details-icon" />
+        <LabelIcon className="ls-details-icon" sx={iconSx} />
       ) : (
-        <LabelOutlinedIcon className="ls-details-icon" />
+        <LabelOutlinedIcon className="ls-details-icon" sx={iconSx} />
       )}
     </LsIconButton>
   );

--- a/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
@@ -1,6 +1,7 @@
 import LabelOutlinedIcon from "@mui/icons-material/LabelImportantOutline";
 import LabelIcon from "@mui/icons-material/LabelImportant";
 import LsIconButton from "./LsIconButton";
+import HajkToolTip from "components/HajkToolTip";
 
 function BtnToggleLayerLabel({ active, onClick }) {
   const iconSx = (theme) => ({
@@ -27,11 +28,13 @@ function BtnToggleLayerLabel({ active, onClick }) {
         onClick?.(e);
       }}
     >
-      {active ? (
-        <LabelIcon className="ls-details-icon" sx={iconSx} />
-      ) : (
-        <LabelOutlinedIcon className="ls-details-icon" sx={iconSx} />
-      )}
+      <HajkToolTip title={active ? "Dölj etiketter" : "Visa etiketter"}>
+        {active ? (
+          <LabelIcon className="ls-details-icon" sx={iconSx} />
+        ) : (
+          <LabelOutlinedIcon className="ls-details-icon" sx={iconSx} />
+        )}
+      </HajkToolTip>
     </LsIconButton>
   );
 }

--- a/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
@@ -5,6 +5,16 @@ import LsIconButton from "./LsIconButton";
 function BtnToggleLayerLabel({ active, onClick }) {
   return (
     <LsIconButton
+      size="small"
+      sx={(theme) => ({
+        marginTop: "3px",
+        "&:hover .ls-details-icon": {
+          color: theme.palette.grey[900],
+          ...theme.applyStyles("dark", {
+            color: "#fff",
+          }),
+        },
+      })}
       onClick={(e) => {
         e.stopPropagation();
         onClick?.(e);

--- a/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BtnToggleLayerLabel.jsx
@@ -1,0 +1,22 @@
+import LabelOutlinedIcon from "@mui/icons-material/LabelImportantOutline";
+import LabelIcon from "@mui/icons-material/LabelImportant";
+import LsIconButton from "./LsIconButton";
+
+function BtnToggleLayerLabel({ active, onClick }) {
+  return (
+    <LsIconButton
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.(e);
+      }}
+    >
+      {active ? (
+        <LabelIcon className="ls-details-icon" />
+      ) : (
+        <LabelOutlinedIcon className="ls-details-icon" />
+      )}
+    </LsIconButton>
+  );
+}
+
+export default BtnToggleLayerLabel;

--- a/apps/client/src/plugins/LayerSwitcher/components/DrawOrder.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/DrawOrder.jsx
@@ -262,6 +262,7 @@ function DrawOrder({ display, app, map, localObserver, options }) {
       numberOfSubLayers: l.subLayers?.length,
       layerInfo: l.get("layerInfo"),
       layerLegendIcon: l.get("legendIcon"),
+      olLayer: l,
     };
     return l.get("layerType") === "base" ? (
       <BackgroundLayer

--- a/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/GroupLayer.jsx
@@ -123,7 +123,6 @@ function GroupLayer({
 
   // Show expand arrow unless hideExpandArrow is set to true
   const showExpandArrow = layerInfo.hideExpandArrow !== true;
-
   return (
     <LayerItem
       display={display}

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -115,10 +115,10 @@ function LayerItem({
 
   const { layerIsToggled } = layerState ?? {};
 
-  // Toggles the state that useEffect picks up to perform the layer change
   const toggleLabelLayer = (e) => {
     e.stopPropagation();
-    setShowingLabelLayer((prev) => !prev);
+    const newValue = !olLayer.get("showLabelLayer");
+    olLayer.set("showLabelLayer", newValue);
   };
 
   const {
@@ -138,40 +138,68 @@ function LayerItem({
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
 
   useEffect(() => {
-    if (!layerIsToggled) {
-      setShowingLabelLayer(false);
-    }
-  }, [layerIsToggled]);
+    if (!olLayer) return;
 
-  // Switches between "*layername*_labels" or last used STYLES if available, otherwise "".
+    // Ensure property exists
+    if (olLayer.get("showLabelLayer") === undefined) {
+      olLayer.set("showLabelLayer", false);
+    }
+
+    const update = () => {
+      setShowingLabelLayer(!!olLayer.get("showLabelLayer"));
+    };
+
+    update();
+
+    olLayer.on("change:showLabelLayer", update);
+
+    return () => {
+      olLayer.un("change:showLabelLayer", update);
+    };
+  }, [olLayer]);
+
   useEffect(() => {
-    if (!olLayer || !layerIsToggled) return;
+    if (!olLayer) return;
 
     const source = olLayer.getSource();
     if (!source) return;
 
-    const currentParams = source.getParams?.() || {};
-    const currentLayerName = currentParams.LAYERS;
+    const updateStyles = () => {
+      const currentParams = source.getParams?.() || {};
+      const currentLayerName = currentParams.LAYERS;
 
-    if (!currentLayerName) return;
+      if (!currentLayerName) return;
 
-    if (showingLabelLayer) {
-      // Save current styles BEFORE overwriting
-      previousStylesRef.current = currentParams.STYLES || "";
+      const isActive = !!olLayer.get("showLabelLayer");
 
-      const labelStyle = `${currentLayerName}_labels`;
+      if (isActive) {
+        // Overwrite if we are not already in label mode
+        if (!currentParams.STYLES?.includes("_labels")) {
+          previousStylesRef.current = currentParams.STYLES || "";
+        }
 
-      source.updateParams({
-        ...currentParams,
-        STYLES: labelStyle,
-      });
-    } else {
-      source.updateParams({
-        ...currentParams,
-        STYLES: previousStylesRef.current || "",
-      });
-    }
-  }, [layerIsToggled, olLayer, showingLabelLayer]);
+        source.updateParams({
+          ...currentParams,
+          STYLES: `${currentLayerName}_labels`,
+        });
+      } else {
+        source.updateParams({
+          ...currentParams,
+          STYLES: previousStylesRef.current || "",
+        });
+      }
+    };
+
+    // run once
+    updateStyles();
+
+    // listen for toggle
+    olLayer.on("change:showLabelLayer", updateStyles);
+
+    return () => {
+      olLayer.un("change:showLabelLayer", updateStyles);
+    };
+  }, [olLayer]);
 
   useEffect(() => {
     const handleLoadStatusChange = (d) => {

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, memo } from "react";
+import { useEffect, useState, memo, useRef } from "react";
 
 // Material UI components
 import {
@@ -107,18 +107,18 @@ function LayerItem({
   const [legendIsActive, setLegendIsActive] = useState(false);
   // Track if the label layer is active
   const [showingLabelLayer, setShowingLabelLayer] = useState(false);
+  // Store the previous STYLES values when toggling labels
+  const previousStylesRef = useRef("");
   const theme = useTheme();
 
   const mapZoom = useMapZoom();
 
   const { layerIsToggled } = layerState ?? {};
 
+  // Toggles the state that useEffect picks up to perform the layer change
   const toggleLabelLayer = (e) => {
     e.stopPropagation();
     setShowingLabelLayer((prev) => !prev);
-    globalObserver.publish("layer.toggleLabelLayer", {
-      layerId,
-    });
   };
 
   const {
@@ -132,6 +132,7 @@ function LayerItem({
     allSubLayers,
     layerInfo,
     layerLegendIcon,
+    olLayer,
   } = layerConfig ?? {};
 
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
@@ -141,6 +142,29 @@ function LayerItem({
       setShowingLabelLayer(false);
     }
   }, [layerIsToggled]);
+
+  // Switches between "labels" or last used STYLES if available, otherwise "".
+  useEffect(() => {
+    if (!olLayer || !layerIsToggled) return;
+
+    const source = olLayer.getSource();
+    if (!source) return;
+
+    const currentParams = source.getParams?.() || {};
+    if (showingLabelLayer) {
+      // Save current styles BEFORE overwriting
+      previousStylesRef.current = currentParams.STYLES || "";
+      source.updateParams({
+        ...currentParams,
+        STYLES: "labels",
+      });
+    } else {
+      source.updateParams({
+        ...currentParams,
+        STYLES: previousStylesRef.current || "",
+      });
+    }
+  }, [layerIsToggled, olLayer, showingLabelLayer]);
 
   useEffect(() => {
     const handleLoadStatusChange = (d) => {

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -137,20 +137,46 @@ function LayerItem({
 
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
 
+  const applyLabelStyle = () => {
+    if (!olLayer) return;
+
+    const source = olLayer.getSource();
+    if (!source) return;
+
+    const currentParams = source.getParams?.() || {};
+    const currentLayerName = currentParams.LAYERS;
+
+    if (!currentLayerName) return;
+
+    const isActive = !!olLayer.get("showLabelLayer");
+
+    if (isActive) {
+      // Save previous style
+      if (!currentParams.STYLES?.includes("_labels")) {
+        previousStylesRef.current = currentParams.STYLES || "";
+      }
+
+      source.updateParams({
+        ...currentParams,
+        STYLES: `${currentLayerName}_labels`,
+      });
+    } else {
+      source.updateParams({
+        ...currentParams,
+        STYLES: previousStylesRef.current || "",
+      });
+    }
+  };
+
   useEffect(() => {
     if (!olLayer) return;
 
-    // Ensure property exists
-    if (olLayer.get("showLabelLayer") === undefined) {
-      olLayer.set("showLabelLayer", false);
-    }
-
     const update = () => {
       setShowingLabelLayer(!!olLayer.get("showLabelLayer"));
+      applyLabelStyle();
     };
-
+    // Initial sync on mount or layer change
     update();
-
     olLayer.on("change:showLabelLayer", update);
 
     return () => {
@@ -159,47 +185,15 @@ function LayerItem({
   }, [olLayer]);
 
   useEffect(() => {
+    // Do not run unless we have olLayer and layer is toggled
     if (!olLayer) return;
+    if (!layerIsToggled) return;
 
-    const source = olLayer.getSource();
-    if (!source) return;
-
-    const updateStyles = () => {
-      const currentParams = source.getParams?.() || {};
-      const currentLayerName = currentParams.LAYERS;
-
-      if (!currentLayerName) return;
-
-      const isActive = !!olLayer.get("showLabelLayer");
-
-      if (isActive) {
-        // Overwrite if we are not already in label mode
-        if (!currentParams.STYLES?.includes("_labels")) {
-          previousStylesRef.current = currentParams.STYLES || "";
-        }
-
-        source.updateParams({
-          ...currentParams,
-          STYLES: `${currentLayerName}_labels`,
-        });
-      } else {
-        source.updateParams({
-          ...currentParams,
-          STYLES: previousStylesRef.current || "",
-        });
-      }
-    };
-
-    // run once
-    updateStyles();
-
-    // listen for toggle
-    olLayer.on("change:showLabelLayer", updateStyles);
-
-    return () => {
-      olLayer.un("change:showLabelLayer", updateStyles);
-    };
-  }, [olLayer]);
+    // Wait for OL state to be ready
+    requestAnimationFrame(() => {
+      applyLabelStyle();
+    });
+  }, [layerIsToggled, olLayer]);
 
   useEffect(() => {
     const handleLoadStatusChange = (d) => {

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -414,7 +414,7 @@ function LayerItem({
               }}
             >
               {renderStatusIcon()}
-              {layerInfo.hasLabelLayer && (
+              {layerInfo?.hasLabelLayer && (
                 <BtnToggleLayerLabel
                   active={showingLabelLayer}
                   onClick={toggleLabelLayer}

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, memo } from "react";
+import { useEffect, useState, memo } from "react";
 
 // Material UI components
 import {
@@ -21,6 +21,7 @@ import LsIconButton from "./LsIconButton";
 import BtnShowDetails from "./BtnShowDetails";
 import BtnLayerWarning from "./BtnLayerWarning";
 import BtnShowLegend from "./BtnShowLegend";
+import BtnToggleLayerLabel from "./BtnToggleLayerLabel";
 import LsCheckBox from "./LsCheckBox";
 
 import { useMapZoom } from "../LayerSwitcherProvider";
@@ -104,11 +105,21 @@ function LayerItem({
   const [wmsLayerLoadStatus, setWmsLayerLoadStatus] = useState("ok");
   // State that toggles legend collapse
   const [legendIsActive, setLegendIsActive] = useState(false);
+  // Track if the label layer is active
+  const [showingLabelLayer, setShowingLabelLayer] = useState(false);
   const theme = useTheme();
 
   const mapZoom = useMapZoom();
 
   const { layerIsToggled } = layerState ?? {};
+
+  const toggleLabelLayer = (e) => {
+    e.stopPropagation();
+    setShowingLabelLayer((prev) => !prev);
+    globalObserver.publish("layer.toggleLabelLayer", {
+      layerId,
+    });
+  };
 
   const {
     layerId,
@@ -124,6 +135,12 @@ function LayerItem({
   } = layerConfig ?? {};
 
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
+
+  useEffect(() => {
+    if (!layerIsToggled) {
+      setShowingLabelLayer(false);
+    }
+  }, [layerIsToggled]);
 
   useEffect(() => {
     const handleLoadStatusChange = (d) => {
@@ -344,6 +361,12 @@ function LayerItem({
               }}
             >
               {renderStatusIcon()}
+              {layerInfo.hasLabelLayer && (
+                <BtnToggleLayerLabel
+                  active={showingLabelLayer}
+                  onClick={toggleLabelLayer}
+                />
+              )}
               {!toggleable && !draggable ? (
                 <LsIconButton size="small">
                   <HajkToolTip title="Bakgrundskartan ligger låst längst ner i ritordningen">

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -143,7 +143,7 @@ function LayerItem({
     }
   }, [layerIsToggled]);
 
-  // Switches between "labels" or last used STYLES if available, otherwise "".
+  // Switches between "*layername*_labels" or last used STYLES if available, otherwise "".
   useEffect(() => {
     if (!olLayer || !layerIsToggled) return;
 
@@ -151,12 +151,19 @@ function LayerItem({
     if (!source) return;
 
     const currentParams = source.getParams?.() || {};
+    const currentLayerName = currentParams.LAYERS;
+
+    if (!currentLayerName) return;
+
     if (showingLabelLayer) {
       // Save current styles BEFORE overwriting
       previousStylesRef.current = currentParams.STYLES || "";
+
+      const labelStyle = `${currentLayerName}_labels`;
+
       source.updateParams({
         ...currentParams,
-        STYLES: "labels",
+        STYLES: labelStyle,
       });
     } else {
       source.updateParams({

--- a/apps/client/src/utils/ConfigMapper.js
+++ b/apps/client/src/utils/ConfigMapper.js
@@ -152,6 +152,7 @@ export default class ConfigMapper {
         layerType: args.layerType,
         caption: args.caption,
         visible: args.visibleAtStart,
+        hasLabelLayer: args.hasLabelLayer || false,
         opacity: args.opacity || 1,
         zIndex: args.drawOrder || 0,
         maxZoom: args.maxZoom,


### PR DESCRIPTION
Separate PR for the client adding the useLabelLayer key to the layersConfig > wmslayers array. (backend/admin part handled separately)
For the label button to be show  we now expect the useLabelLayer key to exist and have the boolean value of true, otherwise its disregarded. So this should not affect existing configurations that's missing this key.

As discussed [here](https://github.com/hajkmap/Hajk/issues/1816) we expect that the wms source has a STYLE available named "labels". If the STYLE is added with any other values and is not left blank, we save these and reapply them when the label layer should no longer be visible.

`{
        "id": "1353",
        "caption": "Polygons of interest",
        "url": "http://192.168.1.2:8086/qgis-server",
        ...
        "visibleAtStart": true,
        "hasLabelLayer": true,
        etc..
`

The label can be activate before the layer is activated, showing the label layer directly.
Although when the layer is disabled, the label layer is disabled aswell to "reset" the menu entry to it's default state.


https://github.com/user-attachments/assets/3dc2461c-72b1-40ed-b313-fa0eeb510b09
