### PR TITLE
Fix for mobile searchbar width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client: Search - User's limit of search sources (made in search settings) was not respected in Safari. [#1852](https://github.com/hajkmap/Hajk/issues/1852).
 - Client: Crashes when activating Snap-enabled tools (e.g. PropertyChecker) with nested GeometryCollection features in the map. [#1860](https://github.com/hajkmap/Hajk/issues/1860).
 - Client: MapSwitcher can now be configured to show as a larger dropdown element next to the search box (in addition to the traditional Control button). [#1858](https://github.com/hajkmap/Hajk/issues/1858).
+- Client: Prevent search bar from overflowing on certain mobile screens. [#1877](https://github.com/hajkmap/Hajk/issues/1877)
 
 ## [4.3.0] 2026-04-20
 

--- a/apps/client/src/components/App.jsx
+++ b/apps/client/src/components/App.jsx
@@ -1294,6 +1294,7 @@ class App extends React.PureComponent {
                   alignItems: "center",
                   gap: 1,
                   ml: this.showDrawerButtons() ? 0 : "auto",
+                  minWidth: 0,
                 }}
               >
                 {showMapSwitcher &&

--- a/apps/client/src/components/Search/SearchBar.jsx
+++ b/apps/client/src/components/Search/SearchBar.jsx
@@ -542,6 +542,7 @@ class SearchBar extends React.PureComponent {
         sx={{
           width: 400,
           height: (theme) => (renderElsewhere ? "auto" : theme.spacing(6)),
+          mr: isMobile ? 1 : 0,
         }}
       >
         <Grid>


### PR DESCRIPTION
As descripbed in [1877](https://github.com/hajkmap/Hajk/issues/1877), this fix is for the searchbar width to not overflow to the right on mobile devices with smaller widths.

<img width="534" height="174" alt="Screenshot from 2026-08-11 17-35-31" src="https://github.com/user-attachments/assets/3cb6f911-9b7f-4230-be7b-e95fa3d6d52e" />
