### PR TITLE
MapSwitcher dropdown on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client: LayerSwitcher - Fix an issue where loading saved favorites and presets did not hide previously visible group layers ([commit](https://github.com/hajkmap/Hajk/commit/bc49dc4fa73c820546b90f97870a17d0a6cb1a00)).
 - Client: Search - User's limit of search sources (made in search settings) was not respected in Safari. [#1852](https://github.com/hajkmap/Hajk/issues/1852).
 - Client: Crashes when activating Snap-enabled tools (e.g. PropertyChecker) with nested GeometryCollection features in the map. [#1860](https://github.com/hajkmap/Hajk/issues/1860).
+- Client: MapSwitcher can now be configured to show as a larger dropdown element next to the search box (in addition to the traditional Control button). [#1858](https://github.com/hajkmap/Hajk/issues/1858).
 
 ## [4.3.0] 2026-04-20
 

--- a/apps/admin/src/views/mapoptions.jsx
+++ b/apps/admin/src/views/mapoptions.jsx
@@ -63,6 +63,7 @@ class MapOptions extends Component {
         pinchRotate: config.pinchRotate || true,
         pinchZoom: config.pinchZoom || true,
         mapselector: config.mapselector,
+        mapSelectorStyle: config.mapSelectorStyle || "button",
         mapcleaner: config.mapcleaner,
         mapresetter: config.mapresetter,
         showThemeToggler: config.showThemeToggler,
@@ -174,6 +175,7 @@ class MapOptions extends Component {
       zoomDelta: mapConfig.zoomDelta || "",
       zoomDuration: mapConfig.zoomDuration || "",
       mapselector: mapConfig.mapselector,
+      mapSelectorStyle: mapConfig.mapSelectorStyle || "button",
       mapcleaner: mapConfig.mapcleaner,
       mapresetter: mapConfig.mapresetter,
       showThemeToggler: mapConfig.showThemeToggler,
@@ -454,6 +456,7 @@ class MapOptions extends Component {
         config.zoomDelta = this.getValue("zoomDelta");
         config.zoomDuration = this.getValue("zoomDuration");
         config.mapselector = this.getValue("mapselector");
+        config.mapSelectorStyle = this.getValue("mapSelectorStyle");
         config.mapcleaner = this.getValue("mapcleaner");
         config.mapresetter = this.getValue("mapresetter");
         config.showThemeToggler = this.getValue("showThemeToggler");
@@ -1320,9 +1323,33 @@ class MapOptions extends Component {
                 <i
                   className="fa fa-question-circle"
                   data-toggle="tooltip"
-                  title="Om aktiv kommer en väljare med andra tillgängliga kartor att visas för användaren"
+                  title="Om aktiv kommer en väljare med andra tillgängliga kartor att visas för användaren (förutsatt att det finns fler än en karta)"
                 />
               </label>
+              {this.state.mapselector && (
+                <div style={{ marginLeft: 24, marginTop: 4 }}>
+                  <select
+                    id="input_mapSelectorStyle"
+                    ref="input_mapSelectorStyle"
+                    value={this.state.mapSelectorStyle}
+                    onChange={(e) => {
+                      this.setState({ mapSelectorStyle: e.target.value });
+                    }}
+                    style={{ width: 200 }}
+                  >
+                    <option value="button">Visa som knapp</option>
+                    <option value="dropdown">
+                      Visa som rullista i sidhuvudet (endast desktop)
+                    </option>
+                  </select>
+                  <i
+                    className="fa fa-question-circle"
+                    data-toggle="tooltip"
+                    title="Rullistan visas endast på desktop. På mobila enheter visas knappen istället."
+                    style={{ marginLeft: 4 }}
+                  />
+                </div>
+              )}
             </div>
             <div>
               <input

--- a/apps/client/src/components/App.jsx
+++ b/apps/client/src/components/App.jsx
@@ -1218,6 +1218,9 @@ class App extends React.PureComponent {
     const showMapSwitcher =
       clean === false && config.activeMap !== "simpleMapAndLayersConfig";
 
+    const mapSelectorStyle =
+      config.mapConfig?.map?.mapSelectorStyle || "button";
+
     const useNewInfoclick = this.infoclickOptions?.useNewInfoclick === true;
 
     return (
@@ -1285,8 +1288,22 @@ class App extends React.PureComponent {
                   drawerStatic={this.state.drawerStatic}
                 />
               )}
-              {/* Render Search even if clean === false: Search contains logic to handle clean inside the component. */}
-              {this.renderSearchComponent()}
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  ml: this.showDrawerButtons() ? 0 : "auto",
+                }}
+              >
+                {showMapSwitcher &&
+                  mapSelectorStyle === "dropdown" &&
+                  !isMobile && (
+                    <MapSwitcher appModel={this.appModel} variant="dropdown" />
+                  )}
+                {/* Render Search even if clean === false: Search contains logic to handle clean inside the component. */}
+                {this.renderSearchComponent()}
+              </Box>
             </StyledHeader>
             <WindowsContainer id="windows-container">
               {useNewInfoclick === false && this.renderInfoclickWindow()}
@@ -1355,7 +1372,10 @@ class App extends React.PureComponent {
                   />
                 )}
                 <Rotate map={this.appModel.getMap()} />
-                {showMapSwitcher && <MapSwitcher appModel={this.appModel} />}
+                {showMapSwitcher &&
+                  (isMobile || mapSelectorStyle !== "dropdown") && (
+                    <MapSwitcher appModel={this.appModel} />
+                  )}
                 {clean === false && <MapCleaner appModel={this.appModel} />}
                 {clean === false && <PresetLinks appModel={this.appModel} />}
                 {clean === false && <ExternalLinks appModel={this.appModel} />}

--- a/apps/client/src/controls/MapSwitcher.jsx
+++ b/apps/client/src/controls/MapSwitcher.jsx
@@ -143,21 +143,27 @@ class MapSwitcher extends React.PureComponent {
               : ""
           }
           onChange={this.handleChange}
+          renderValue={() =>
+            selectedIndex !== null && this.maps[selectedIndex]
+              ? this.maps[selectedIndex].mapConfigurationTitle
+              : ""
+          }
           displayEmpty
           sx={{
             height: (theme) => theme.spacing(6),
             backgroundColor: "background.paper",
           }}
         >
-          {this.maps.map((item, index) => (
-            <MenuItem
-              key={index}
-              value={item.mapConfigurationName}
-              selected={index === selectedIndex}
-            >
-              {item.mapConfigurationTitle}
-            </MenuItem>
-          ))}
+          {this.maps
+            .filter((_, index) => index !== selectedIndex)
+            .map((item) => (
+              <MenuItem
+                key={item.mapConfigurationName}
+                value={item.mapConfigurationName}
+              >
+                {item.mapConfigurationTitle}
+              </MenuItem>
+            ))}
         </Select>
       </FormControl>
     );

--- a/apps/client/src/controls/MapSwitcher.jsx
+++ b/apps/client/src/controls/MapSwitcher.jsx
@@ -83,10 +83,24 @@ class MapSwitcher extends React.PureComponent {
       const hashParams = new URLSearchParams(
         window.location.hash.replaceAll("#", "")
       );
+      // Set the m param to the new map's name
       hashParams.set("m", selectedMap);
+      // We must remove layer and group layer keys as it's really
+      // dangerous to keep them. If a layer, specified in l, wouldn't
+      // be available in the new map we're changing to, we would end up
+      // with no layers at all. (The reason for that is that _if_ the l param
+      // is present, the visibleAtStart value for layers from map config are
+      // ignored. We don't want to do that when changing map, so be sure and
+      // remove them.)
+      // TODO: Consider removing more keys, if issues come up. Candidates include
+      // "q", "s" and "p".
       hashParams.delete("l");
       hashParams.delete("gl");
+
+      // Set the modified hash to our location bar
       url.hash = "#" + hashParams.toString();
+
+      // Force the browser to reload
       window.location.href = url.toString();
     } else {
       // If live hash params are disabled, fall back to the old and tried

--- a/apps/client/src/controls/MapSwitcher.jsx
+++ b/apps/client/src/controls/MapSwitcher.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, MenuItem } from "@mui/material";
+import { Menu, MenuItem, Select, FormControl } from "@mui/material";
 import SwitchCameraIcon from "@mui/icons-material/SwitchCamera";
 import { hfetch } from "../utils/FetchWrapper";
 import ControlButton from "components/ControlButton";
@@ -76,35 +76,18 @@ class MapSwitcher extends React.PureComponent {
   handleMenuItemClick = (event, index) => {
     const selectedMap = this.maps[index].mapConfigurationName;
     if (this.appModel.config.mapConfig.map?.enableAppStateInHash === true) {
-      // If live changing of hash params is enabled, grab the old hash
-      const oldHash = new URLSearchParams(
+      // Build a clean URL: clear query params to avoid conflicts,
+      // set the m param in the hash, and reload.
+      const url = new URL(window.location.href);
+      url.search = "";
+      const hashParams = new URLSearchParams(
         window.location.hash.replaceAll("#", "")
       );
-
-      // Set the m param to the new map's name
-      oldHash.set("m", selectedMap);
-
-      // We must remove layer and group layer keys as it's really
-      // dangerous to keep them. If a layer, specified in l, wouldn't
-      // be available in the new map we're changing to, we would end up
-      // with no layers at all. (The reason for that is that _if_ the l param
-      // is present, the visibleAtStart value for layers from map config are
-      // ignored. We don't want to do that when changing map, so be sure and
-      // remove them.)
-      // TODO: Consider removing more keys, if issues come up. Candidates include
-      // "q", "s" and "p".
-      oldHash.delete("l");
-      oldHash.delete("gl");
-
-      // Set the modified hash to our location bar
-      window.location.hash = "#" + oldHash.toString();
-
-      // Force the browser to reload
-      window.location.reload();
-
-      // Not needed, but if we will ever go towards hot reload,
-      // don't forget to hide the dropdown menu
-      // this.setState({ anchorEl: null, selectedIndex: index });
+      hashParams.set("m", selectedMap);
+      hashParams.delete("l");
+      hashParams.delete("gl");
+      url.hash = "#" + hashParams.toString();
+      window.location.href = url.toString();
     } else {
       // If live hash params are disabled, fall back to the old and tried
       // method of setting query params. This will also reload the page
@@ -114,9 +97,7 @@ class MapSwitcher extends React.PureComponent {
       const y = this.map.getView().getCenter()[1];
       const z = this.map.getView().getZoom();
 
-      window.location.assign(
-        `${window.location.origin}${window.location.pathname}?m=${selectedMap}&x=${x}&y=${y}&z=${z}`
-      );
+      window.location.href = `${window.location.origin}${window.location.pathname}?m=${selectedMap}&x=${x}&y=${y}&z=${z}`;
     }
   };
 
@@ -124,36 +105,85 @@ class MapSwitcher extends React.PureComponent {
     this.setState({ anchorEl: null });
   };
 
+  handleChange = (event) => {
+    const selectedMapName = event.target.value;
+    const index = this.maps.findIndex(
+      (m) => m.mapConfigurationName === selectedMapName
+    );
+    if (index !== -1) {
+      this.handleMenuItemClick(event, index);
+    }
+  };
+
+  renderDropdown = () => {
+    const { selectedIndex } = this.state;
+
+    return (
+      <FormControl sx={{ minWidth: 180 }}>
+        <Select
+          variant="outlined"
+          size="small"
+          value={
+            selectedIndex !== null && this.maps[selectedIndex]
+              ? this.maps[selectedIndex].mapConfigurationName
+              : ""
+          }
+          onChange={this.handleChange}
+          displayEmpty
+          sx={{
+            height: (theme) => theme.spacing(6),
+            backgroundColor: "background.paper",
+          }}
+        >
+          {this.maps.map((item, index) => (
+            <MenuItem
+              key={index}
+              value={item.mapConfigurationName}
+              selected={index === selectedIndex}
+            >
+              {item.mapConfigurationTitle}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    );
+  };
+
   render() {
     const { anchorEl } = this.state;
     const open = Boolean(anchorEl);
+    const { variant = "button" } = this.props;
 
     const title =
       this.props.appModel.config.mapConfig.map.title || "Karta utan titel";
 
+    if (!this.props.appModel.config.mapConfig.map.mapselector) return null;
+    if (this.maps.length <= 1) return null;
+
+    if (variant === "dropdown") {
+      return this.renderDropdown();
+    }
+
     return (
-      // Render only if config says so
-      this.props.appModel.config.mapConfig.map.mapselector && (
-        <>
-          <ControlButton
-            tooltip={`Nuvarande karta: ${title}`}
-            ariaLabel="Byt karta"
-            aria-owns={open ? "render-props-menu" : undefined}
-            aria-haspopup="true"
-            onClick={this.handleClick}
-          >
-            <SwitchCameraIcon />
-          </ControlButton>
-          <Menu
-            id="render-props-menu"
-            anchorEl={anchorEl}
-            open={open}
-            onClose={this.handleClose}
-          >
-            {this.renderMenuItems()}
-          </Menu>
-        </>
-      )
+      <>
+        <ControlButton
+          tooltip={`Nuvarande karta: ${title}`}
+          ariaLabel="Byt karta"
+          aria-owns={open ? "render-props-menu" : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          <SwitchCameraIcon />
+        </ControlButton>
+        <Menu
+          id="render-props-menu"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={this.handleClose}
+        >
+          {this.renderMenuItems()}
+        </Menu>
+      </>
     );
   }
 }

--- a/apps/client/src/controls/MapSwitcher.jsx
+++ b/apps/client/src/controls/MapSwitcher.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, MenuItem, Select, FormControl } from "@mui/material";
+import { Menu, MenuItem, Select, FormControl, InputLabel } from "@mui/material";
 import SwitchCameraIcon from "@mui/icons-material/SwitchCamera";
 import { hfetch } from "../utils/FetchWrapper";
 import ControlButton from "components/ControlButton";
@@ -134,9 +134,12 @@ class MapSwitcher extends React.PureComponent {
 
     return (
       <FormControl sx={{ minWidth: 180 }}>
+        <InputLabel id="selected-map-label">Aktiv karta</InputLabel>
         <Select
           variant="outlined"
           size="small"
+          label="Aktiv karta"
+          labelId="selected-map-label"
           value={
             selectedIndex !== null && this.maps[selectedIndex]
               ? this.maps[selectedIndex].mapConfigurationName


### PR DESCRIPTION
Suggested fix for [1858](https://github.com/hajkmap/Hajk/issues/1858).

The dropdown in configurable in the admin tool per map.
"Visa som knapp" or "Visa som rullista i sidhuvud".
<img width="629" height="151" alt="Screenshot from 2026-06-27 11-43-07" src="https://github.com/user-attachments/assets/a03b9e07-c533-4a91-ba6f-00a57585f334" />

The dropdown is hidden on mobile and the button is shown instead in it's normal place (even if the map is set to "Visa som rullista i sidhuvud").
This is currently not responsive since isMobile is evaluated once when App.jsx is mounted.

<img width="607" height="608" alt="Screenshot from 2026-06-27 11-57-39" src="https://github.com/user-attachments/assets/d9398ebe-c69f-465c-a912-fb9b58506a8c" />

