### PR TITLE
Enhance detailed request logger with structured output and file logging configuration

### DIFF
--- a/apps/backend/server/common/middlewares/detailed.request.logger.js
+++ b/apps/backend/server/common/middlewares/detailed.request.logger.js
@@ -3,17 +3,35 @@ import log4js from "log4js";
 const logger = log4js.getLogger("detailed.request.logger");
 
 export default function detailedRequestLogger(req, res, next) {
-  logger.trace("req.ip: %o", req.ip);
-  logger.trace("req.ips: %o", req.ips);
-  logger.trace(
-    "req.connection.remoteAddress: %o",
-    req.connection.remoteAddress
-  );
-  logger.trace("req.hostname: %o", req.hostname);
-  logger.trace("AD_TRUSTED_PROXY_IPS: %o", process.env.AD_TRUSTED_PROXY_IPS);
-  logger.trace(
-    "EXPRESS_TRUST_PROXY: app.set('trust proxy', %o)",
-    process.env.EXPRESS_TRUST_PROXY
-  );
+  const col = (k) => (k + ":").padEnd(26);
+
+  const allHeaders = Object.entries(req.headers);
+  const xHeaders = allHeaders.filter(([k]) => k.startsWith("x-"));
+
+  const lines = [
+    ``,
+    `┌─ ${req.method} ${req.originalUrl}`,
+    `│`,
+    `├─ Connection`,
+    `│  ${col("ip")}${req.ip ?? "-"}`,
+    `│  ${col("ips")}${JSON.stringify(req.ips)}`,
+    `│  ${col("remote address")}${req.connection?.remoteAddress ?? "-"}`,
+    `│  ${col("hostname")}${req.hostname ?? "-"}`,
+    `│`,
+    `├─ Proxy config`,
+    `│  ${col("AD_TRUSTED_PROXY_IPS")}${process.env.AD_TRUSTED_PROXY_IPS ?? "(not set)"}`,
+    `│  ${col("EXPRESS_TRUST_PROXY")}${process.env.EXPRESS_TRUST_PROXY ?? "(not set)"}`,
+    `│`,
+    `├─ X-* headers`,
+    ...(xHeaders.length > 0
+      ? xHeaders.map(([k, v]) => `│  ${col(k)}${v}`)
+      : [`│  (none)`]),
+    `│`,
+    `└─ All headers`,
+    ...allHeaders.map(([k, v]) => `   ${col(k)}${v}`),
+    ``,
+  ];
+
+  logger.info(lines.join("\n"));
   next();
 }

--- a/apps/backend/server/common/utils/hajkLogger.js
+++ b/apps/backend/server/common/utils/hajkLogger.js
@@ -66,6 +66,16 @@ log4js.configure({
       layout: { type: "messagePassThrough" },
       ...commonDateFileOptions,
     },
+    // Appender for the detailed request logger middleware.
+    detailedRequestLog: {
+      type: "dateFile",
+      filename: `logs/detailed-requests${uniqueInstance}.log`,
+      layout: {
+        type: "pattern",
+        pattern: "[%d]%m",
+      },
+      ...commonDateFileOptions,
+    },
   },
   // Categories specify _which appender is used with respective logger_. E.g., if we create
   // a logger with 'const logger = log4js.getLogger("foo")', and there exists a "foo" category
@@ -89,6 +99,13 @@ log4js.configure({
     ...(process.env.LOG_ACCESS_LOG_TO.trim().length !== 0 && {
       http: {
         appenders: process.env.LOG_ACCESS_LOG_TO.split(","),
+        level: "all",
+      },
+    }),
+    // If activated in .env, write detailed request log to its own file, independent of LOG_LEVEL
+    ...(process.env.LOG_DETAILED_REQUEST_LOGGER === "true" && {
+      "detailed.request.logger": {
+        appenders: ["detailedRequestLog"],
         level: "all",
       },
     }),


### PR DESCRIPTION
I needed to debug my backend log to ensure that auth works as intended. This got me thinking that the Backend has always had a "detailed request logger" just for time like this, that prints some relevant info. 

But it was ugly and did not contain the most important part for me know: the X-* headers. 

So here's a remake of that feature. Changed:
- writes to a dedicated log file in `logs/`
- much nicer formatting
- prints all headers

Preview:

<img width="553" height="547" alt="image" src="https://github.com/user-attachments/assets/0e032ca7-7ce8-41c6-86c3-3c92f643fd08" />
