### PR TITLE
Feature/1833 documenthandler maplink link search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Client: DocumentHandler - Fixed maplink and link not being triggered when opening a document via search results. [#1833](https://github.com/hajkmap/Hajk/issues/1833)
 - Client: DocumentHandler - Fixed subscription accumulation in Contents.jsx that caused duplicate print headers [#1773](https://github.com/hajkmap/Hajk/issues/1773)
 - Client: Ensure the Quick Access function respects the cookie setting [Issue #1798](https://github.com/hajkmap/Hajk/issues/1798)
 - Backend: Removed/replaced two unnecessary dependencies, see [commit](https://github.com/hajkmap/Hajk/commit/138e8668326b19a643542330ffef2ec5e3d847a6).

--- a/apps/client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.jsx
+++ b/apps/client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.jsx
@@ -83,10 +83,10 @@ class PanelMenuView extends React.PureComponent {
   #handleOpenDocumentFromLink = ({ documentName, headerIdentifier }) => {
     const itemClicked = findMenuItemWithDocumentName(documentName, this.state);
     this.#setDocument(documentName, headerIdentifier);
-    this.#handleExternalLinkClicked(itemClicked.id);
-    this.#handleShowMapLayersFromPanelMenu(itemClicked.id);
     this.#setItemStateProperties(itemClicked.id).then(() => {
       this.#scrollToMenuItem(itemClicked.itemRef.current.offsetTop);
+      this.#handleExternalLinkClicked(itemClicked.id);
+      this.#handleShowMapLayersFromPanelMenu(itemClicked.id);
     });
   };
 

--- a/apps/client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.jsx
+++ b/apps/client/src/plugins/DocumentHandler/panelMenu/PanelMenuContainerView.jsx
@@ -83,6 +83,8 @@ class PanelMenuView extends React.PureComponent {
   #handleOpenDocumentFromLink = ({ documentName, headerIdentifier }) => {
     const itemClicked = findMenuItemWithDocumentName(documentName, this.state);
     this.#setDocument(documentName, headerIdentifier);
+    this.#handleExternalLinkClicked(itemClicked.id);
+    this.#handleShowMapLayersFromPanelMenu(itemClicked.id);
     this.#setItemStateProperties(itemClicked.id).then(() => {
       this.#scrollToMenuItem(itemClicked.itemRef.current.offsetTop);
     });


### PR DESCRIPTION
## Summary

- maplink and link were not triggered when a document was opened via search results, only when clicked in the panel menu.
- Root cause: #handleOpenDocumentFromLink() only opened the document and it never called the external link or maplink handlers.
- Fix: two additional calls to #handleExternalLinkClicked() and #handleShowMapLayersFromPanelMenu() in #handleOpenDocumentFromLink() in PanelMenuContainerView.jsx.

## Test

- [ ] Configure a document menu item with maplink and/or link in the map config
- [ ] Search for a heading inside that document
- [ ] Click the search result and verify the document opens at the correct heading, the map zooms to the maplink, and/or the external link opens in a new tab
- [ ] Verify normal panel menu click still works as before

Fixes #1833