### PR TITLE
Load layers with labels on app start.

### DIFF
--- a/apps/client/src/models/AnchorModel.js
+++ b/apps/client/src/models/AnchorModel.js
@@ -106,7 +106,15 @@ class AnchorModel {
           isValidLayerId(layer.getProperties().name)
         );
       })
-      .map((layer) => layer.getProperties().name)
+      .map((layer) => {
+        // Add a check if we want this layer to use labels or not
+        // If so, append _l to the layer in the url
+        const name = layer.getProperties().name;
+        if (layer.get("showLabelLayer")) {
+          return `${name}_l`;
+        }
+        return name;
+      })
       .join(",");
   }
 

--- a/apps/client/src/models/AnchorModel.js
+++ b/apps/client/src/models/AnchorModel.js
@@ -53,10 +53,18 @@ class AnchorModel {
         const layerId = layer.get("name");
 
         // Update anchor each time layer visibility changes (to reflect current visible layers)
-        layer.on("change:visible", async (event) => {
+        layer.on("change:visible", async (_event) => {
           this.#app.globalObserver.publish("core.mapUpdated", {
             url: await this.getAnchor(),
             source: "layerVisibility",
+          });
+        });
+
+        // E: Update anchor when label layer state changes
+        layer.on("change:showLabelLayer", async (_event) => {
+          this.#app.globalObserver.publish("core.mapUpdated", {
+            url: await this.getAnchor(),
+            source: "labelLayerToggle",
           });
         });
 
