### PR TITLE
Fixes bookmarks with layers that should show labels.

### DIFF
--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -711,8 +711,10 @@ class AppModel {
 
         if (layer.hasLabelStyle === true) {
           layerItem.layer.set("hasLabelStyle", true);
+          // Store the layername so we can access it before wms layer changes
+          // ex when switching labels
+          layerItem.layer.set("wmsLayerName", layer.layers?.[0] || layer.name); // ← Store it!
 
-          // Store initialStyles immediately when layer is created
           const source = layerItem.layer.getSource();
           if (source && source.getParams) {
             const params = source.getParams();
@@ -1376,32 +1378,6 @@ class AppModel {
           // Each layer has a listener that will take care of toggling
           // the checkbox in LayerSwitcher.
           olLayer.setVisible(true);
-
-          // Apply WMS params after React renders LayerItem
-          setTimeout(() => {
-            if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
-              const source = olLayer.getSource?.();
-
-              if (source && typeof source.updateParams === "function") {
-                // Get the layer config to find the WMS layer name
-                const layerConfig = this.layers?.find((l) => l.id === baseId);
-
-                if (layerConfig) {
-                  // Get the actual WMS layer name from config
-                  const layerName =
-                    layerConfig.layers?.[0] || layerConfig.name || baseId;
-
-                  const params = source.getParams?.() || {};
-
-                  source.updateParams({
-                    ...params,
-                    LAYERS: layerName,
-                    STYLES: `${layerName}_labels`,
-                  });
-                }
-              }
-            }
-          }, 100);
         }
       });
 

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -711,6 +711,13 @@ class AppModel {
 
         if (layer.hasLabelStyle === true) {
           layerItem.layer.set("hasLabelStyle", true);
+
+          // Store initialStyles immediately when layer is created
+          const source = layerItem.layer.getSource();
+          if (source && source.getParams) {
+            const params = source.getParams();
+            layerItem.layer.set("initialStyles", params.STYLES || "");
+          }
         }
 
         // Check if we should load the label layer for this layer
@@ -1359,15 +1366,42 @@ class AppModel {
           // That's it for group layer. The other layers, the "normal"
           // ones, are easier: just show them.
         } else {
-          // Each layer has a listener that will take care of toggling
-          // the checkbox in LayerSwitcher.
-          olLayer.setVisible(true);
-
+          // Set label state before making it visible
           if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
             olLayer.set("useLabelStyle", true);
           } else {
             olLayer.set("useLabelStyle", false);
           }
+
+          // Each layer has a listener that will take care of toggling
+          // the checkbox in LayerSwitcher.
+          olLayer.setVisible(true);
+
+          // Apply WMS params after React renders LayerItem
+          setTimeout(() => {
+            if (hasLabelSuffix && olLayer.get("hasLabelStyle")) {
+              const source = olLayer.getSource?.();
+
+              if (source && typeof source.updateParams === "function") {
+                // Get the layer config to find the WMS layer name
+                const layerConfig = this.layers?.find((l) => l.id === baseId);
+
+                if (layerConfig) {
+                  // Get the actual WMS layer name from config
+                  const layerName =
+                    layerConfig.layers?.[0] || layerConfig.name || baseId;
+
+                  const params = source.getParams?.() || {};
+
+                  source.updateParams({
+                    ...params,
+                    LAYERS: layerName,
+                    STYLES: `${layerName}_labels`,
+                  });
+                }
+              }
+            }
+          }, 100);
         }
       });
 

--- a/apps/client/src/plugins/Bookmarks/BookmarksModel.js
+++ b/apps/client/src/plugins/Bookmarks/BookmarksModel.js
@@ -25,7 +25,7 @@ class BookmarksModel {
   }
 
   getVisibleLayers() {
-    return this.map
+    const layers = this.map
       .getLayers()
       .getArray()
       .filter(
@@ -33,9 +33,23 @@ class BookmarksModel {
           layer.getVisible() &&
           layer.getProperties().name &&
           isValidLayerId(layer.getProperties().name)
-      )
-      .map((layer) => layer.getProperties().name)
+      );
+
+    const result = layers
+      .map((layer) => {
+        const layerId = layer.getProperties().name;
+        const useLabelStyle = layer.get("useLabelStyle");
+        const hasLabelStyle = layer.get("hasLabelStyle");
+
+        // Add _l suffix if label layer is active and supported
+        if (useLabelStyle && hasLabelStyle) {
+          return `${layerId}_l`;
+        }
+        return layerId;
+      })
       .join(",");
+
+    return result;
   }
 
   setVisibleLayers(strLayers) {

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -136,7 +136,9 @@ function LayerItem({
     if (!source || typeof source.updateParams !== "function") return;
 
     const currentParams = source.getParams?.() || {};
-    const layerName = currentParams.LAYERS;
+
+    // Get stored layer name
+    const layerName = olLayer.get("wmsLayerName") || currentParams.LAYERS;
 
     if (!layerName) return;
 
@@ -145,6 +147,7 @@ function LayerItem({
 
     source.updateParams({
       ...currentParams,
+      LAYERS: layerName,
       STYLES: isActive ? `${layerName}_labels` : baseStyle,
     });
   }, [olLayer, layerId]);

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, memo } from "react";
+import { useEffect, useState, memo, useCallback } from "react";
 
 // Material UI components
 import {
@@ -128,7 +128,8 @@ function LayerItem({
 
   const legendIcon = layerInfo?.legendIcon || layerLegendIcon;
 
-  const applyLabelStyle = () => {
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization
+  const applyLabelStyle = useCallback(() => {
     if (!olLayer) return;
 
     const source = olLayer.getSource?.();
@@ -146,7 +147,7 @@ function LayerItem({
       ...currentParams,
       STYLES: isActive ? `${layerName}_labels` : baseStyle,
     });
-  };
+  }, [olLayer, layerId]);
 
   const toggleLabelLayer = (e) => {
     e.stopPropagation();
@@ -190,7 +191,7 @@ function LayerItem({
     return () => {
       olLayer.un("change:useLabelStyle", update);
     };
-  }, [olLayer]);
+  }, [olLayer, layerId, applyLabelStyle]);
 
   // Apply label style when layer becomes visible (in case it was set while hidden)
   useEffect(() => {


### PR DESCRIPTION
An attempt to fix bookmarks showing layers with labels, a bit hacky to use a setTimeout for 100ms in . But we need to wait a tiny bit for LayerItem to mount and be ready before we set the wms style.

The usage of useCallback hook in LayerItem and the accompanied eslint rule disable is needed since useCallback in a useMemo component means that the react compiler can't do its thing to optimize, and eslint frowns.
Anyway, it stops applyLabelStyle from not rerunning during re-renders where it shouldn't.