### PR TITLE
Added AI_POLICY.md, updated CONTRIBUTE to cross-reference to AI_POLICY

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,75 @@
+# AI Policy
+
+Hajk's maintainer team is small. This policy exists to protect that limited time of the maintainers – not to discourage
+AI use as such. We use AI tools ourselves. The issue is specifically
+**contributions where AI replaces understanding**, because those cost the
+project more time to review than they save the contributor to produce.
+
+This policy applies to any pull request where an AI tool (Copilot, Cursor,
+Claude, ChatGPT, or similar) generated a non-trivial share of the diff —
+whether that's the whole PR or a large chunk of it. Trivial use, like
+IDE autocomplete for a line or two, or AI-assisted spelling/wording fixes in
+docs, does not need to follow this process.
+
+## The rule
+
+**We do not review unsolicited AI-generated pull requests.** If you open a
+substantial AI-assisted PR without following the steps below, a maintainer
+will close it, link here, and will not provide a detailed review.
+
+This is a hard line, not a suggestion — see [Why](#why) if you want the
+reasoning.
+
+## What we require instead
+
+1. **Open an issue first, and get a maintainer to confirm the approach**
+   before writing any code. Describe the problem and your proposed solution
+   in plain language. Wait for a maintainer to comment that the approach is
+   acceptable. This is the step that actually saves time: it's much cheaper
+   for us to correct a misunderstanding in a paragraph than in a 400-line
+   diff.
+2. **Disclose AI use in the PR description.** State which tool you used and
+   roughly how (e.g. "implementation drafted with Claude Code based on the
+   approach agreed in #1234, then tested manually against GeoServer 2.28").
+3. **You must be able to explain and defend every line.** If a maintainer
+   asks "why does this touch the WMS proxy layer" or "what does this do to
+   existing saved map configs," you need to answer from your own
+   understanding, not by re-pasting the question into an AI tool and
+   forwarding the answer. If you can't explain it, you shouldn't be
+   submitting it yet.
+4. **You are responsible for testing it.** "It builds" and "the AI said
+   it works" are not tests. Run it against a real Hajk instance. Tell us
+   what you tested and how, in the PR description.
+5. **Keep the PR scoped to the linked issue.** Don't let the agent wander
+   into unrelated refactors, formatting churn, or "while I was in there"
+   changes. Large diffs mixing unrelated concerns are closed regardless of
+   how they were produced.
+
+**PRs that skip step 1 (no prior issue / no maintainer sign-off on approach)
+will be closed on sight, even if the code looks fine.** This isn't about the
+code being bad — it's that we have no way to cheaply verify it's good
+without the up-front discussion.
+
+## Why
+
+An open pull request is a _request for a maintainer's time_. Historically,
+the effort it took a human to write a PR was itself a rough filter — if
+you'd spent hours on it, you'd usually understood the codebase well enough
+for the PR to be reviewable in a reasonable amount of time. AI coding tools
+remove that filter: a plausible-looking, large diff can now be produced in
+minutes by someone with no context on Hajk's architecture, and reviewing it
+still takes a maintainer the same amount of time it always did — often
+longer, since diagnosing _why_ an AI-generated approach doesn't fit isn't
+always obvious from the code alone.
+
+We're a small team maintaining GIS infrastructure used in production by
+municipalities. Pre-approving the approach in an issue is how we keep that
+tradeoff sane without shutting the door on contributors entirely.
+
+## If you don't have coding capacity
+
+You don't need to write code to contribute meaningfully. See
+[CONTRIBUTING.md](CONTRIBUTING.md) — writing user documentation on the
+[Wiki](https://github.com/hajkmap/Hajk/wiki), filing detailed bug reports,
+or testing releases are all genuinely useful and don't run into any of the
+above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,23 @@
 
 ## Required tools
 
-- Node.js ≥22 (LTS)
+- Latest LTS of NodeJS
 - Latest Git
 
-## Project structure
+All apps reside inside the `apps/` directory. The Client UI (`client`), Admin UI (`admin`) and NodeJS backend (`backend`) applications can be built and deployed on any OS supported by recent Git and Node versions (tested on macOS, Windows and Linux).
 
-Hajk is a monorepo with three independent apps under `apps/` — no root-level workspace tooling. Each app manages its own dependencies.
+## AI-assisted contributions
 
-| App       | Directory       | Port | Stack                                                       |
-| --------- | --------------- | ---- | ----------------------------------------------------------- |
-| Client UI | `apps/client/`  | 3000 | React 19, Vite 7, OpenLayers 10, MUI v7, TypeScript         |
-| Admin UI  | `apps/admin/`   | 3001 | React 16 (legacy), Create React App 3, MUI v4, OpenLayers 5 |
-| Backend   | `apps/backend/` | 3002 | Node.js ESM, Express 5                                      |
+**Read [AI_POLICY.md](AI_POLICY.md) before opening a pull request that was
+substantially generated or written with an AI tool** (Copilot, Cursor,
+Claude, ChatGPT, or similar). In short: get a maintainer to agree on the
+approach in an issue _before_ you write the code, and disclose AI use in
+your PR description. Unsolicited, undisclosed AI-generated PRs will be
+closed without detailed review — this is explained in full, including our
+reasoning, in AI_POLICY.md.
+
+This doesn't apply to trivial AI-assisted edits (e.g. autocomplete for a
+line or two, or wording fixes in docs).
 
 ## User documentation
 
@@ -23,100 +28,47 @@ End-user documentation can be found in [Hajk's Wiki](https://github.com/hajkmap/
 
 Hajk is built using **Material Design** components from the [Material UI](https://material-ui.com/) project. Make sure to familiarize yourself with all the available components. It is crucial for the user experience that the design principles are followed throughout the system.
 
-## Local development setup
-
-Start apps in this order:
-
-1. **Backend**
-
-   ```bash
-   cd apps/backend
-   cp .env.example .env   # edit as needed
-   npm install
-   npm run dev            # http://localhost:3002
-                          # API Explorer: http://localhost:3002/api-explorer/
-   ```
-
-2. **Client UI**
-
-   Ensure `apps/client/public/appConfig.json` has `mapserviceBase: "http://localhost:3002/api/v2"`.
-
-   ```bash
-   cd apps/client
-   npm install
-   npm run dev   # http://localhost:3000
-   ```
-
-3. **Admin UI** (optional)
-
-   Ensure `apps/admin/public/config.json` URLs point to `http://localhost:3002/api/v2/...`.
-
-   ```bash
-   cd apps/admin
-   npm install
-   npm start     # http://localhost:3001
-   ```
-
-## Build commands
-
-```bash
-# Backend: compile to dist/
-cd apps/backend && npm run compile && npm start
-
-# Client: build to build/
-cd apps/client && npm run build
-
-# Admin: build to build/ (OpenSSL legacy provider handled by npm scripts)
-cd apps/admin && npm run build
-```
-
 ## Git workflow
 
-Hajk enforces the **Git Feature Branch Workflow** as described in [this document](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).
+Hajk strictly enforces the use of **Git Feature Branch Workflow** as described in [this document](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).
 
-### Steps
+### Pre-requirements
 
-1. **Create a GitHub issue.** You will need the issue number for your branch name.
-1. `git fetch` and `git checkout develop` and `git merge` to get the latest.
-1. Create a branch: `git checkout -b feature/1234-blue-button` (use your issue number and a short description).
-1. Set upstream: `git push --set-upstream origin feature/1234-blue-button`
-1. Code, commit, and push regularly:
+**Create an issue on GitHub.** You will need the issue number to give your branch a good name in the steps that follow.
 
-   ```bash
-   git commit -S -m "A good commit message"
-   git push
-   ```
+If your contribution will be substantially AI-generated, **wait for a
+maintainer to confirm the proposed approach in the issue before you start
+coding.** See [AI_POLICY.md](AI_POLICY.md) — this step is mandatory for
+AI-assisted PRs and skipping it is the most common reason such PRs get
+closed without review.
 
-   (The `-S` flag [signs your commit](https://help.github.com/en/articles/signing-commits), which is strongly recommended.)
+### Steps in `git`
 
-1. **Regularly merge `develop` into your branch** to stay up to date:
+In short, developing a new feature, would look something like:
 
-   ```bash
-   git stash && git checkout develop && git fetch && git merge \
-     && git checkout feature/1234-blue-button && git merge develop && git stash apply
-   ```
+1. Always fetch latest with `git fetch`.
+2. Make sure you are in the develop branch by `git checkout develop`.
+3. Make sure that you've merged all upstream changes in `develop` with `git merge`.
+4. Create a new branch and give it a name that relates to the issue you created on GitHub. E.g. if you created an issue called _"Add a blue button"_ and it has issue number #1234, your branch should be called `feature/1234-blue-button`. You create this branch by running `git checkout -b feature/1234-blue-button`
+5. Don't forget to set upstream so that your newly created branch is pushed to GitHub: `git push --set-upstream origin feature/1234-blue-button`
+6. Code…
+7. Regularly commit changes to your branch with `git commit -S -m "A good comment, can be multiline."`. (Note, the `-S` flag [signs your commit](https://help.github.com/en/articles/signing-commits), and signing commits is something you really should be doing.)
+8. Regularly push your changes upstream (to GitHub) with `git push`
+9. **Regularly merge changes that other developers might be doing, from `develop` into your branch.** That means that you will incorporate recent changes and your local branch will stay up-to-date with the latest developments. **Please don't overlook it. This is a really important part.** You can do it like this: `git stash && git checkout develop && git fetch && git merge && git checkout feature/1234-blue-button && git merge develop && git stash apply`. (If you feel comfortable enough with Git, there are of course shorter way of doing this, such as directly merging the upstream remote branch.)
+10. Describe your change with a log entry in the CHANGELOG.md. Select the subsection below the **Unreleased** section based on the type of issue: **Added** for feature, **Fixed** for any bug fixes, **Changed** for changes in existing functionality, **Security** in case of vulnerabilities. See further at the very end of CHANGELOG.md.
+    Format your new row like:
+    - `area`: Short explanation of what the change resolves/adds. [#`issue-number`](https://github.com/hajkmap/Hajk/issues/`issue-number`)
+      - area: could be a specific feature in Hajk like Sketch, Print or Cookie or an app like Admin, Backend or Client or more generic like Core, Bug, Fix.
+      - issue-number: The number of your Hajk issue.
+11. When you're done coding, go to GitHub and create a new pull request. Make sure that you want to merge your branch into `develop`. If AI tools contributed substantially to your change, disclose this in the PR description as described in [AI_POLICY.md](AI_POLICY.md).
+12. Hajk maintainers will get notified when you create the PR. They will review your PR and either accept and merge your branch (as well as delete it from the remote, as it's no longer needed) or (if the code isn't considered ready) request changes. After a successful merge you will still have a copy of your feature branch locally, but it can be safely removed by running `git branch -d feature/1234-blue-button`. **PRs that skip the pre-approval or disclosure steps required for AI-assisted contributions may be closed without detailed review.**
 
-1. Add a line to `CHANGELOG.md` under the **Unreleased** section:
+## Code standard
 
-   ```markdown
-   - area: Short explanation. [#1234](https://github.com/hajkmap/Hajk/issues/1234)
-   ```
+Hajk uses **ESLint** and **Prettier** to enforce code formatting across the project.
 
-   Use `Added`, `Fixed`, `Changed`, or `Security` subsections as appropriate. `area` can be a plugin name (Sketch, Print…) or app name (Admin, Backend, Client) or general (Core, Bug).
+🔥 **Code that gets checked in must follow those rules.** 🔥
 
-1. Open a pull request on GitHub targeting the `develop` branch.
+The `client` and `backend` directories contain all necessary configuration files. The recommended way is to use an editor that has extensions for ESLint and Prettier installed. It is also highly recommended to make the editor run Prettier on each file save (i.e. in VSCode it can be controlled by the `formatOnSave: true` flag).
 
-## Code standards
-
-The **Client** and **Backend** use ESLint 9 + Prettier. The **Admin** uses Prettier only.
-
-Run `npm run lint:fix` in the relevant app directory before committing. Code that does not pass linting will not be accepted.
-
-Additional conventions for the Client:
-
-- Prefer functional components with hooks over class components.
-- Use TypeScript interfaces for prop types.
-- Keep components focused — aim for under 200 lines.
-- Backend uses ES module syntax throughout; do not use CommonJS `require()`.
-
-The recommended editor setup is VSCode with the ESLint and Prettier extensions, with `formatOnSave: true` enabled.
+**For a simple guide on setting up VSCode with ESLint, Prettier and some , see [this presentation](https://github.com/hajkmap/Hajk/blob/master/dokumentation/VSCodeSetup.pdf)**. (Swedish only)


### PR DESCRIPTION
Here's a proposal for Hajk's AI Policy. I reviewed several projects from [this list](https://github.com/melissawm/open-source-ai-contribution-policies), finding that the main principles from [Ghostty's policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md) are very applicable to our project. 

The main takeaway is this, as stated in CONTRIBUTE.md:

> In short: get a maintainer to agree on the approach in an issue _before_ you write the code, and disclose AI use in your PR description.

For this PR, I expect opinions and reviews only from other maintainers. 