### PR TITLE
Added the `matchAllWordsInSameField` option to search settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Client + Admin: Search - Added an optional setting "Kräv att alla sökord matchar i samma fält" that requires all words in a multi-word search to match within one and the same field, avoiding cross-field false positives. Off by default to preserve current behavior. [#1850](https://github.com/hajkmap/Hajk/issues/1850)
 - Client + Admin: LayerSwitcher - Added a new admin setting "Visa teckenförklaring direkt" that forces the legend to be expanded by default in the layer details view, so users don't have to click the legend button. [#1838](https://github.com/hajkmap/Hajk/issues/1838)
 - Client + Admin: DocumentHandler - Added a "Direct Print" setting that prints the currently active document directly without showing the document selection dialog [#1773](https://github.com/hajkmap/Hajk/issues/1773)
 - Client: Infoclick - Functionality to hide links that point to non-existing resources [#1804](https://github.com/hajkmap/Hajk/issues/1804)

--- a/apps/admin/src/views/tools/search.jsx
+++ b/apps/admin/src/views/tools/search.jsx
@@ -31,6 +31,7 @@ const defaultState = {
   delayBeforeAutoSearch: 500,
   disableAutocomplete: false,
   disableSearchCombinations: false,
+  matchAllWordsInSameField: false,
   searchBarPlaceholder: "Sök...",
   excelColumnFilter: "",
   autocompleteWildcardAtStart: false,
@@ -164,6 +165,9 @@ class ToolOptions extends Component {
           disableSearchCombinations:
             tool.options.disableSearchCombinations ??
             this.state.disableSearchCombinations,
+          matchAllWordsInSameField:
+            tool.options.matchAllWordsInSameField ??
+            this.state.matchAllWordsInSameField,
           autocompleteWildcardAtStart:
             tool.options.autocompleteWildcardAtStart ??
             this.state.autocompleteWildcardAtStart,
@@ -389,6 +393,7 @@ class ToolOptions extends Component {
         delayBeforeAutoSearch: this.state.delayBeforeAutoSearch,
         disableAutocomplete: this.state.disableAutocomplete,
         disableSearchCombinations: this.state.disableSearchCombinations,
+        matchAllWordsInSameField: this.state.matchAllWordsInSameField,
         searchBarPlaceholder: this.state.searchBarPlaceholder,
         excelColumnFilter: this.state.excelColumnFilter,
         autocompleteWildcardAtStart: this.state.autocompleteWildcardAtStart,
@@ -813,6 +818,29 @@ class ToolOptions extends Component {
                 (Kombinationerna kan öka möjligheten att användarna hittar vad de
                 letar efter, men det kan ta längre tid för servern att bearbeta
                 sökningen.)"
+              />
+            </label>
+          </div>
+          <div>
+            <input
+              id="matchAllWordsInSameField"
+              name="matchAllWordsInSameField"
+              type="checkbox"
+              onChange={(e) => {
+                this.handleInputChange(e);
+              }}
+              checked={this.state.matchAllWordsInSameField}
+            />
+            &nbsp;
+            <label htmlFor="matchAllWordsInSameField" className="long-label">
+              Kräv att alla sökord matchar i samma fält{" "}
+              <i
+                className="fa fa-question-circle"
+                data-toggle="tooltip"
+                title="Vid sökning på flera ord kräver att samtliga ord
+                matchar inom ett och samma fält. Förhindrar oväntade träffar
+                där olika sökord matchar i olika fält (t.ex. ett ord i
+                fastighet_f och ett annat i fastighet_l)."
               />
             </label>
           </div>

--- a/apps/client/src/components/Search/Search.jsx
+++ b/apps/client/src/components/Search/Search.jsx
@@ -502,6 +502,7 @@ class Search extends React.PureComponent {
       ...fetchSettings,
       wildcardAtStart: options.autocompleteWildcardAtStart || false,
       getPossibleCombinations: !this.disableSearchCombinations,
+      matchAllWordsInSameField: options.matchAllWordsInSameField ?? false,
       initiator: "autocomplete",
     };
     return fetchSettings;
@@ -1033,6 +1034,8 @@ class Search extends React.PureComponent {
       matchCase: matchCase,
       wildcardAtStart: wildcardAtStart,
       wildcardAtEnd: wildcardAtEnd,
+      matchAllWordsInSameField:
+        this.props.options?.matchAllWordsInSameField ?? false,
       maxResultsPerDataset: maxResultsPerDataset,
     };
   };

--- a/apps/client/src/models/SearchModel.js
+++ b/apps/client/src/models/SearchModel.js
@@ -28,6 +28,7 @@ class SearchModel {
     matchCase: false, // should search be case sensitive?
     wildcardAtStart: false, // should the search string start with the wildcard character?
     wildcardAtEnd: true, // should the search string be end with the wildcard character?
+    matchAllWordsInSameField: false, // should all words be required to match within the same field?
   };
 
   #componentOptions;
@@ -290,6 +291,28 @@ class SearchModel {
   };
 
   #getSearchFilters = (wordsArray, searchSource, searchOptions) => {
+    // Opt-in behavior: require all words to match within the SAME field.
+    // We build an OR across fields of (AND across words), so a feature only
+    // matches when one and the same field contains every word. This avoids
+    // cross-field false positives (e.g. one word matching "fastighet_f" while
+    // another matches "fastighet_l"). Only meaningful for multi-field,
+    // multi-word queries; otherwise fall through to the existing logic.
+    if (
+      searchOptions.matchAllWordsInSameField &&
+      searchSource.searchFields.length > 1 &&
+      wordsArray.length > 1
+    ) {
+      return new Or(
+        ...searchSource.searchFields.map((searchField) => {
+          return new And(
+            ...wordsArray.map((word) => {
+              return this.#getIsLikeFilter(searchField, word, searchOptions);
+            })
+          );
+        })
+      );
+    }
+
     if (searchSource.searchFields.length > 1) {
       let OrFilters = wordsArray.map((word) => {
         return this.#getOrFilter(word, searchSource, searchOptions);


### PR DESCRIPTION
When active, this requires all words in a multi-word search to match within one and the same field, avoiding cross-field false positives.

It was implemented in order to close #1850, but as I documented in that issue, I found that the already-existing `disableSearchCombinations` setting does a similar job and solved our specific use case.

For that reason I do not plan to merge this into `develop`. But I save this code in a separate branch in order someone finds it useful and wants to merge. This is non-obstructive - does not modify existing behavior, so it could be merged safely.