### PR TITLE
Version 1.0 of LayerControlModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Client: Add centralized LayerControlModel API (showLayer/hideLayer/toggleLayer/layerIsVisible) for toggling layers by id, exposed on the AppModel and `window.hajkPublicApi`, plus `useLayerVisibility`/`useLayerState` React hooks.
 - Client + Admin: LayerSwitcher - Added a new admin setting "Visa teckenförklaring direkt" that forces the legend to be expanded by default in the layer details view, so users don't have to click the legend button. [#1838](https://github.com/hajkmap/Hajk/issues/1838)
 - Client + Admin: DocumentHandler - Added a "Direct Print" setting that prints the currently active document directly without showing the document selection dialog [#1773](https://github.com/hajkmap/Hajk/issues/1773)
 - Client: Infoclick - Functionality to hide links that point to non-existing resources [#1804](https://github.com/hajkmap/Hajk/issues/1804)

--- a/apps/client/src/components/App.jsx
+++ b/apps/client/src/components/App.jsx
@@ -488,6 +488,7 @@ class App extends React.PureComponent {
       .createMap()
       .addSearchModel()
       .addLayers()
+      .addLayerControl() // Layer control must be added after the layers
       .addAnchorModel() // Anchor model must be added after the layers
       .loadPlugins(this.props.activeTools);
 
@@ -562,6 +563,7 @@ class App extends React.PureComponent {
     window.hajkPublicApi = {
       ...window.hajkPublicApi,
       olMap: this.appModel.map,
+      layerControl: this.appModel.layerControl,
       dirtyLayers: {},
     };
 

--- a/apps/client/src/constants/backgroundLayers.js
+++ b/apps/client/src/constants/backgroundLayers.js
@@ -1,0 +1,13 @@
+/**
+ * Ids for the "special"/non-server background layers that Hajk creates client
+ * side (see `models/appModel/backgroundLayers.js`). They are real OpenLayers
+ * layers added to the map, but the white/black ones only render via the
+ * `div#map` background color rather than any tiles.
+ *
+ * The id equals the layer's OpenLayers `name` property.
+ */
+export const BACKGROUND_LAYER_IDS = {
+  WHITE: "-1",
+  BLACK: "-2",
+  OSM: "-3",
+};

--- a/apps/client/src/hooks/useLayerVisibility.js
+++ b/apps/client/src/hooks/useLayerVisibility.js
@@ -1,0 +1,47 @@
+import { useSyncExternalStore, useCallback } from "react";
+
+/**
+ * Subscribe to a layer's visibility and re-render automatically whenever it
+ * changes, no matter who toggled it (LayerSwitcher, URL hash, another plugin or
+ * the LayerControl API). Also accepts a LayerSwitcher tree-group folder id, in
+ * which case the value is `true` only when every leaf layer is visible.
+ *
+ * @param {import("../models/LayerControlModel").default} layerControl
+ * @param {string} id Layer id (OpenLayers `name`) or tree-group folder id.
+ * @returns {boolean} Current visibility.
+ */
+export function useLayerVisibility(layerControl, id) {
+  const subscribe = useCallback(
+    (cb) => layerControl.subscribe(id, cb),
+    [layerControl, id]
+  );
+  const getSnapshot = useCallback(
+    () => layerControl.getVisibilitySnapshot(id),
+    [layerControl, id]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Richer, cached object snapshot for semi-checked group layers etc. The returned
+ * object is referentially stable until one of its fields actually changes.
+ *
+ * For a layer id the shape is
+ * `{ visible, visibleSubLayers, opacity }`; for a LayerSwitcher tree-group
+ * folder id it is `{ visible, state: "all"|"some"|"none", visibleLayers }`.
+ *
+ * @param {import("../models/LayerControlModel").default} layerControl
+ * @param {string} id Layer id (OpenLayers `name`) or tree-group folder id.
+ * @returns {object}
+ */
+export function useLayerState(layerControl, id) {
+  const subscribe = useCallback(
+    (cb) => layerControl.subscribe(id, cb),
+    [layerControl, id]
+  );
+  const getSnapshot = useCallback(
+    () => layerControl.getLayerStateSnapshot(id),
+    [layerControl, id]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/apps/client/src/models/AppModel.js
+++ b/apps/client/src/models/AppModel.js
@@ -1,6 +1,7 @@
 import AnchorModel from "./AnchorModel";
 import SearchModel from "./SearchModel";
 import WindowZModel from "./WindowZModel";
+import LayerControlModel from "./LayerControlModel";
 import { decorateConfig } from "./appModel/configTranslator";
 import { createMap } from "./appModel/mapFactory";
 import { addLayers, highlight, clear } from "./appModel/layerLoader";
@@ -36,6 +37,7 @@ class AppModel {
    */
   constructor(_settings) {
     this.map = undefined;
+    this.layerControl = undefined;
     this.activeTool = undefined;
     this.layersFromParams = [];
     this.groupLayersFromParams = [];
@@ -203,6 +205,18 @@ class AppModel {
 
   addLayers() {
     addLayers(this);
+    return this;
+  }
+
+  addLayerControl() {
+    const layerSwitcherConfig = this.config.mapConfig.tools.find(
+      (t) => t.type === "layerswitcher"
+    );
+    this.layerControl = new LayerControlModel({
+      map: this.map,
+      globalObserver: this.globalObserver,
+      layerSwitcherConfig,
+    });
     return this;
   }
 

--- a/apps/client/src/models/LayerControlModel.js
+++ b/apps/client/src/models/LayerControlModel.js
@@ -1,5 +1,6 @@
 import { unByKey } from "ol/Observable";
 import { setOLSubLayers } from "../utils/groupLayers";
+import { BACKGROUND_LAYER_IDS } from "../constants/backgroundLayers";
 
 /**
  * @summary Centralized, reusable API for toggling layers by id.
@@ -15,10 +16,13 @@ import { setOLSubLayers } from "../utils/groupLayers";
  *
  * KNOWN LIMITATIONS / GAPS (please keep this list up to date):
  * 1. Base/background layers have only partial support. See `showLayer`/`hideLayer`
- *    `"base"` handling below.
- * 2. "Fake" background layers (white `"-1"`, black `"-2"`, OSM `"-3"`) are NOT
- *    real OpenLayers layers in the map collection, so they cannot be toggled
- *    through this API — `getLayer()` misses them and the call just warns.
+ *    `"base"` handling below (notably hide does not auto-select another bg).
+ * 2. The built-in "special" background layers (white `"-1"`, black `"-2"`, OSM
+ *    `"-3"`) ARE real OpenLayers layers and CAN be toggled through this API (see
+ *    `showBackgroundWhite`/`showBackgroundBlack`/`showBackgroundOSM` for named
+ *    shortcuts). The white/black ones render via
+ *    the `div#map` background color rather than tiles; that repaint is performed
+ *    by the BackgroundSwitcher when it observes the visibility change.
  * 3. This model lives for the whole app lifetime (instantiated once via
  *    `AppModel.addLayerControl()`), so the layer-collection `add`/`remove`
  *    listeners registered in the constructor are intentionally never torn down.
@@ -95,6 +99,10 @@ const arraysEqual = (a = [], b = []) => {
  * lc.toggleLayer("id");
  * lc.setLayerVisibility("id", true);               // boolean form of show/hide
  * lc.layerIsVisible("id");                         // -> boolean
+ * lc.showBackground("baseId");                     // any base layer (warns if not base)
+ * lc.showBackgroundWhite();                        // built-in white background
+ * lc.showBackgroundBlack();                        // built-in black background
+ * lc.showBackgroundOSM();                          // built-in OSM background
  *
  * // Sublayers of a WMS group layer (the nested checkboxes)
  * lc.showSubLayer("groupId", "subId");
@@ -309,11 +317,11 @@ class LayerControlModel {
           "layerswitcher.backgroundLayerChanged",
           id
         );
-        // GAP: the `div#map` background-color repaint for "fake" backgrounds is
-        // done only inside the BackgroundSwitcher/BackgroundLayer click
-        // handlers, so toggling a base layer through this API does NOT repaint
-        // the map canvas background. Replicate that logic here if full visual
-        // parity is ever needed.
+        // The white/black `div#map` background repaint is handled by the
+        // BackgroundSwitcher, which observes the layer's visibility change
+        // (`core.layerVisibilityChanged`, published by the special background
+        // layers) and repaints accordingly — so toggling a base layer through
+        // this API gets the same visual result as a click in the UI.
         break;
       }
       case "system": {
@@ -414,6 +422,59 @@ class LayerControlModel {
     } else {
       this.hideLayer(id);
     }
+  }
+
+  /**
+   * Show a background (base) layer by id, e.g. a configured server background.
+   * Warns and does nothing if the id is not a `layerType === "base"` layer, so
+   * callers can't accidentally route a normal/group layer through here. For the
+   * three built-in special backgrounds there are also the named shortcuts
+   * `showBackgroundWhite`/`showBackgroundBlack`/`showBackgroundOSM`.
+   * @param {string} id
+   */
+  showBackground(id) {
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      console.warn(
+        `Attempt to show background with id ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+    if (olLayer.get("layerType") !== "base") {
+      console.warn(
+        `Attempt to show background with id ${id} failed: layer is not a background (layerType "${olLayer.get(
+          "layerType"
+        )}"). Use showLayer() for non-background layers.`
+      );
+      return;
+    }
+    this.showLayer(id);
+  }
+
+  /**
+   * Convenience shortcut for the built-in white background layer, so callers
+   * don't have to know the magic `-1` id. Delegates to `showLayer`, so the
+   * exclusive base-layer behavior, the LayerSwitcher radio sync and the
+   * `div#map` background repaint all apply.
+   */
+  showBackgroundWhite() {
+    this.showLayer(BACKGROUND_LAYER_IDS.WHITE);
+  }
+
+  /**
+   * Convenience shortcut for the built-in black background layer (magic id
+   * `-2`). See `showBackgroundWhite` for details.
+   */
+  showBackgroundBlack() {
+    this.showLayer(BACKGROUND_LAYER_IDS.BLACK);
+  }
+
+  /**
+   * Convenience shortcut for the built-in OpenStreetMap background layer (magic
+   * id `-3`). See `showBackgroundWhite` for details.
+   */
+  showBackgroundOSM() {
+    this.showLayer(BACKGROUND_LAYER_IDS.OSM);
   }
 
   /**

--- a/apps/client/src/models/LayerControlModel.js
+++ b/apps/client/src/models/LayerControlModel.js
@@ -1,0 +1,812 @@
+import { unByKey } from "ol/Observable";
+import { setOLSubLayers } from "../utils/groupLayers";
+
+/**
+ * @summary Centralized, reusable API for toggling layers by id.
+ *
+ * @description The LayerSwitcher UI mirrors OpenLayers state via `propertychange`
+ * listeners, so any code that calls `olLayer.setVisible()` / `setOLSubLayers()`
+ * makes the corresponding checkbox update automatically. This model extracts the
+ * complete toggling rules (normal, WMS group + sublayers, base/background and
+ * LayerSwitcher tree-group folders) that previously lived only inside the
+ * LayerSwitcher React context and the URL-hash handler, into one place that can
+ * be consumed from anywhere (plugins, embedders via `window.hajkPublicApi`, and
+ * React via the `useLayerVisibility`/`useLayerState` hooks).
+ *
+ * KNOWN LIMITATIONS / GAPS (please keep this list up to date):
+ * 1. Base/background layers have only partial support. See `showLayer`/`hideLayer`
+ *    `"base"` handling below.
+ * 2. "Fake" background layers (white `"-1"`, black `"-2"`, OSM `"-3"`) are NOT
+ *    real OpenLayers layers in the map collection, so they cannot be toggled
+ *    through this API — `getLayer()` misses them and the call just warns.
+ * 3. This model lives for the whole app lifetime (instantiated once via
+ *    `AppModel.addLayerControl()`), so the layer-collection `add`/`remove`
+ *    listeners registered in the constructor are intentionally never torn down.
+ *    There is no `dispose()`. If this ever becomes a per-map/disposable object,
+ *    add teardown for those listeners.
+ */
+
+const findGroupInConfig = (groups, groupId) => {
+  if (!Array.isArray(groups)) {
+    return null;
+  }
+  for (const group of groups) {
+    if (!group) {
+      continue;
+    }
+    if (group.id === groupId) {
+      return group;
+    }
+    const found = findGroupInConfig(group.groups, groupId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+};
+
+const collectLayerIdsFromGroup = (group) => {
+  if (!group) {
+    return [];
+  }
+  const ids = [];
+  (group.layers ?? []).forEach((l) => {
+    if (l?.id !== undefined) {
+      ids.push(l.id);
+    }
+  });
+  (group.groups ?? []).forEach((g) => {
+    ids.push(...collectLayerIdsFromGroup(g));
+  });
+  return ids;
+};
+
+const arraysEqual = (a = [], b = []) => {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * ============================================================================
+ * EXAMPLES — all public methods (assume `const lc = appModel.layerControl` or
+ * `window.hajkPublicApi.layerControl`). A layer id === OpenLayers `name`.
+ * ============================================================================
+ *
+ * // Lookup
+ * lc.getLayer("id");                               // -> ol layer | undefined
+ *
+ * // Single layer (normal, WMS group, or base/background).
+ * // show/hide/toggle/set/...IsVisible accept a layer id, a tree-group folder
+ * // id, or a "groupId:subId" sublayer address.
+ * lc.showLayer("id");
+ * lc.showLayer("id", { subLayers: ["a", "b"] });   // WMS group: show a subset
+ * lc.showLayer("id", { useLabelStyle: true });     // layers with a label style
+ * lc.hideLayer("id");
+ * lc.toggleLayer("id");
+ * lc.setLayerVisibility("id", true);               // boolean form of show/hide
+ * lc.layerIsVisible("id");                         // -> boolean
+ *
+ * // Sublayers of a WMS group layer (the nested checkboxes)
+ * lc.showSubLayer("groupId", "subId");
+ * lc.hideSubLayer("groupId", "subId");
+ * lc.toggleSubLayer("groupId", "subId");
+ * lc.setSubLayerVisibility("groupId", "subId", true);
+ * lc.setSubLayers("groupId", ["subA", "subB"]);    // exact visible set
+ * lc.subLayerIsVisible("groupId", "subId");        // -> boolean
+ * // ...or via the single-layer API: lc.toggleLayer("groupId:subId")
+ *
+ * // LayerSwitcher tree-group folders (operate on every leaf layer)
+ * lc.showGroup("folderId");
+ * lc.hideGroup("folderId");
+ * lc.toggleGroup("folderId");
+ * lc.setGroupVisibility("folderId", true);
+ * lc.groupIsVisible("folderId");                   // -> boolean (all leaves visible)
+ *
+ * // Reactive primitives (back the useLayerVisibility / useLayerState hooks)
+ * const off = lc.subscribe("id", () => {});        // -> unsubscribe fn
+ * lc.getVisibilitySnapshot("id");                  // -> boolean (stable)
+ * lc.getLayerStateSnapshot("id");                  // -> cached state object
+ */
+class LayerControlModel {
+  #map;
+  #globalObserver;
+  #layerSwitcherConfig;
+  // Cache for getLayerStateSnapshot: a stable object reference per layer id, so
+  // React's useSyncExternalStore does not over-render or loop. We only replace
+  // the cached reference when one of the tracked fields actually changes.
+  #stateCache;
+  // O(1) id -> OpenLayers layer index. With 700+ layers a naive
+  // `map.getAllLayers().find()` on every lookup (run from getSnapshot on every
+  // React render) would be O(n) plus a fresh array allocation each call. The
+  // index keeps lookups constant-time with no allocation and makes misses
+  // (e.g. tree-group folder ids) O(1) too. Kept in sync via layer add/remove.
+  #layerIndex;
+
+  constructor({ map, globalObserver, layerSwitcherConfig }) {
+    this.#map = map;
+    this.#globalObserver = globalObserver;
+    this.#layerSwitcherConfig = layerSwitcherConfig;
+    this.#stateCache = new Map();
+
+    this.#layerIndex = new Map();
+    this.#map.getAllLayers().forEach((l) => this.#indexLayer(l));
+
+    // Keep the index fresh if layers are added/removed at runtime. Hajk adds its
+    // named layers flat to the map root, so the top-level collection covers them.
+    const collection = this.#map.getLayers();
+    collection.on("add", (e) => this.#indexLayer(e.element));
+    collection.on("remove", (e) => {
+      const name = e.element?.get("name");
+      if (name !== undefined) {
+        this.#layerIndex.delete(name);
+      }
+    });
+  }
+
+  #indexLayer(layer) {
+    const name = layer?.get("name");
+    if (name !== undefined) {
+      this.#layerIndex.set(name, layer);
+    }
+  }
+
+  /**
+   * Canonical layer lookup: layer id === OpenLayers `name` property.
+   * @param {string} id
+   * @returns {import("ol/layer/Layer").default | undefined}
+   */
+  getLayer(id) {
+    return this.#layerIndex.get(id);
+  }
+
+  /**
+   * Parse a composite `"groupId:subLayerId"` address so that the top-level
+   * `showLayer`/`hideLayer`/`toggleLayer`/`layerIsVisible` API can target a
+   * single sublayer of a WMS group layer (e.g.
+   * `toggleLayer("70d0ft:trafiksamordning_linje_paborjad")`).
+   *
+   * Returns the parts only when this really looks like a sublayer address:
+   * the whole id is NOT itself a real layer (so real layer names that happen to
+   * contain a ":" keep working unchanged) and the part before the first ":"
+   * resolves to a WMS group layer. Otherwise returns `null` and the id is
+   * treated as an ordinary layer / tree-group folder id.
+   * @param {string} id
+   * @returns {{ groupId: string, subLayerId: string } | null}
+   */
+  #resolveSubLayerTarget(id) {
+    if (typeof id !== "string") {
+      return null;
+    }
+    const idx = id.indexOf(":");
+    if (idx === -1) {
+      return null;
+    }
+    // A real layer whose name happens to contain ":" takes precedence.
+    if (this.getLayer(id) !== undefined) {
+      return null;
+    }
+    const groupId = id.slice(0, idx);
+    const subLayerId = id.slice(idx + 1);
+    if (!groupId || !subLayerId) {
+      return null;
+    }
+    const group = this.getLayer(groupId);
+    if (group === undefined || group.get("layerType") !== "group") {
+      return null;
+    }
+    return { groupId, subLayerId };
+  }
+
+  /**
+   * Resolve the leaf layer ids of a LayerSwitcher tree-group folder. The config
+   * tree can reference layers that were never added to OpenLayers (unsupported
+   * type or missing/broken `layersConfig` — the LayerSwitcher drops these too),
+   * so we filter down to ids that actually resolve to an OL layer. Returns `[]`
+   * (not `null`) for a folder whose leaves are all missing, so callers can still
+   * tell it apart from a non-folder id.
+   * @param {string} id
+   * @returns {string[] | null} The existing leaf ids, or `null` if `id` is not a
+   * folder.
+   */
+  #getGroupLayerIds(id) {
+    const group = findGroupInConfig(
+      this.#layerSwitcherConfig?.options?.groups,
+      id
+    );
+    if (!group) {
+      return null;
+    }
+    return collectLayerIdsFromGroup(group).filter(
+      (leafId) => this.getLayer(leafId) !== undefined
+    );
+  }
+
+  /**
+   * @param {string} id A layer id, a LayerSwitcher tree-group folder id, or a
+   * `"groupId:subLayerId"` sublayer address.
+   * @returns {boolean} For a layer: whether it is visible. For a group folder:
+   * whether all of its leaf layers are visible. For a sublayer address: whether
+   * that sublayer is visible.
+   */
+  layerIsVisible(id) {
+    const sub = this.#resolveSubLayerTarget(id);
+    if (sub) {
+      return this.subLayerIsVisible(sub.groupId, sub.subLayerId);
+    }
+
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      // Not a real layer — maybe a LayerSwitcher tree-group folder.
+      if (this.#getGroupLayerIds(id) !== null) {
+        return this.groupIsVisible(id);
+      }
+      return false;
+    }
+    return olLayer.get("visible") === true;
+  }
+
+  /**
+   * Show a layer by id. Dispatches on the layer's `layerType`. If `id` is a
+   * LayerSwitcher tree-group folder instead of a real layer, this delegates to
+   * `showGroup(id)`. A `"groupId:subLayerId"` address delegates to
+   * `showSubLayer(groupId, subLayerId)`.
+   * @param {string} id
+   * @param {{ subLayers?: string[], useLabelStyle?: boolean }} [options]
+   */
+  showLayer(id, { subLayers, useLabelStyle } = {}) {
+    const sub = this.#resolveSubLayerTarget(id);
+    if (sub) {
+      this.showSubLayer(sub.groupId, sub.subLayerId);
+      return;
+    }
+
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      // Not a real layer — maybe it's a LayerSwitcher tree-group folder.
+      if (this.#getGroupLayerIds(id) !== null) {
+        this.showGroup(id);
+        return;
+      }
+      console.warn(
+        `Attempt to show layer with id ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+
+    switch (olLayer.get("layerType")) {
+      case "group": {
+        // WMS group layers must go through setOLSubLayers so that the WMS
+        // LAYERS/STYLES/CQL_FILTER params are updated correctly.
+        // GOTCHA: passing `subLayers: []` here will actually HIDE the layer,
+        // because setOLSubLayers([]) calls setVisible(false). This is consistent
+        // with "show exactly these sublayers (= none)", but is surprising for a
+        // method named showLayer — use hideLayer(id) to hide instead.
+        const subs = subLayers ?? olLayer.get("allSubLayers") ?? [];
+        olLayer.set("subLayers", subs);
+        setOLSubLayers(olLayer, subs);
+        break;
+      }
+      case "base": {
+        // Base layers are exclusive (radio behavior).
+        this.#map
+          .getAllLayers()
+          .filter((l) => l.get("layerType") === "base" && l !== olLayer)
+          .forEach((l) => l.setVisible(false));
+        olLayer.setVisible(true);
+        // BackgroundSwitcher / BackgroundLayer sync via this globalObserver
+        // event, not just change:visible.
+        this.#globalObserver?.publish(
+          "layerswitcher.backgroundLayerChanged",
+          id
+        );
+        // GAP: the `div#map` background-color repaint for "fake" backgrounds is
+        // done only inside the BackgroundSwitcher/BackgroundLayer click
+        // handlers, so toggling a base layer through this API does NOT repaint
+        // the map canvas background. Replicate that logic here if full visual
+        // parity is ever needed.
+        break;
+      }
+      case "system": {
+        console.warn(
+          `Refusing to show layer with id ${id}: system layers are managed by their plugin.`
+        );
+        break;
+      }
+      default: {
+        olLayer.setVisible(true);
+        if (useLabelStyle !== undefined && olLayer.get("hasLabelStyle")) {
+          olLayer.set("useLabelStyle", !!useLabelStyle);
+        }
+      }
+    }
+  }
+
+  /**
+   * Hide a layer by id. Dispatches on the layer's `layerType`. If `id` is a
+   * LayerSwitcher tree-group folder instead of a real layer, this delegates to
+   * `hideGroup(id)`. A `"groupId:subLayerId"` address delegates to
+   * `hideSubLayer(groupId, subLayerId)`.
+   * @param {string} id
+   */
+  hideLayer(id) {
+    const sub = this.#resolveSubLayerTarget(id);
+    if (sub) {
+      this.hideSubLayer(sub.groupId, sub.subLayerId);
+      return;
+    }
+
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      // Not a real layer — maybe it's a LayerSwitcher tree-group folder.
+      if (this.#getGroupLayerIds(id) !== null) {
+        this.hideGroup(id);
+        return;
+      }
+      console.warn(
+        `Attempt to hide layer with id ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+
+    switch (olLayer.get("layerType")) {
+      case "group": {
+        olLayer.set("subLayers", []);
+        setOLSubLayers(olLayer, []);
+        break;
+      }
+      case "system": {
+        console.warn(
+          `Refusing to hide layer with id ${id}: system layers are managed by their plugin.`
+        );
+        break;
+      }
+      // "base" and default ("layer") share the same hide behavior.
+      // ASYMMETRY/GAP for "base": unlike showLayer, hiding a base layer does NOT
+      // activate another background and does NOT publish
+      // "layerswitcher.backgroundLayerChanged". Since base layers are exclusive
+      // (radio), this can leave the map with no background and the
+      // BackgroundSwitcher radio out of sync. Hiding a base layer is generally
+      // not a meaningful operation — prefer showLayer(otherBaseId) to switch.
+      default: {
+        olLayer.setVisible(false);
+      }
+    }
+  }
+
+  /**
+   * Toggle a layer's visibility by id. Also accepts a LayerSwitcher tree-group
+   * folder id, or a `"groupId:subLayerId"` sublayer address (e.g.
+   * `toggleLayer("70d0ft:trafiksamordning_linje_paborjad")`) — these route
+   * through `layerIsVisible` + `showLayer`/`hideLayer` automatically.
+   * @param {string} id
+   * @param {{ subLayers?: string[], useLabelStyle?: boolean }} [options]
+   */
+  toggleLayer(id, options) {
+    if (this.layerIsVisible(id)) {
+      this.hideLayer(id);
+    } else {
+      this.showLayer(id, options);
+    }
+  }
+
+  /**
+   * Set a layer's visibility by id (the boolean form of `showLayer`/`hideLayer`).
+   * Accepts the same ids as `showLayer` (layer, tree-group folder, or
+   * `"groupId:subLayerId"` sublayer address).
+   * @param {string} id
+   * @param {boolean} visible
+   * @param {{ subLayers?: string[], useLabelStyle?: boolean }} [options] Forwarded
+   * to `showLayer` when `visible` is true.
+   */
+  setLayerVisibility(id, visible, options) {
+    if (visible) {
+      this.showLayer(id, options);
+    } else {
+      this.hideLayer(id);
+    }
+  }
+
+  /**
+   * Set the exact set of visible sublayers for a WMS group layer. The provided
+   * ids are sorted to match the configured `allSubLayers` order.
+   * @param {string} id
+   * @param {string[]} subLayerIds
+   */
+  setSubLayers(id, subLayerIds = []) {
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      console.warn(
+        `Attempt to set sublayers for ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+    const allSubLayers = olLayer.get("allSubLayers") ?? [];
+    const wanted = new Set(subLayerIds);
+    // Keep the order consistent regardless of toggle order.
+    const sorted = allSubLayers.filter((l) => wanted.has(l));
+    olLayer.set("subLayers", sorted);
+    setOLSubLayers(olLayer, sorted);
+  }
+
+  /**
+   * Show a single sublayer of a WMS group layer.
+   * @param {string} id
+   * @param {string} subLayerId
+   */
+  showSubLayer(id, subLayerId) {
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      console.warn(
+        `Attempt to show sublayer ${subLayerId} of ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+    const current = olLayer.get("visible")
+      ? new Set(olLayer.get("subLayers"))
+      : new Set();
+    current.add(subLayerId);
+    this.setSubLayers(id, [...current]);
+  }
+
+  /**
+   * Hide a single sublayer of a WMS group layer.
+   * @param {string} id
+   * @param {string} subLayerId
+   */
+  hideSubLayer(id, subLayerId) {
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined) {
+      console.warn(
+        `Attempt to hide sublayer ${subLayerId} of ${id} failed: layer not found in current map`
+      );
+      return;
+    }
+    const current = olLayer.get("visible")
+      ? new Set(olLayer.get("subLayers"))
+      : new Set();
+    current.delete(subLayerId);
+    this.setSubLayers(id, [...current]);
+  }
+
+  /**
+   * Whether a single sublayer of a WMS group layer is currently visible. A
+   * sublayer counts as visible only when the parent group layer itself is
+   * visible and the sublayer is part of its current `subLayers` selection.
+   * @param {string} id The parent WMS group layer id.
+   * @param {string} subLayerId
+   * @returns {boolean}
+   */
+  subLayerIsVisible(id, subLayerId) {
+    const olLayer = this.getLayer(id);
+    if (olLayer === undefined || !olLayer.get("visible")) {
+      return false;
+    }
+    return (olLayer.get("subLayers") ?? []).includes(subLayerId);
+  }
+
+  /**
+   * Toggle a single sublayer of a WMS group layer. This is the sublayer
+   * equivalent of `toggleLayer`: use it for the nested checkboxes ("Påbörjad"
+   * etc.) under a group layer. Note that a sublayer is NOT a standalone
+   * OpenLayers layer, so `toggleLayer(subLayerId)` will not work — the sublayer
+   * must always be addressed via its parent group layer id.
+   * @param {string} id The parent WMS group layer id.
+   * @param {string} subLayerId
+   */
+  toggleSubLayer(id, subLayerId) {
+    if (this.subLayerIsVisible(id, subLayerId)) {
+      this.hideSubLayer(id, subLayerId);
+    } else {
+      this.showSubLayer(id, subLayerId);
+    }
+  }
+
+  /**
+   * Set a single sublayer's visibility (the boolean form of
+   * `showSubLayer`/`hideSubLayer`).
+   * @param {string} id The parent WMS group layer id.
+   * @param {string} subLayerId
+   * @param {boolean} visible
+   */
+  setSubLayerVisibility(id, subLayerId, visible) {
+    if (visible) {
+      this.showSubLayer(id, subLayerId);
+    } else {
+      this.hideSubLayer(id, subLayerId);
+    }
+  }
+
+  /**
+   * Whether a LayerSwitcher tree-group folder is fully visible, i.e. every one
+   * of its leaf layers is visible. (Equivalent to `layerIsVisible(folderId)`.)
+   * @param {string} groupId
+   * @returns {boolean}
+   */
+  groupIsVisible(groupId) {
+    const ids = this.#getGroupLayerIds(groupId);
+    if (ids === null || ids.length === 0) {
+      return false;
+    }
+    return ids.every((id) => this.layerIsVisible(id));
+  }
+
+  /**
+   * Show every leaf layer under a LayerSwitcher tree-group folder.
+   * @param {string} groupId
+   */
+  showGroup(groupId) {
+    this.setGroupVisibility(groupId, true);
+  }
+
+  /**
+   * Hide every leaf layer under a LayerSwitcher tree-group folder.
+   * @param {string} groupId
+   */
+  hideGroup(groupId) {
+    this.setGroupVisibility(groupId, false);
+  }
+
+  /**
+   * Toggle a LayerSwitcher tree-group folder: hide every leaf layer if the
+   * folder is fully visible, otherwise show every leaf layer.
+   * @param {string} groupId
+   */
+  toggleGroup(groupId) {
+    this.setGroupVisibility(groupId, !this.groupIsVisible(groupId));
+  }
+
+  /**
+   * Set visibility for every leaf layer under a LayerSwitcher tree-group folder.
+   * @param {string} groupId
+   * @param {boolean} visible
+   */
+  setGroupVisibility(groupId, visible) {
+    const ids = this.#getGroupLayerIds(groupId);
+
+    if (ids === null || ids.length === 0) {
+      console.warn(
+        `Attempt to set group visibility for ${groupId} failed: no layers found for group`
+      );
+      return;
+    }
+
+    ids.forEach((id) => {
+      const olLayer = this.getLayer(id);
+      if (olLayer === undefined) {
+        console.warn(
+          `Attempt to set group visibility for layer ${id} failed: layer not found in current map`
+        );
+        return;
+      }
+
+      if (visible && olLayer.get("layerType") === "group") {
+        // Re-show workaround for WMS group layers inside a folder, so they
+        // render correctly when the whole folder is toggled on.
+        const allSubLayers = olLayer.get("allSubLayers") ?? [];
+        if (olLayer.get("visible")) {
+          olLayer.setVisible(false);
+        }
+        olLayer.set("subLayers", allSubLayers);
+        setOLSubLayers(olLayer, allSubLayers);
+        setTimeout(() => {
+          olLayer.setVisible(true);
+        }, 0);
+      } else if (visible) {
+        this.showLayer(id);
+      } else {
+        this.hideLayer(id);
+      }
+    });
+  }
+
+  /**
+   * Attach the appropriate OL listeners to a single layer and return their keys.
+   * @param {import("ol/layer/Layer").default} olLayer
+   * @param {() => void} callback
+   * @returns {import("ol/events").EventsKey[]}
+   */
+  #listenToLayer(olLayer, callback) {
+    const keys = [olLayer.on("change:visible", () => callback())];
+    if (olLayer.get("layerType") === "group") {
+      // Group layers also change their partial/semi-checked state via subLayers.
+      keys.push(olLayer.on("change:subLayers", () => callback()));
+    }
+    return keys;
+  }
+
+  /**
+   * Subscribe to visibility changes for a layer id, a LayerSwitcher tree-group
+   * folder id (in which case it listens to every leaf layer), or a
+   * `"groupId:subLayerId"` sublayer address (in which case it listens to the
+   * parent group layer). Returns an unsubscribe function. Backs React's
+   * useSyncExternalStore.
+   * @param {string} id
+   * @param {() => void} callback
+   * @returns {() => void} unsubscribe
+   */
+  subscribe(id, callback) {
+    const sub = this.#resolveSubLayerTarget(id);
+    if (sub) {
+      // A sublayer's state lives on its parent group layer (change:subLayers /
+      // change:visible), so listen there.
+      const group = this.getLayer(sub.groupId);
+      const keys = group ? this.#listenToLayer(group, callback) : [];
+      return () => unByKey(keys);
+    }
+
+    const olLayer = this.getLayer(id);
+
+    if (olLayer === undefined) {
+      // Not a real layer — maybe it's a tree-group folder. Listen to all leaves.
+      const leafIds = this.#getGroupLayerIds(id);
+      if (leafIds !== null) {
+        const keys = leafIds.flatMap((leafId) => {
+          const leaf = this.getLayer(leafId);
+          return leaf ? this.#listenToLayer(leaf, callback) : [];
+        });
+        return () => unByKey(keys);
+      }
+
+      // The layer may not exist yet; fall back to the globalObserver event
+      // until it does.
+      // GAP: this fallback only reacts to visibility (`core.layerVisibilityChanged`),
+      // NOT to sublayer changes. So if a WMS group layer is added AFTER this
+      // subscription is set up, its partial/semi-checked (subLayers) changes
+      // won't trigger a re-render. In practice all named layers are added during
+      // AppModel.addLayers() — before any React subscription — so this path is
+      // effectively never hit; revisit if layers start being added lazily.
+      const handle = this.#globalObserver?.subscribe(
+        "core.layerVisibilityChanged",
+        (e) => {
+          if (e?.target?.get?.("name") === id) {
+            callback();
+          }
+        }
+      );
+      return () => handle?.unsubscribe?.();
+    }
+
+    const keys = this.#listenToLayer(olLayer, callback);
+    return () => unByKey(keys);
+  }
+
+  /**
+   * Boolean visibility snapshot. Primitives are always referentially stable, so
+   * this is safe for useSyncExternalStore.
+   * @param {string} id
+   * @returns {boolean}
+   */
+  getVisibilitySnapshot(id) {
+    return this.layerIsVisible(id);
+  }
+
+  /**
+   * Richer, cached object snapshot. Returns a stable reference that only changes
+   * when a tracked field actually changes, so it is safe for useSyncExternalStore.
+   *
+   * For a layer id:
+   *   `{ visible: boolean, visibleSubLayers: string[], opacity: number }`
+   * For a LayerSwitcher tree-group folder id:
+   *   `{ visible: boolean, state: "all"|"some"|"none", visibleLayers: string[] }`
+   *   where `visible` is true only when every leaf layer is visible.
+   * For a `"groupId:subLayerId"` sublayer address:
+   *   `{ visible: boolean, visibleSubLayers: string[], opacity: number }`
+   *   where `visible` reflects that one sublayer and the other fields reflect
+   *   the parent group layer.
+   * @param {string} id
+   * @returns {object}
+   */
+  getLayerStateSnapshot(id) {
+    const sub = this.#resolveSubLayerTarget(id);
+    if (sub) {
+      return this.#getSubLayerStateSnapshot(id, sub.groupId, sub.subLayerId);
+    }
+
+    const olLayer = this.getLayer(id);
+
+    if (olLayer === undefined) {
+      const leafIds = this.#getGroupLayerIds(id);
+      if (leafIds !== null) {
+        return this.#getGroupStateSnapshot(id, leafIds);
+      }
+    }
+
+    const next = {
+      visible: olLayer?.get("visible") === true,
+      visibleSubLayers: olLayer?.get("visible")
+        ? (olLayer.get("subLayers") ?? [])
+        : [],
+      opacity: olLayer?.get("opacity"),
+    };
+
+    const prev = this.#stateCache.get(id);
+    if (
+      prev &&
+      prev.visible === next.visible &&
+      prev.opacity === next.opacity &&
+      arraysEqual(prev.visibleSubLayers, next.visibleSubLayers)
+    ) {
+      return prev;
+    }
+
+    this.#stateCache.set(id, next);
+    return next;
+  }
+
+  /**
+   * Cached snapshot for a single sublayer of a WMS group layer.
+   * @param {string} cacheId The composite id used as the cache key.
+   * @param {string} groupId
+   * @param {string} subLayerId
+   * @returns {{ visible: boolean, visibleSubLayers: string[], opacity: number }}
+   */
+  #getSubLayerStateSnapshot(cacheId, groupId, subLayerId) {
+    const group = this.getLayer(groupId);
+    const next = {
+      visible: this.subLayerIsVisible(groupId, subLayerId),
+      visibleSubLayers: group?.get("visible")
+        ? (group.get("subLayers") ?? [])
+        : [],
+      opacity: group?.get("opacity"),
+    };
+
+    const prev = this.#stateCache.get(cacheId);
+    if (
+      prev &&
+      prev.visible === next.visible &&
+      prev.opacity === next.opacity &&
+      arraysEqual(prev.visibleSubLayers, next.visibleSubLayers)
+    ) {
+      return prev;
+    }
+
+    this.#stateCache.set(cacheId, next);
+    return next;
+  }
+
+  /**
+   * Cached aggregated snapshot for a tree-group folder.
+   * @param {string} id
+   * @param {string[]} leafIds
+   * @returns {{ visible: boolean, state: "all"|"some"|"none", visibleLayers: string[] }}
+   */
+  #getGroupStateSnapshot(id, leafIds) {
+    const visibleLayers = leafIds.filter((leafId) =>
+      this.layerIsVisible(leafId)
+    );
+    const count = visibleLayers.length;
+    const total = leafIds.length;
+    const state = count === 0 ? "none" : count === total ? "all" : "some";
+
+    const next = {
+      visible: total > 0 && count === total,
+      state,
+      visibleLayers,
+    };
+
+    const prev = this.#stateCache.get(id);
+    if (
+      prev &&
+      prev.visible === next.visible &&
+      prev.state === next.state &&
+      arraysEqual(prev.visibleLayers, next.visibleLayers)
+    ) {
+      return prev;
+    }
+
+    this.#stateCache.set(id, next);
+    return next;
+  }
+}
+
+export default LayerControlModel;

--- a/apps/client/src/models/appModel/backgroundLayers.js
+++ b/apps/client/src/models/appModel/backgroundLayers.js
@@ -4,6 +4,7 @@ import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { mapDirectionToAngle } from "../../utils/mapDirectionToAngle";
 import { easeOut } from "ol/easing";
+import { BACKGROUND_LAYER_IDS } from "../../constants/backgroundLayers";
 
 export function createWhiteLayer(appModel) {
   // Creates a empty vectorlayer to let the url handle them like other layers. BackgroundSwitcher then
@@ -14,7 +15,7 @@ export function createWhiteLayer(appModel) {
     zIndex: -1,
     layerType: "base",
     rotateMap: "n",
-    name: "-1",
+    name: BACKGROUND_LAYER_IDS.WHITE,
     caption: "Vit",
     layerInfo: {
       caption: "Vit",
@@ -39,7 +40,7 @@ export function createBlackLayer(appModel) {
     zIndex: -1,
     layerType: "base",
     rotateMap: "n",
-    name: "-2",
+    name: BACKGROUND_LAYER_IDS.BLACK,
     caption: "Svart",
     layerInfo: {
       caption: "Svart",
@@ -76,7 +77,7 @@ export function createOSMLayer(appModel) {
     zIndex: -1,
     layerType: "base",
     rotateMap: "n", // OpenStreetMap should be rotated to North
-    name: "-3",
+    name: BACKGROUND_LAYER_IDS.OSM,
     caption: "OpenStreetMap",
     layerInfo: {
       infoText:

--- a/apps/client/src/models/appModel/layerLoader.js
+++ b/apps/client/src/models/appModel/layerLoader.js
@@ -5,6 +5,7 @@ import WFSVectorLayer from "../layers/VectorLayer";
 import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import { Icon, Fill, Stroke, Style } from "ol/style";
+import { BACKGROUND_LAYER_IDS } from "../../constants/backgroundLayers";
 
 export function addMapLayer(appModel, layer) {
   const configMapper = new ConfigMapper(appModel.config.appConfig.proxy);
@@ -166,28 +167,34 @@ function applyBackgroundLayerVisibilityFromParams(
 ) {
   // Check if the layerParams contains -1 (white background) and handle set it to visible on load
   if (
-    layersFromParams.includes("-1") &&
+    layersFromParams.includes(BACKGROUND_LAYER_IDS.WHITE) &&
     layerSwitcherConf?.options?.backgroundSwitcherWhite
   ) {
-    const whiteLayer = map.getAllLayers().find((l) => l.get("name") === "-1");
+    const whiteLayer = map
+      .getAllLayers()
+      .find((l) => l.get("name") === BACKGROUND_LAYER_IDS.WHITE);
     whiteLayer.setVisible(true);
   }
 
   // Check if the layerParams contains -2 (black background) and handle set it to visible on load
   if (
-    layersFromParams.includes("-2") &&
+    layersFromParams.includes(BACKGROUND_LAYER_IDS.BLACK) &&
     layerSwitcherConf?.options?.backgroundSwitcherBlack
   ) {
-    const blackLayer = map.getAllLayers().find((l) => l.get("name") === "-2");
+    const blackLayer = map
+      .getAllLayers()
+      .find((l) => l.get("name") === BACKGROUND_LAYER_IDS.BLACK);
     blackLayer.setVisible(true);
   }
 
   // Check if the layerParams contains -3 (osm-layer) and handle set it to visible on load
   if (
-    layersFromParams.includes("-3") &&
+    layersFromParams.includes(BACKGROUND_LAYER_IDS.OSM) &&
     layerSwitcherConf?.options?.enableOSM
   ) {
-    const osmLayer = map.getAllLayers().find((l) => l.get("name") === "-3");
+    const osmLayer = map
+      .getAllLayers()
+      .find((l) => l.get("name") === BACKGROUND_LAYER_IDS.OSM);
     if (osmLayer === undefined) {
       console.warn(`Cannot find the OSM layer`);
     } else {

--- a/apps/client/src/plugins/LayerSwitcher/components/BackgroundLayer.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BackgroundLayer.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import BackgroundLayerItem from "./BackgroundLayerItem";
+import { BACKGROUND_LAYER_IDS } from "../../../constants/backgroundLayers";
 
 export default function BackgroundLayer({
   layer,
@@ -34,15 +35,15 @@ export default function BackgroundLayer({
       if (layer.isFakeMapLayer) {
         switch (name) {
           // Openstreetmap
-          case "-3":
+          case BACKGROUND_LAYER_IDS.OSM:
             document.getElementById("map").style.backgroundColor = "#FFF";
             break;
           // Black only background
-          case "-2":
+          case BACKGROUND_LAYER_IDS.BLACK:
             document.getElementById("map").style.backgroundColor = "#000";
             break;
           // White only background
-          case "-1":
+          case BACKGROUND_LAYER_IDS.WHITE:
             document.getElementById("map").style.backgroundColor = "#FFF";
             break;
           default:

--- a/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/BackgroundSwitcher.jsx
@@ -2,8 +2,12 @@ import { useEffect, useState, useCallback } from "react";
 import { isValidLayerId } from "../../../utils/Validator";
 import BackgroundLayerItem from "./BackgroundLayerItem";
 import Box from "@mui/material/Box";
-
+import { BACKGROUND_LAYER_IDS } from "../../../constants/backgroundLayers";
 import { useLayerSwitcherDispatch } from "../LayerSwitcherProvider";
+
+// The special/non-server background layer ids, used to reorder them to the
+// bottom of the background list.
+const SPECIAL_BACKGROUND_LAYER_IDS = Object.values(BACKGROUND_LAYER_IDS);
 
 const BackgroundSwitcher = ({
   display,
@@ -17,15 +21,37 @@ const BackgroundSwitcher = ({
 
   const layerSwitcherDispatch = useLayerSwitcherDispatch();
 
+  // Sets the bg color of the map element to match the selected background.
+  // Declared before the effects below so they can call it and list it as a
+  // dependency without a use-before-declaration issue.
+  const handleMapBackgroundColor = useCallback((selectedId) => {
+    switch (selectedId) {
+      // Our white option
+      case BACKGROUND_LAYER_IDS.WHITE:
+        document.getElementById("map").style.backgroundColor = "#fff";
+        break;
+      // Our black option
+      case BACKGROUND_LAYER_IDS.BLACK:
+        document.getElementById("map").style.backgroundColor = "#000";
+        break;
+      // Our default option for other background layers, default to white.
+      default:
+        document.getElementById("map").style.backgroundColor = "#fff";
+        break;
+    }
+  }, []);
+
   useEffect(() => {
     const backgroundVisibleFromStart = layers.find((layer) => layer.visible);
     // Check that the background visible from start exists and not undefined
     // if b/w or osm is uncheked in admin and a user still tries to load it then do nothing
     if (backgroundVisibleFromStart) {
+      // Syncs the initial radio selection from the layers' load-time visibility.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedLayerId(backgroundVisibleFromStart.name);
       handleMapBackgroundColor(backgroundVisibleFromStart.name);
     }
-  }, [layers]);
+  }, [layers, handleMapBackgroundColor]);
 
   useEffect(() => {
     // Ensure that BackgroundSwitcher correctly selects visible layer,
@@ -46,30 +72,15 @@ const BackgroundSwitcher = ({
           return;
         }
 
-        // If we got this far, we have a background layer that just
-        // became visible. Let's notify the radio buttons by setting state!
-        setSelectedLayerId(layer.get("name"));
+        // If we got this far, we have a background layer that just became
+        // visible. Notify the radio buttons by setting state, and repaint the
+        // map background so toggles from outside the LayerSwitcher (URL hash,
+        // LayerControlModel, other plugins) get the white/black fill too.
+        setSelectedLayerId(name);
+        handleMapBackgroundColor(name);
       }
     );
-  }, [globalObserver, layers]);
-
-  const handleMapBackgroundColor = (selectedId) => {
-    // Handle setting the bg color of the map element
-    switch (selectedId) {
-      // Our white option
-      case "-1":
-        document.getElementById("map").style.backgroundColor = "#fff";
-        break;
-      // Our black option
-      case "-2":
-        document.getElementById("map").style.backgroundColor = "#000";
-        break;
-      // Our default option for other background layers, default to white.
-      default:
-        document.getElementById("map").style.backgroundColor = "#fff";
-        break;
-    }
-  };
+  }, [globalObserver, layers, handleMapBackgroundColor]);
 
   /**
    * @summary Hides previously selected background and shows current selection.
@@ -88,7 +99,7 @@ const BackgroundSwitcher = ({
 
       layerSwitcherDispatch.setBackgroundLayer(newSelectedId);
     },
-    [globalObserver, layerSwitcherDispatch]
+    [globalObserver, layerSwitcherDispatch, handleMapBackgroundColor]
   );
 
   // TODO This filter should be moved to the core application.
@@ -105,7 +116,7 @@ const BackgroundSwitcher = ({
   // If the static layers b/w and osm should be shown last in the bg-layer list
   // reorder the array to accomodate that.
   if (renderSpecialBackgroundsAtBottom) {
-    const staticLayersRange = ["-1", "-2", "-3"];
+    const staticLayersRange = SPECIAL_BACKGROUND_LAYER_IDS;
     const staticLayersToMove = layersToShow.filter((layer) =>
       staticLayersRange.includes(layer.name)
     );

--- a/apps/client/src/plugins/LayerSwitcher/components/Favorites/Favorites.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/Favorites/Favorites.jsx
@@ -8,6 +8,7 @@ import FavoritesList from "./FavoritesList";
 import FavoritesOptions from "./FavoritesOptions";
 import FavoritesViewHeader from "./FavoritesViewHeader";
 import ConfirmationDialog from "components/ConfirmationDialog";
+import { BACKGROUND_LAYER_IDS } from "../../../../constants/backgroundLayers";
 import {
   QUICK_ACCESS_KEY,
   QUICK_ACCESS_LS_KEY,
@@ -25,6 +26,16 @@ import {
   Typography,
 } from "@mui/material";
 
+// Sort favorites by title and, for equal titles, by saved date (newest first)
+const sortFavorites = (favorites) =>
+  [...favorites].sort((a, b) => {
+    const titleComparison = a.metadata.title.localeCompare(b.metadata.title);
+    if (titleComparison === 0) {
+      return new Date(b.metadata.savedAt) - new Date(a.metadata.savedAt);
+    }
+    return titleComparison;
+  });
+
 function Favorites({
   handleFavoritesViewToggle,
   app,
@@ -41,7 +52,13 @@ function Favorites({
   const [saveFavoriteDialog, setSaveFavoriteDialog] = useState(false);
   const [loadDialog, setLoadDialog] = useState(false);
   const [selectedFavorite, setSelectedFavorite] = useState(null);
-  const [favorites, setFavorites] = useState([]);
+  const [favorites, setFavorites] = useState(() => {
+    // Initialize state from localstorage on component load
+    const currentLsSettings = LocalStorageHelper.get("layerswitcher");
+    return currentLsSettings.savedLayers?.length > 0
+      ? sortFavorites(currentLsSettings.savedLayers)
+      : [];
+  });
   const [missingLayersConfirmation, setMissingLayersConfirmation] =
     useState(null);
   const [toggleFavoritesView, setToggleFavoritesView] = useState(false);
@@ -50,13 +67,15 @@ function Favorites({
   const { functionalCookiesOk } = useCookieStatus(globalObserver);
   const layerSwitcherDispatch = useLayerSwitcherDispatch();
 
+  const handleSetFavorites = (newFavorites) => {
+    setFavorites(sortFavorites(newFavorites));
+  };
+
   useEffect(() => {
-    // Set state from localstorage on component load
-    const currentLsSettings = LocalStorageHelper.get("layerswitcher");
-    if (currentLsSettings.savedLayers?.length > 0) {
-      handleSetFavorites(currentLsSettings.savedLayers);
-    }
-    // Set dom ready flag to true
+    // Set dom ready flag once mounted so the portal target
+    // (#layer-switcher-view-root) exists before we render into it. This
+    // intentional re-render-after-mount is why setState is called here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDomReady(true);
   }, []);
 
@@ -154,10 +173,10 @@ function Favorites({
         globalObserver.publish("layerswitcher.backgroundLayerChanged", l.id);
         // And set background color to map
         switch (l.id) {
-          case "-2":
+          case BACKGROUND_LAYER_IDS.BLACK:
             document.getElementById("map").style.backgroundColor = "#000";
             break;
-          case "-1":
+          case BACKGROUND_LAYER_IDS.WHITE:
           default:
             document.getElementById("map").style.backgroundColor = "#FFF";
             break;
@@ -285,13 +304,11 @@ function Favorites({
       // No "real" base layer is visible, so we need to check for a fake one (black or white).
       const currentBackgroundColor =
         document.getElementById("map").style.backgroundColor;
-      const WHITE_BACKROUND_LAYER_ID = "-1";
-      const BLACK_BACKROUND_LAYER_ID = "-2";
       layers.push({
         id:
           currentBackgroundColor === "rgb(0, 0, 0)"
-            ? BLACK_BACKROUND_LAYER_ID
-            : WHITE_BACKROUND_LAYER_ID,
+            ? BACKGROUND_LAYER_IDS.BLACK
+            : BACKGROUND_LAYER_IDS.WHITE,
         visible: true,
         subLayers: [],
         opacity: 1,
@@ -343,21 +360,6 @@ function Favorites({
       variant: "success",
       anchorOrigin: { vertical: "bottom", horizontal: "center" },
     });
-  };
-
-  const handleSetFavorites = (newFavorites) => {
-    // Sort favorites by title and saved date
-    const sortedFavorites = newFavorites.sort((a, b) => {
-      // Compare titles
-      const titleComparison = a.metadata.title.localeCompare(b.metadata.title);
-      // If titles are equal, compare saved dates
-      if (titleComparison === 0) {
-        return new Date(b.metadata.savedAt) - new Date(a.metadata.savedAt);
-      }
-      return titleComparison;
-    });
-    // And set to state
-    setFavorites(sortedFavorites);
   };
 
   // Handles edit favorite title and description
@@ -560,7 +562,6 @@ function Favorites({
               setSaveFavoriteDialog(!saveFavoriteDialog);
               handleSaveFavorite();
             }}
-            autoFocus
           >
             Spara
           </Button>

--- a/apps/client/src/plugins/LayerSwitcher/components/Favorites/FavoritesList.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/Favorites/FavoritesList.jsx
@@ -5,6 +5,7 @@ import { saveAs } from "file-saver";
 import FavoritePackageOptions from "./FavoritePackageOptions";
 import ConfirmationDialog from "../../../../components/ConfirmationDialog";
 import BaseDialog from "components/Dialog/BaseDialog";
+import { BACKGROUND_LAYER_IDS } from "../../../../constants/backgroundLayers";
 
 import {
   Button,
@@ -121,10 +122,10 @@ function FavoritesList({
       } else if (layer.id < 0) {
         // A fake maplayer is in the package
         switch (layer.id) {
-          case "-2":
+          case BACKGROUND_LAYER_IDS.BLACK:
             backgroundLayerName = "Svart";
             break;
-          case "-1":
+          case BACKGROUND_LAYER_IDS.WHITE:
           default:
             backgroundLayerName = "Vit";
             break;
@@ -246,7 +247,6 @@ function FavoritesList({
               e.stopPropagation();
               handleEditFavorite();
             }}
-            autoFocus
           >
             Spara
           </Button>

--- a/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.jsx
+++ b/apps/client/src/plugins/LayerSwitcher/components/QuickAccessPresets.jsx
@@ -37,6 +37,7 @@ import {
   useLayerSwitcherDispatch,
 } from "../LayerSwitcherProvider";
 import LocalStorageHelper from "../../../utils/LocalStorageHelper";
+import { BACKGROUND_LAYER_IDS } from "../../../constants/backgroundLayers";
 import LsIconButton from "./LsIconButton";
 
 function QuickAccessPresets({
@@ -182,10 +183,10 @@ function QuickAccessPresets({
         globalObserver.publish("layerswitcher.backgroundLayerChanged", l.id);
         // And set background color to map
         switch (l.id) {
-          case "-2":
+          case BACKGROUND_LAYER_IDS.BLACK:
             document.getElementById("map").style.backgroundColor = "#000";
             break;
-          case "-1":
+          case BACKGROUND_LAYER_IDS.WHITE:
           default:
             document.getElementById("map").style.backgroundColor = "#FFF";
             break;
@@ -278,10 +279,10 @@ function QuickAccessPresets({
       } else if (layer.id < 0) {
         // A fake maplayer is in the package
         switch (layer.id) {
-          case "-2":
+          case BACKGROUND_LAYER_IDS.BLACK:
             backgroundLayerName = "Svart";
             break;
-          case "-1":
+          case BACKGROUND_LAYER_IDS.WHITE:
           default:
             backgroundLayerName = "Vit";
             break;


### PR DESCRIPTION
Here is a generated testing procedure that I found very useful.

### LayerControl API — Manual Testing

Quick smoke-test guide for the centralized layer toggle API
(`LayerControlModel`, exposed on `window.hajkPublicApi.layerControl`).

Run all commands in the **browser console** while the client is running
(`cd apps/client && npm run dev`).

After every toggle, verify that the **LayerSwitcher checkbox/radio updates
automatically** — the UI mirrors OpenLayers state via `propertychange`
listeners, so no manual refresh is needed.

## 1. Grab the API

```js
const lc = window.hajkPublicApi.layerControl;
const map = window.hajkPublicApi.olMap; // the OL map, for inspecting ids below
```

## 2. Find ids to test with

A layer's id is its OpenLayers `name` property. Note `getAllLayers()` already
returns a plain array (no `.getArray()` needed).

```js
// All layers with their type
map.getAllLayers().map((l) => [l.get("name"), l.get("layerType")]);

const L = map.getAllLayers();
L.filter((l) => l.get("layerType") === "group").map((l) => l.get("name")); // WMS group layers
L.filter((l) => l.get("layerType") === "base").map((l) => l.get("name"));  // backgrounds
```

For a LayerSwitcher tree-group **folder** id, probe ids from the LayerSwitcher UI
groups — `lc.showGroup(id)` warns if the id is not a folder.

## 3. Normal layer

```js
lc.showLayer("<id>");
lc.hideLayer("<id>");
lc.toggleLayer("<id>");
lc.setLayerVisibility("<id>", true); // boolean form of show/hide
lc.layerIsVisible("<id>"); // -> true / false
```

## 4. WMS group layer + its sublayers

A WMS group layer (`layerType === "group"`) is one OpenLayers layer with several
**sublayers**. The sublayers are NOT standalone layers, so you must always
address them via the parent group layer id — `showLayer("<subLayerId>")` /
`toggleLayer("<subLayerId>")` will fail (sublayer is not a real OL layer).

```js
// Whole group layer (all sublayers on/off)
lc.showLayer("<groupId>");                                   // all sublayers
lc.showLayer("<groupId>", { subLayers: ["sub1", "sub2"] });  // subset
lc.toggleLayer("<groupId>");

// Individual sublayers (the nested checkboxes)
lc.showSubLayer("<groupId>", "sub1");
lc.hideSubLayer("<groupId>", "sub1");
lc.toggleSubLayer("<groupId>", "sub1");
lc.setSubLayerVisibility("<groupId>", "sub1", true); // boolean form
lc.setSubLayers("<groupId>", ["sub1", "sub3"]);      // exact visible set
lc.subLayerIsVisible("<groupId>", "sub1");           // -> true / false
```

### Composite `"groupId:subLayerId"` shorthand

`showLayer` / `hideLayer` / `toggleLayer` / `layerIsVisible` also accept a single
`"groupId:subLayerId"` string and route it to the matching sublayer method.
(A real layer whose name happens to contain `:` still takes precedence, so this
never breaks existing ids.)

```js
lc.toggleLayer("<groupId>:sub1");          // === lc.toggleSubLayer("<groupId>", "sub1")
lc.showLayer("<groupId>:sub1");            // === lc.showSubLayer(...)
lc.hideLayer("<groupId>:sub1");            // === lc.hideSubLayer(...)
lc.layerIsVisible("<groupId>:sub1");       // === lc.subLayerIsVisible(...)
```

Example for the "Trafiksamordning linje" group layer (`70d0ft`) and its
"Påbörjad" sublayer:

```js
// Either of these work and are equivalent:
lc.toggleLayer("70d0ft:trafiksamordning_linje_paborjad");
lc.toggleSubLayer("70d0ft", "trafiksamordning_linje_paborjad");

lc.layerIsVisible("70d0ft:trafiksamordning_linje_paborjad");
```

To list a group layer's sublayer ids:

```js
map.getAllLayers()
  .find((l) => l.get("name") === "70d0ft")
  .get("allSubLayers");
```

## 5. Base / background layer (exclusive radio)

Showing a base layer hides all other base layers (radio behavior), syncs the
LayerSwitcher radio, and repaints the `div#map` background.

```js
// Any base layer by id. showBackground warns if the id is not a background.
lc.showBackground("<baseId>");
lc.showLayer("<baseId>"); // equivalent low-level call

// Built-in "special" backgrounds — named shortcuts, no magic ids needed.
lc.showBackgroundWhite(); // "-1" -> map canvas turns white (#fff)
lc.showBackgroundBlack(); // "-2" -> map canvas turns black (#000)
lc.showBackgroundOSM();   // "-3" -> OpenStreetMap tiles

// Equivalent to the raw ids:
lc.showLayer("-1");
lc.showLayer("-2");
lc.showLayer("-3");
```

Verify the result (radio updates automatically, and the canvas repaints):

```js
lc.layerIsVisible("-1");                              // -> true / false
document.getElementById("map").style.backgroundColor; // -> "rgb(255, 255, 255)" after white
map.getAllLayers()
  .filter((l) => l.get("layerType") === "base")
  .map((l) => [l.get("name"), l.get("visible")]);      // only one base visible
```

`showBackground` is guarded — passing a non-background id warns and does nothing:

```js
lc.showBackground("<normalOrGroupLayerId>"); // console warning, no change
```

## 6. LayerSwitcher tree-group folder (operates on every leaf)

```js
lc.showGroup("<folderId>");
lc.hideGroup("<folderId>");
lc.toggleGroup("<folderId>");
lc.setGroupVisibility("<folderId>", true);
lc.groupIsVisible("<folderId>"); // -> true / false (all leaves visible)
```