### PR TITLE
Fix for issue 1831 window collapse should hide color marker.

### DIFF
--- a/apps/client/src/components/PanelHeader.jsx
+++ b/apps/client/src/components/PanelHeader.jsx
@@ -22,9 +22,9 @@ const StyledHeader = styled("header")(({ theme }) => ({
         mode: "minimized",
       },
       style: {
-        padding: {
-          padding: theme.spacing(0),
-        },
+        padding: `0 ${theme.spacing(2)}`,
+        borderBottom: "none",
+        minHeight: 50,
       },
     },
   ],


### PR DESCRIPTION
As per [Issue 1831](https://github.com/hajkmap/Hajk/issues/1831)

This is an attempt to fix the hiding of the color marker on all windows that uses the PanelHeader. Albeit some windows had their color marker already not visible on collapse, examples like Bookmarks and the Document Handler window did show their color marker.

<img width="849" height="234" alt="Screenshot from 2026-06-24 18-19-27" src="https://github.com/user-attachments/assets/05e4e150-b105-41c7-9d4e-2e92615bbaa1" />