@@ -99,21 +107,20 @@ class AnchorModel {
       .getArray()
       .filter((layer) => {
         return (
-          // We consider a layer to be visible only if…
-          // …has a specified name property…
-          layer.getVisible() && // …it's visible…
-          layer.getProperties().name &&
-          isValidLayerId(layer.getProperties().name)
+          layer.getVisible() === true &&
+          ["group", "layer", "base"].includes(layer.get("layerType"))
         );
       })
       .map((layer) => {
-        // Add a check if we want this layer to use labels or not
-        // If so, append _l to the layer in the url
-        const name = layer.getProperties().name;
-        if (layer.get("showLabelLayer")) {
-          return `${name}_l`;
+        const layerId = layer.get("name");
+        // Check if the layer should show labels
+        const showLabelLayer = layer.get("showLabelLayer");
+        const hasLabelLayer = layer.get("hasLabelLayer");
+
+        if (showLabelLayer && hasLabelLayer) {
+          return `${layerId}_l`;
         }
-        return name;
+        return layerId;
       })
       .join(",");
   }

--- a/apps/client/src/models/AnchorModel.js
+++ b/apps/client/src/models/AnchorModel.js
@@ -143,9 +143,9 @@ class AnchorModel {
         const layerId = layer.get("name");
         // Check if the layer should show labels
         const showLabelLayer = layer.get("showLabelLayer");
-        const hasLabelLayer = layer.get("hasLabelLayer");
+        const hasLabelStyle = layer.get("hasLabelStyle");
 
-        if (showLabelLayer && hasLabelLayer) {
+        if (showLabelLayer && hasLabelStyle) {
           return `${layerId}_l`;
         }
         return layerId;

--- a/apps/client/src/models/AnchorModel.js
+++ b/apps/client/src/models/AnchorModel.js
@@ -72,7 +72,7 @@ class AnchorModel {
         });
 
         // E: Update anchor when label layer state changes
-        layer.on("change:showLabelLayer", async (_event) => {
+        layer.on("change:useLabelStyle", async (_event) => {
           this.#app.globalObserver.publish("core.mapUpdated", {
             url: await this.getAnchor(),
             source: "labelLayerToggle",
@@ -142,10 +142,10 @@ class AnchorModel {
       .map((layer) => {
         const layerId = layer.get("name");
         // Check if the layer should show labels
-        const showLabelLayer = layer.get("showLabelLayer");
+        const useLabelStyle = layer.get("useLabelStyle");
         const hasLabelStyle = layer.get("hasLabelStyle");
 
-        if (showLabelLayer && hasLabelStyle) {
+        if (useLabelStyle && hasLabelStyle) {
           return `${layerId}_l`;
         }
         return layerId;

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -712,7 +712,7 @@ class AppModel {
 
           // Save the provided style before we change it
           olLayer.set("initialStyles", params.STYLES || "");
-          olLayer.set("showLabelLayer", true);
+          olLayer.set("useLabelStyle", true);
 
           source.updateParams({
             ...params,
@@ -832,7 +832,7 @@ class AppModel {
       this.addMapLayer(layer);
     });
 
-    // Now that layers exist, we set showLabelLayer on the proper layers
+    // Now that layers exist, we set useLabelStyle on the proper layers
     this.layers.forEach((layer) => {
       if (layer._requestLabelLayer === true) {
         const olLayer = this.map
@@ -840,8 +840,8 @@ class AppModel {
           .find((l) => l.get("name") === layer.id);
 
         if (olLayer && olLayer.get("hasLabelStyle")) {
-          if (!olLayer.get("showLabelLayer")) {
-            olLayer.set("showLabelLayer", true);
+          if (!olLayer.get("useLabelStyle")) {
+            olLayer.set("useLabelStyle", true);
           }
         }
       }
@@ -1315,9 +1315,9 @@ class AppModel {
           );
         } else {
           if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
-            olLayer.set("showLabelLayer", true);
+            olLayer.set("useLabelStyle", true);
           } else {
-            olLayer.set("showLabelLayer", false);
+            olLayer.set("useLabelStyle", false);
           }
         }
       });
@@ -1351,9 +1351,9 @@ class AppModel {
           olLayer.setVisible(true);
 
           if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
-            olLayer.set("showLabelLayer", true);
+            olLayer.set("useLabelStyle", true);
           } else {
-            olLayer.set("showLabelLayer", false);
+            olLayer.set("useLabelStyle", false);
           }
         }
       });

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -688,10 +688,32 @@ class AppModel {
       case "wms":
         layerConfig = configMapper.mapWMSConfig(layer, this.config);
         layerItem = new WMSLayer(
-          layerConfig.options,
+          {
+            ...layerConfig.options,
+            requestLabelLayer: layer._requestLabelLayer === true,
+          },
           this.config.appConfig.proxy,
           this.globalObserver
         );
+        // Check if te should load use the label layer for this layer
+        if (
+          layer._requestLabelLayer &&
+          layerItem?.layer?.getSource?.()?.updateParams
+        ) {
+          const olLayer = layerItem.layer;
+          const source = olLayer.getSource();
+          const params = source.getParams?.() || {};
+          const layerName = params.LAYERS;
+
+          // Save the provided style before we change it
+          olLayer.set("initialStyles", params.STYLES || "");
+          olLayer.set("showLabelLayer", true);
+
+          source.updateParams({
+            ...params,
+            STYLES: `${layerName}_labels`,
+          });
+        }
         this.map.addLayer(layerItem.layer);
         break;
       case "wmts":
@@ -781,10 +803,14 @@ class AppModel {
     // Loop the layers and add each of them to the map
     this.layers.forEach((layer) => {
       if (this.layersFromParams.length > 0) {
-        // Override the default visibleAtStart if a value was provided in URLSearchParams
-        layer.visibleAtStart = this.layersFromParams.some(
-          (layerId) => layerId === layer.id
-        );
+        // Override the default visibleAtStart if a value was provided in URLSearchParams or has our _l label flag
+        layer.visibleAtStart = this.layersFromParams.some((layerId) => {
+          return layerId === layer.id || layerId === `${layer.id}_l`;
+        });
+
+        layer._requestLabelLayer =
+          layer.hasLabelLayer === true &&
+          this.layersFromParams.includes(`${layer.id}_l`);
 
         // groupLayersFromParams is an object where keys are layer IDs and values are
         // the sublayers that should be active for this given layer. A layer's key will
@@ -896,7 +922,6 @@ class AppModel {
         // Let's handle multiple features as array and keep backward compatibility with single features.
         features = Array.isArray(features) ? features : [features];
         this.highlightSource.addFeatures(features);
-        
       }
     }
   }

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -695,7 +695,12 @@ class AppModel {
           this.config.appConfig.proxy,
           this.globalObserver
         );
-        // Check if te should load use the label layer for this layer
+
+        if (layer.hasLabelLayer === true) {
+          layerItem.layer.set("hasLabelLayer", true);
+        }
+
+        // Check if we should load the label layer for this layer
         if (
           layer._requestLabelLayer &&
           layerItem?.layer?.getSource?.()?.updateParams
@@ -803,7 +808,7 @@ class AppModel {
     // Loop the layers and add each of them to the map
     this.layers.forEach((layer) => {
       if (this.layersFromParams.length > 0) {
-        // Override the default visibleAtStart if a value was provided in URLSearchParams or has our _l label flag
+        // Override the default visibleAtStart if a value was provided in URLSearchParams
         layer.visibleAtStart = this.layersFromParams.some((layerId) => {
           return layerId === layer.id || layerId === `${layer.id}_l`;
         });
@@ -825,6 +830,21 @@ class AppModel {
       }
       layer.cqlFilter = this.cqlFiltersFromParams[layer.id] || null;
       this.addMapLayer(layer);
+    });
+
+    // Now that layers exist, we set showLabelLayer on the proper layers
+    this.layers.forEach((layer) => {
+      if (layer._requestLabelLayer === true) {
+        const olLayer = this.map
+          .getAllLayers()
+          .find((l) => l.get("name") === layer.id);
+
+        if (olLayer && olLayer.get("hasLabelLayer")) {
+          if (!olLayer.get("showLabelLayer")) {
+            olLayer.set("showLabelLayer", true);
+          }
+        }
+      }
     });
 
     // Check if the layerParams contains -1 (white background) and handle set it to visible on load
@@ -1240,47 +1260,79 @@ class AppModel {
       // console.log("No changes");
     } else {
       // It's easier to work on the values if we parse them first
+      const parseLayerId = (layerId) => {
+        const hasLabelSuffix = layerId.endsWith("_l");
+        const baseId = hasLabelSuffix ? layerId.slice(0, -2) : layerId;
+        return { baseId, hasLabelSuffix };
+      };
+
+      const findOLLayer = (baseId) => {
+        return this.map.getAllLayers().find((l) => l.get("name") === baseId);
+      };
+
       const wantedL = l.split(",");
       const wantedGl = JSON.parse(gl);
       const currentL = visibleLayers.split(",");
-      const currentGl = partlyToggledGroupLayers; // This is already an object, no need to parse
+      const currentGl = partlyToggledGroupLayers;
 
-      // Get what should be shown
-      const lToShow = wantedL.filter((a) => !currentL.includes(a));
+      const wantedLayersMap = new Map();
+      wantedL.forEach((layerId) => {
+        const { baseId, hasLabelSuffix } = parseLayerId(layerId);
+        wantedLayersMap.set(baseId, hasLabelSuffix);
+      });
 
-      // Get what should be hidden
-      const lToHide = currentL.filter((a) => !wantedL.includes(a));
+      const currentLayersMap = new Map();
+      currentL.forEach((layerId) => {
+        const { baseId, hasLabelSuffix } = parseLayerId(layerId);
+        currentLayersMap.set(baseId, hasLabelSuffix);
+      });
 
-      // Act!
-      lToShow.forEach((layer) => {
-        // Grab the corresponding OL layer from Map
-        const olLayer = this.map
-          .getAllLayers()
-          .find((l) => l.get("name") === layer);
+      const lToShow = [];
+      const lToHide = [];
+      const lToUpdateStyle = [];
 
-        // First, ensure that we had a match. It is possible that pretty much
-        // anything shows up as layer id here (as it can come from multiple sources)
-        // and we can't assume that the requested layer actually exists in current
-        // map's config. In order to prevent a silent failure (see #1305), this check is added.
+      wantedLayersMap.forEach((wantedHasLabel, baseId) => {
+        if (!currentLayersMap.has(baseId)) {
+          lToShow.push({ baseId, hasLabelSuffix: wantedHasLabel });
+        } else if (currentLayersMap.get(baseId) !== wantedHasLabel) {
+          lToUpdateStyle.push({ baseId, hasLabelSuffix: wantedHasLabel });
+        }
+      });
+
+      currentLayersMap.forEach((currentHasLabel, baseId) => {
+        if (!wantedLayersMap.has(baseId)) {
+          lToHide.push({ baseId, hasLabelSuffix: currentHasLabel });
+        }
+      });
+
+      // Update label styles for layers that are already visible
+      lToUpdateStyle.forEach(({ baseId, hasLabelSuffix }) => {
+        const olLayer = findOLLayer(baseId);
+
         if (olLayer === undefined) {
           console.warn(
-            `Attempt to show layer with id ${layer} failed: layer not found in current map`
+            `Attempt to update layer style for ${baseId} failed: layer not found in current map`
           );
+        } else {
+          if (hasLabelSuffix && olLayer.get("hasLabelLayer")) {
+            olLayer.set("showLabelLayer", true);
+          } else {
+            olLayer.set("showLabelLayer", false);
+          }
         }
-        // If it's a group layer we can use the 'layerswitcher.showLayer' event
-        // that each group layer listens to.
-        else if (olLayer.get("layerType") === "group") {
-          // We can publish the 'layerswitcher.showLayer' event with two different
-          // sets of parameters, depending on whether the group layer has all
-          // sublayers selected, or only a subset.
+      });
 
-          // If only a subset is selected, we will find the sublayers in our 'wantedGl' object.
-          // Anything else than 'undefined' here means that we want to publish
-          // the showLayer event and supply the sub-selection of sublayers too.
-          if (wantedGl[layer]) {
-            // In addition, this looks like a group layer that has
-            // its sublayers specified and we should take care of that too
-            const subLayersToShow = wantedGl[layer]?.split(",");
+      // Show layers
+      lToShow.forEach(({ baseId, hasLabelSuffix }) => {
+        const olLayer = findOLLayer(baseId);
+
+        if (olLayer === undefined) {
+          console.warn(
+            `Attempt to show layer with id ${baseId} failed: layer not found in current map`
+          );
+        } else if (olLayer.get("layerType") === "group") {
+          if (wantedGl[baseId]) {
+            const subLayersToShow = wantedGl[baseId]?.split(",");
             setOLSubLayers(olLayer, subLayersToShow);
           }
           // On the other hand, if the layer to be shown does not exist in 'wantedGl',
@@ -1291,25 +1343,28 @@ class AppModel {
             const allSubLayers = olLayer.get("allSubLayers");
             setOLSubLayers(olLayer, allSubLayers);
           }
-        }
-        // That's it for group layer. The other layers, the "normal"
-        // ones, are easier: just show them.
-        else {
+          // That's it for group layer. The other layers, the "normal"
+          // ones, are easier: just show them.
+        } else {
           // Each layer has a listener that will take care of toggling
           // the checkbox in LayerSwitcher.
           olLayer.setVisible(true);
+
+          if (hasLabelSuffix && olLayer.get("hasLabelLayer")) {
+            olLayer.set("showLabelLayer", true);
+          } else {
+            olLayer.set("showLabelLayer", false);
+          }
         }
       });
 
       // Next, let's take care of layers that should be hidden.
-      lToHide.forEach((layer) => {
-        const olLayer = this.map
-          .getAllLayers()
-          .find((l) => l.get("name") === layer);
+      lToHide.forEach(({ baseId }) => {
+        const olLayer = findOLLayer(baseId);
 
         if (olLayer === undefined) {
           console.warn(
-            `Attempt to hide layer with id ${layer} failed: layer not found in current map`
+            `Attempt to hide layer with id ${baseId} failed: layer not found in current map`
           );
         } else if (olLayer.get("layerType") === "group") {
           // Tell the LayerSwitcher about it
@@ -1329,12 +1384,11 @@ class AppModel {
         // If the currently visible groups object has the layer's key…
         // …and it's value differs from the wantedGl's corresponding value…
         if (Object.hasOwn(currentGl, key) && currentGl[key] !== wantedGl[key]) {
-          const olLayer = this.map
-            .getAllLayers()
-            .find((l) => l.get("name") === key);
-
-          const subLayersToShow = wantedGl[key]?.split(",");
-          setOLSubLayers(olLayer, subLayersToShow);
+          const olLayer = findOLLayer(key);
+          if (olLayer) {
+            const subLayersToShow = wantedGl[key]?.split(",");
+            setOLSubLayers(olLayer, subLayersToShow);
+          }
         }
       }
 
@@ -1347,22 +1401,23 @@ class AppModel {
       // One solution is to loop through our visible layers (again). Any of them
       // that are of type 'groupLayer', and where a wantedGl key is missing should
       // be toggled on completely.
-      wantedL.forEach((layer) => {
+      wantedL.forEach((layerId) => {
+        const { baseId } = parseLayerId(layerId);
         const olLayer = this.map
           .getAllLayers()
           .find(
-            (l) => l.get("name") === layer && l.get("layerType") === "group"
+            (l) => l.get("name") === baseId && l.get("layerType") === "group"
           );
 
         if (olLayer !== undefined) {
           // Determine how we should call the layerswitcher.showLayer event.
           // A: No sublayers specified for layer in 'wantedGl'. That means show ALL sublayers.
           // B: Sublayers found in 'wantedGl'. Set visibility accordingly.
-          if (wantedGl[layer] === undefined) {
+          if (wantedGl[baseId] === undefined) {
             const allSubLayers = olLayer.get("allSubLayers");
             setOLSubLayers(olLayer, allSubLayers);
           } else {
-            const subLayersToShow = wantedGl[layer]?.split(",");
+            const subLayersToShow = wantedGl[baseId]?.split(",");
             setOLSubLayers(olLayer, subLayersToShow);
           }
         }

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -696,8 +696,8 @@ class AppModel {
           this.globalObserver
         );
 
-        if (layer.hasLabelLayer === true) {
-          layerItem.layer.set("hasLabelLayer", true);
+        if (layer.hasLabelStyle === true) {
+          layerItem.layer.set("hasLabelStyle", true);
         }
 
         // Check if we should load the label layer for this layer
@@ -814,7 +814,7 @@ class AppModel {
         });
 
         layer._requestLabelLayer =
-          layer.hasLabelLayer === true &&
+          layer.hasLabelStyle === true &&
           this.layersFromParams.includes(`${layer.id}_l`);
 
         // groupLayersFromParams is an object where keys are layer IDs and values are
@@ -839,7 +839,7 @@ class AppModel {
           .getAllLayers()
           .find((l) => l.get("name") === layer.id);
 
-        if (olLayer && olLayer.get("hasLabelLayer")) {
+        if (olLayer && olLayer.get("hasLabelStyle")) {
           if (!olLayer.get("showLabelLayer")) {
             olLayer.set("showLabelLayer", true);
           }
@@ -1314,7 +1314,7 @@ class AppModel {
             `Attempt to update layer style for ${baseId} failed: layer not found in current map`
           );
         } else {
-          if (hasLabelSuffix && olLayer.get("hasLabelLayer")) {
+          if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
             olLayer.set("showLabelLayer", true);
           } else {
             olLayer.set("showLabelLayer", false);
@@ -1350,7 +1350,7 @@ class AppModel {
           // the checkbox in LayerSwitcher.
           olLayer.setVisible(true);
 
-          if (hasLabelSuffix && olLayer.get("hasLabelLayer")) {
+          if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
             olLayer.set("showLabelLayer", true);
           } else {
             olLayer.set("showLabelLayer", false);

--- a/apps/client/src/models/layers/WMSLayer.jsx
+++ b/apps/client/src/models/layers/WMSLayer.jsx
@@ -122,7 +122,7 @@ class WMSLayer {
         : this.subLayers
     );
     this.layer.set("hasLabelStyle", config.hasLabelStyle);
-    this.layer.set("showLabelLayer", false);
+    this.layer.set("useLabelStyle", false);
     this.layer.getSource().set("url", config.url);
     this.type = "wms";
     this.bindHandlers();

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
@@ -162,7 +162,6 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
   return {
     setLayerVisibility(layerId, visible) {
       const olLayer = map.getAllLayers().find((l) => l.get("name") === layerId);
-      olLayer.setVisible(visible);
 
       // Only handle sublayers for WMS group layers (they have allSubLayers
       // configured and a source that supports updateParams).
@@ -172,10 +171,13 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
           olLayer.set("subLayers", allSubLayers);
           setOLSubLayers(olLayer, allSubLayers);
         } else {
+          olLayer.setVisible(false);
           olLayer.set("subLayers", []);
           setOLSubLayers(olLayer, []);
+          return;
         }
       }
+      olLayer.setVisible(visible);
     },
     setSubLayerVisibility(layerId, subLayerId, visible) {
       const olLayer = map.getAllLayers().find((l) => l.get("name") === layerId);
@@ -219,7 +221,29 @@ const createDispatch = (map, staticLayerConfig, staticLayerTree) => {
 
       allLayerIdsInGroup.forEach((id) => {
         const olLayer = map.getAllLayers().find((l) => l.get("name") === id);
-        olLayer.setVisible(visible);
+
+        const allSubLayers = staticLayerConfig[id]?.allSubLayers;
+        if (allSubLayers && !(olLayer instanceof VectorLayer)) {
+          if (visible) {
+            const wasVisible = olLayer.get("visible");
+            if (wasVisible) {
+              olLayer.setVisible(false);
+            }
+
+            olLayer.set("subLayers", allSubLayers);
+            setOLSubLayers(olLayer, allSubLayers);
+
+            setTimeout(() => {
+              olLayer.setVisible(true);
+            }, 0);
+          } else {
+            olLayer.setVisible(false);
+            olLayer.set("subLayers", []);
+            setOLSubLayers(olLayer, []);
+          }
+        } else {
+          olLayer.setVisible(visible);
+        }
       });
     },
     setAllLayersInvisible() {

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -139,7 +139,7 @@ function LayerItem({
 
     if (!layerName) return;
 
-    const isActive = !!olLayer.get("showLabelLayer");
+    const isActive = !!olLayer.get("useLabelStyle");
     const baseStyle = olLayer.get("initialStyles") || "";
 
     source.updateParams({
@@ -152,8 +152,8 @@ function LayerItem({
     e.stopPropagation();
     if (!olLayer) return;
 
-    const newValue = !olLayer.get("showLabelLayer");
-    olLayer.set("showLabelLayer", newValue);
+    const newValue = !olLayer.get("useLabelStyle");
+    olLayer.set("useLabelStyle", newValue);
   };
 
   // Save the initial styles in "initialStyles" once when olLayer is ready
@@ -176,7 +176,7 @@ function LayerItem({
     if (!olLayer) return;
 
     const update = () => {
-      const active = !!olLayer.get("showLabelLayer");
+      const active = !!olLayer.get("useLabelStyle");
       setShowingLabelLayer(active);
       applyLabelStyle();
     };
@@ -185,10 +185,10 @@ function LayerItem({
     update();
 
     // Listen for changes on label change
-    olLayer.on("change:showLabelLayer", update);
+    olLayer.on("change:useLabelStyle", update);
 
     return () => {
-      olLayer.un("change:showLabelLayer", update);
+      olLayer.un("change:useLabelStyle", update);
     };
   }, [olLayer]);
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, memo, useRef } from "react";
+import { useEffect, useState, memo } from "react";
 
 // Material UI components
 import {
@@ -113,29 +113,10 @@ function LayerItem({
 
   const { layerIsToggled } = layerState ?? {};
 
-  const toggleLabelLayer = (e) => {
-    e.stopPropagation();
-
-    if (!olLayer) return;
-
-    const source = olLayer.getSource?.();
-    const params = source?.getParams?.() || {};
-
-    // Save the provided startstyle
-    if (olLayer.get("initialStyles") === undefined) {
-      olLayer.set("initialStyles", params.STYLES || "");
-    }
-
-    const newValue = !olLayer.get("showLabelLayer");
-
-    olLayer.set("showLabelLayer", newValue);
-  };
-
   const {
     layerId,
     layerCaption,
     layerType,
-
     layerIsFakeMapLayer,
     layerMinZoom,
     layerMaxZoom,
@@ -151,7 +132,7 @@ function LayerItem({
     if (!olLayer) return;
 
     const source = olLayer.getSource?.();
-    if (!source) return;
+    if (!source || typeof source.updateParams !== "function") return;
 
     const currentParams = source.getParams?.() || {};
     const layerName = currentParams.LAYERS;
@@ -159,7 +140,6 @@ function LayerItem({
     if (!layerName) return;
 
     const isActive = !!olLayer.get("showLabelLayer");
-
     const baseStyle = olLayer.get("initialStyles") || "";
 
     source.updateParams({
@@ -168,6 +148,15 @@ function LayerItem({
     });
   };
 
+  const toggleLabelLayer = (e) => {
+    e.stopPropagation();
+    if (!olLayer) return;
+
+    const newValue = !olLayer.get("showLabelLayer");
+    olLayer.set("showLabelLayer", newValue);
+  };
+
+  // Save the initial styles in "initialStyles" once when olLayer is ready
   useEffect(() => {
     if (!olLayer) return;
 
@@ -176,12 +165,13 @@ function LayerItem({
 
     const params = source.getParams?.() || {};
 
-    // store original style once
+    // Store original style once
     if (olLayer.get("initialStyles") == null) {
       olLayer.set("initialStyles", params.STYLES || "");
     }
   }, [olLayer]);
 
+  // Sync showingLabelLayer state with olLayer property and apply styles
   useEffect(() => {
     if (!olLayer) return;
 
@@ -190,8 +180,11 @@ function LayerItem({
       setShowingLabelLayer(active);
       applyLabelStyle();
     };
+
     // Initial sync on mount or layer change
     update();
+
+    // Listen for changes on label change
     olLayer.on("change:showLabelLayer", update);
 
     return () => {
@@ -199,19 +192,8 @@ function LayerItem({
     };
   }, [olLayer]);
 
+  // Apply label style when layer becomes visible (in case it was set while hidden)
   useEffect(() => {
-    if (!olLayer) return;
-
-    const isLabelLayerFromUrl =
-      typeof layerId === "string" && layerId.endsWith("_l");
-
-    if (isLabelLayerFromUrl) {
-      olLayer.set("showLabelLayer", true);
-    }
-  }, [olLayer, layerId]);
-
-  useEffect(() => {
-    // Do not run unless we have olLayer and layer is toggled
     if (!olLayer) return;
     if (!layerIsToggled) return;
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -107,8 +107,6 @@ function LayerItem({
   const [legendIsActive, setLegendIsActive] = useState(false);
   // Track if the label layer is active
   const [showingLabelLayer, setShowingLabelLayer] = useState(false);
-  // Store the previous STYLES values when toggling labels
-  const previousStylesRef = useRef("");
   const theme = useTheme();
 
   const mapZoom = useMapZoom();
@@ -117,7 +115,19 @@ function LayerItem({
 
   const toggleLabelLayer = (e) => {
     e.stopPropagation();
+
+    if (!olLayer) return;
+
+    const source = olLayer.getSource?.();
+    const params = source?.getParams?.() || {};
+
+    // Save the provided startstyle
+    if (olLayer.get("initialStyles") === undefined) {
+      olLayer.set("initialStyles", params.STYLES || "");
+    }
+
     const newValue = !olLayer.get("showLabelLayer");
+
     olLayer.set("showLabelLayer", newValue);
   };
 
@@ -140,39 +150,44 @@ function LayerItem({
   const applyLabelStyle = () => {
     if (!olLayer) return;
 
-    const source = olLayer.getSource();
+    const source = olLayer.getSource?.();
     if (!source) return;
 
     const currentParams = source.getParams?.() || {};
-    const currentLayerName = currentParams.LAYERS;
+    const layerName = currentParams.LAYERS;
 
-    if (!currentLayerName) return;
+    if (!layerName) return;
 
     const isActive = !!olLayer.get("showLabelLayer");
 
-    if (isActive) {
-      // Save previous style
-      if (!currentParams.STYLES?.includes("_labels")) {
-        previousStylesRef.current = currentParams.STYLES || "";
-      }
+    const baseStyle = olLayer.get("initialStyles") || "";
 
-      source.updateParams({
-        ...currentParams,
-        STYLES: `${currentLayerName}_labels`,
-      });
-    } else {
-      source.updateParams({
-        ...currentParams,
-        STYLES: previousStylesRef.current || "",
-      });
-    }
+    source.updateParams({
+      ...currentParams,
+      STYLES: isActive ? `${layerName}_labels` : baseStyle,
+    });
   };
 
   useEffect(() => {
     if (!olLayer) return;
 
+    const source = olLayer.getSource?.();
+    if (!source) return;
+
+    const params = source.getParams?.() || {};
+
+    // store original style once
+    if (olLayer.get("initialStyles") == null) {
+      olLayer.set("initialStyles", params.STYLES || "");
+    }
+  }, [olLayer]);
+
+  useEffect(() => {
+    if (!olLayer) return;
+
     const update = () => {
-      setShowingLabelLayer(!!olLayer.get("showLabelLayer"));
+      const active = !!olLayer.get("showLabelLayer");
+      setShowingLabelLayer(active);
       applyLabelStyle();
     };
     // Initial sync on mount or layer change
@@ -183,6 +198,17 @@ function LayerItem({
       olLayer.un("change:showLabelLayer", update);
     };
   }, [olLayer]);
+
+  useEffect(() => {
+    if (!olLayer) return;
+
+    const isLabelLayerFromUrl =
+      typeof layerId === "string" && layerId.endsWith("_l");
+
+    if (isLabelLayerFromUrl) {
+      olLayer.set("showLabelLayer", true);
+    }
+  }, [olLayer, layerId]);
 
   useEffect(() => {
     // Do not run unless we have olLayer and layer is toggled


### PR DESCRIPTION
As @jacobwod described [here](https://github.com/hajkmap/Hajk/pull/1817) users will probably want to load the map with the labels toggled on/off to reflect the same view one user may link to another user..

We reserve the suffix of the layername in the querystring, where `{layername}_l` indicates that the layer should have it's _labels style loaded.

A caveat is that if a layer is linked with the _l suffix in the url's querystring under key "l", for example mylayer_l.
And mylayer doesn't support labels, the whole layer is removed from the querystring on app start and the "normal" layer is not activated at all.

If this should be the default behavior should be decided, or if the normal layer should be activated as a fallback.

Since there's some changes done in the AppModel, I would appreciate help testing this PR since the loading of WMS layers have been modified and could affect plugins/modules I'm not familiar with. 