### PR TITLE
LayerSwitcher: add a `exclusive` setting to groups, allow only one layer to be visible at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client: Infoclick - Functionality to hide links that point to non-existing resources [#1804](https://github.com/hajkmap/Hajk/issues/1804)
 - Client: LayerComparer - Added the long-awaited spy glass mode [#1808](https://github.com/hajkmap/Hajk/issues/1808)
 - Client: LayerComparer - The Spy can now be resized and the transparency can be changed [#1812](https://github.com/hajkmap/Hajk/issues/1812)
+- Client: LayerSwitcher - A group can now be set to be `exclusive`, meaning that its layers will be rendered as radio buttons and just one layer will be allowed to be visible at a given time. [#1848](https://github.com/hajkmap/Hajk/pull/1848)
 - Admin: You can now configure CQL filters for WMS layers directly in the admin interface [#1818](https://github.com/hajkmap/Hajk/issues/1818)
 - Client: Better WMTS Support [#1795](https://github.com/hajkmap/Hajk/issues/1795)
 - Client: LayerSwitcher - it is possible to add an additional style to WMS layers that contains feature labels. A button in the LayerSwitcher allows user to control labels' visibility for such a layer. [#1816](https://github.com/hajkmap/Hajk/issues/1816)

--- a/apps/admin/src/views/mapsettings.jsx
+++ b/apps/admin/src/views/mapsettings.jsx
@@ -93,6 +93,7 @@ $.fn.editable = function (component) {
       remove.remove();
       toggled.remove();
       expanded.remove();
+      exclusive.remove();
       infogroupcontainer.remove();
       infogroupvisible.remove();
       infogrouptitle.remove();
@@ -111,6 +112,7 @@ $.fn.editable = function (component) {
       let name = input.val();
       let toggled = checkbox2.is(":checked");
       let expanded = checkbox.is(":checked");
+      let exclusive = checkbox6.is(":checked");
       let infogroupvisible = checkbox5.is(":checked");
       let infogrouptitle = infogroupvisible ? input5.val() : "";
       let infogrouptext = infogroupvisible ? input6.val() : "";
@@ -123,6 +125,7 @@ $.fn.editable = function (component) {
       node.parent().attr("data-name", name);
       node.parent().attr("data-toggled", toggled);
       node.parent().attr("data-expanded", expanded);
+      node.parent().attr("data-exclusive", exclusive);
       node.parent().attr("data-infogroupvisible", infogroupvisible);
       node.parent().attr("data-infogrouptitle", infogrouptitle);
       node.parent().attr("data-infogrouptext", infogrouptext);
@@ -170,6 +173,7 @@ $.fn.editable = function (component) {
       id12 = Math.floor(Math.random() * 1e5),
       id13 = Math.floor(Math.random() * 1e5),
       id14 = Math.floor(Math.random() * 1e5),
+      id15 = Math.floor(Math.random() * 1e5),
       ok = $('<span class="btn btn-success">OK</span>'),
       layerOk = $('<span class="btn btn-success">OK</span>'),
       layerOk2 = $('<span class="btn btn-success">OK</span>'),
@@ -189,6 +193,9 @@ $.fn.editable = function (component) {
       label5 = $(`<br /><label for="${id6}">Tillträde</label><br />`),
       label6 = $(`<label for="${id7}">Infobox</label><br />`),
       label7 = $(`<label for="${id8}">Infodokument&nbsp;</label>`).css(
+        groupCheckboxLabelStyle
+      ),
+      label14 = $(`<label for="${id15}">Exklusiv grupp&nbsp;</label>`).css(
         groupCheckboxLabelStyle
       ),
       label8 = $(`<label for="${id9}">Rubrik&nbsp;</label>`).css(
@@ -214,6 +221,7 @@ $.fn.editable = function (component) {
       checkbox3 = $(`<input id="${id3}" type="checkbox"/>`),
       checkbox4 = $(`<input id="${id4}" type="text" value="Nytt namn"/><br />`),
       checkbox5 = $(`<input id="${id8}" type="checkbox"/>`),
+      checkbox6 = $(`<input id="${id15}" type="checkbox"/>`),
       remove = $('<span class="fa fa-minus-circle"></span>'),
       input = $("<input />"),
       input2 = $(`<input id="${id5}" type="text" placeholder="Ny länk"/>`),
@@ -229,6 +237,7 @@ $.fn.editable = function (component) {
       input10 = $(`<input id="${id14}" type="text"/>`).css(infoGroupInputStyle),
       expanded = $('<div class="expanded-at-start"></div>'),
       toggled = $('<div class="expanded-at-start"></div>'),
+      exclusive = $('<div class="expanded-at-start"></div>'),
       infogroupvisible = $('<div class="expanded-at-start"></div>'),
       infogroupcontainer = $('<div class="info-groupContainer"></div>'),
       infogrouptitle = $("<div></div>").css(infoGroupStyle),
@@ -264,6 +273,9 @@ $.fn.editable = function (component) {
     }
     if (node.parent().attr("data-toggled")) {
       checkbox2.attr("checked", JSON.parse(node.parent().attr("data-toggled")));
+    }
+    if (node.parent().attr("data-exclusive")) {
+      checkbox6.attr("checked", JSON.parse(node.parent().attr("data-exclusive")));
     }
 
     if (node.parent().attr("data-infogroupvisible")) {
@@ -316,6 +328,7 @@ $.fn.editable = function (component) {
     ) {
       expanded.append(checkbox, label);
       toggled.append(checkbox2, label2);
+      exclusive.append(checkbox6, label14);
       infogroupvisible.append(checkbox5, label7);
       infogrouptitle.append(label8, input5);
       infogrouptext.append(label9, input6);
@@ -398,7 +411,7 @@ $.fn.editable = function (component) {
       marginTop: "7px",
     });
 
-    tools.append(ok, abort, toggled, expanded, infogroupvisible);
+    tools.append(ok, abort, toggled, expanded, exclusive, infogroupvisible);
 
     infogroupcontainer.append(
       infogrouptitle,
@@ -924,6 +937,7 @@ class Menu extends Component {
         name: node.dataset.name,
         toggled: checkIfTrue(node.dataset.toggled),
         expanded: checkIfTrue(node.dataset.expanded),
+        exclusive: checkIfTrue(node.dataset.exclusive),
         infogroupvisible: checkIfTrue(node.dataset.infogroupvisible),
         infogrouptitle: node.dataset.infogrouptitle,
         infogrouptext: node.dataset.infogrouptext,
@@ -1155,6 +1169,7 @@ class Menu extends Component {
     name,
     expanded,
     toggled,
+    exclusive,
     infogroupvisible,
     infogrouptitle,
     infogrouptext,
@@ -1171,6 +1186,7 @@ class Menu extends Component {
         data-type="group"
         data-toggled="${toggled}"
         data-expanded="${expanded}"
+        data-exclusive="${exclusive}"
         data-infogroupvisible="${infogroupvisible}"
         data-infogrouptitle="${infogrouptitle}"
         data-infogrouptext="${infogrouptext}"
@@ -1382,6 +1398,7 @@ class Menu extends Component {
               data-type="group"
               data-expanded={group.expanded}
               data-toggled={group.toggled}
+              data-exclusive={group.exclusive}
               data-infogroupvisible={group.infogroupvisible}
               data-infogrouptitle={group.infogrouptitle}
               data-infogrouptext={group.infogrouptext}
@@ -2641,6 +2658,7 @@ class Menu extends Component {
                   onClick={(e) =>
                     this.createGroup(
                       "Ny grupp",
+                      false,
                       false,
                       false,
                       false,

--- a/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/LayerSwitcherProvider.jsx
@@ -395,6 +395,7 @@ const buildLayerTree = (groups, olLayerMap) =>
       groupIsToggable: group.toggled,
       defaultExpanded: group.expanded,
       parent: group.parent,
+      exclusive: group.exclusive,
     };
   });
 

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerGroup.jsx
@@ -124,6 +124,11 @@ const LayerGroup = ({
       ? overrideToggleable
       : staticGroupTree.groupIsToggable;
 
+  // An exclusive group means that only one child can be toggled on at a time.
+  // This is controlled by the "exclusive" property on the group and implemented
+  // in the UI using radio buttons.
+  const groupIsExclusive = staticGroupTree.exclusive ?? false;
+
   const infogrouptitle = groupConfig?.infogrouptitle;
   const infogrouptext = groupConfig?.infogrouptext;
   const infogroupurl = groupConfig?.infogroupurl;
@@ -196,7 +201,7 @@ const LayerGroup = ({
         disableAccordion={disableAccordion}
         toggleDetails={
           <ToggleAllComponent
-            toggleable={groupIsToggable}
+            toggleable={groupIsToggable && !groupIsExclusive} // Exclusive groups cannot be toggled as a whole, only individual children
             toggleState={toggleState}
             clickHandler={() => {
               if (limitToggleToTree) {
@@ -280,6 +285,26 @@ const LayerGroup = ({
               return null;
             }
 
+            // Exclusive groups act as radio buttons: toggling one layer turns off all siblings.
+            // directChildLayerIds excludes sub-groups, so we only affect direct layer children.
+            // First, let's grab the ids of all direct child layers. Then we can use those ids
+            // in the callback to toggle siblings off when another is toggled on.
+            const directChildLayerIds = children
+              .filter((c) => staticLayerConfig[c.id]?.layerType !== "group")
+              .map((c) => c.id);
+
+            const exclusiveClickCallback = groupIsExclusive
+              ? () => {
+                  const nowVisible = !layerState?.layerIsToggled;
+                  directChildLayerIds.forEach((sibId) => {
+                    if (sibId !== layerId) {
+                      layerSwitcherDispatch.setLayerVisibility(sibId, false);
+                    }
+                  });
+                  layerSwitcherDispatch.setLayerVisibility(layerId, nowVisible);
+                }
+              : undefined;
+
             return layerSettings.layerType === "groupLayer" ? (
               <GroupLayer
                 key={layerId}
@@ -301,6 +326,8 @@ const LayerGroup = ({
                 toggleable={true}
                 globalObserver={globalObserver}
                 filterValue={filterValue}
+                isExclusive={groupIsExclusive}
+                clickCallback={exclusiveClickCallback}
               />
             );
           })}

--- a/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LayerItem.jsx
@@ -23,6 +23,7 @@ import BtnLayerWarning from "./BtnLayerWarning";
 import BtnShowLegend from "./BtnShowLegend";
 import BtnToggleLayerLabel from "./BtnToggleLayerLabel";
 import LsCheckBox from "./LsCheckBox";
+import LsRadioButton from "./LsRadioButton";
 
 import { useMapZoom } from "../LayerSwitcherProvider";
 import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
@@ -100,6 +101,7 @@ function LayerItem({
   subLayersSection,
   isGroupLayerQuickAccess,
   isLayerQuickAccess,
+  isExclusive,
 }) {
   // WmsLayer load status, shows warning icon if !ok
   const [wmsLayerLoadStatus, setWmsLayerLoadStatus] = useState("ok");
@@ -389,16 +391,26 @@ function LayerItem({
               borderBottom: (theme) => renderBorder(theme),
             }}
           >
-            {toggleable && (
-              <LsCheckBox
-                id={
-                  !isLayerQuickAccess && !isGroupLayerQuickAccess
-                    ? "toggle-layer-item"
-                    : undefined
-                }
-                toggleState={toggleState}
-              />
-            )}
+            {toggleable &&
+              (isExclusive ? (
+                <LsRadioButton
+                  id={
+                    !isLayerQuickAccess && !isGroupLayerQuickAccess
+                      ? "toggle-layer-item"
+                      : undefined
+                  }
+                  toggleState={toggleState}
+                />
+              ) : (
+                <LsCheckBox
+                  id={
+                    !isLayerQuickAccess && !isGroupLayerQuickAccess
+                      ? "toggle-layer-item"
+                      : undefined
+                  }
+                  toggleState={toggleState}
+                />
+              ))}
             <LayerLegendIcon
               legendIcon={legendIcon}
               layerType={layerType}

--- a/apps/client/src/plugins/LayerSwitcher/components/LsRadioButton.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/LsRadioButton.jsx
@@ -1,0 +1,41 @@
+import { Box } from "@mui/material";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
+import LsIconButton from "./LsIconButton";
+
+const LsRadioButton = ({ toggleState, id }) => {
+  return (
+    <LsIconButton id={id} size="small" sx={{}}>
+      <RadioButtonUncheckedIcon />
+      <Box
+        sx={[
+          {
+            position: "absolute",
+            top: "calc(50%)",
+            left: "50%",
+            transition: "transform 200ms ease, opacity 200ms ease",
+            lineHeight: 0,
+          },
+          toggleState !== "unchecked"
+            ? {
+                transform: "translate(-50%, -50%) scale(1.05)",
+              }
+            : {
+                transform: "translate(-50%, -50%) scale(0.0)",
+              },
+          toggleState !== "unchecked"
+            ? {
+                opacity: 1.0,
+              }
+            : {
+                opacity: 0.0,
+              },
+        ]}
+      >
+        <RadioButtonCheckedIcon />
+      </Box>
+    </LsIconButton>
+  );
+};
+
+export default LsRadioButton;


### PR DESCRIPTION
This PR adds a long-wished-for feature: layers in a group can now be rendered as radio buttons rather than regular checkboxes. This is very useful for certain use cases, see attached video. 

I ensured that it's possible to deselect a layer too, which is not the typical behaviour for radio buttons but a necessity if we want to be able to actually turn off all layers in such a group (which must be possible IMO). 


https://github.com/user-attachments/assets/4e589c87-aefa-497f-8cd3-3e21638968a8

There even is a corresponding setting in Admin:
<img width="545" height="365" alt="image" src="https://github.com/user-attachments/assets/038e5ca1-fc13-4322-a586-4bfe5b99e2c9" />
