### PR TITLE
Enhance Backend's error responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ This is a monorepo with three independent apps — no root-level workspace tooli
 
 ### Tech Stack at a Glance
 
-|           | Backend                 | Client              | Admin                 |
-| --------- | ----------------------- | ------------------- | --------------------- |
-| Framework | Express 5               | React 19            | React 16 (legacy)     |
-| Build     | ES modules (no bundler) | Vite 7              | Create React App 3    |
-| UI        | —                       | MUI v7              | MUI v4 + Ant Design 4 |
-| Maps      | —                       | OpenLayers 10       | OpenLayers 5          |
-| Language  | JavaScript (ESM)        | TypeScript (strict) | JavaScript            |
-| Linting   | ESLint 9 + Prettier     | ESLint 9 + Prettier | Prettier only         |
+| | Backend | Client | Admin |
+| --- | --- | --- | --- |
+| Framework | Express 5 | React 19 | React 16 (legacy) |
+| Build | ES modules (no bundler) | Vite 7 | Create React App 3 |
+| UI | — | MUI v7 | MUI v4 + Ant Design 4 |
+| Maps | — | OpenLayers 10 | OpenLayers 5 |
+| Language | JavaScript (ESM) | TypeScript (strict) | JavaScript |
+| Linting | ESLint 9 + Prettier | ESLint 9 + Prettier | Prettier only |
 
 ### Critical Configuration Files
 
@@ -100,7 +100,6 @@ cd apps/admin && npm run build
   - Client UI consumes: `/api/v2/`
   - Admin UI consumes: `/api/v2/mapconfig/` for admin operations
   - ActiveDirectory auth (when enabled) affects `/config` vs `/mapconfig` responses
-  - API Error Handling: The backend uses `handleStandardResponse` to standardize API outputs. Custom errors should extend `Error` and define a `statusCode` property to control the HTTP response.
 
 ### Noteworthy Quirks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ This is a monorepo with three independent apps — no root-level workspace tooli
 
 ### Tech Stack at a Glance
 
-| | Backend | Client | Admin |
-| --- | --- | --- | --- |
-| Framework | Express 5 | React 19 | React 16 (legacy) |
-| Build | ES modules (no bundler) | Vite 7 | Create React App 3 |
-| UI | — | MUI v7 | MUI v4 + Ant Design 4 |
-| Maps | — | OpenLayers 10 | OpenLayers 5 |
-| Language | JavaScript (ESM) | TypeScript (strict) | JavaScript |
-| Linting | ESLint 9 + Prettier | ESLint 9 + Prettier | Prettier only |
+|           | Backend                 | Client              | Admin                 |
+| --------- | ----------------------- | ------------------- | --------------------- |
+| Framework | Express 5               | React 19            | React 16 (legacy)     |
+| Build     | ES modules (no bundler) | Vite 7              | Create React App 3    |
+| UI        | —                       | MUI v7              | MUI v4 + Ant Design 4 |
+| Maps      | —                       | OpenLayers 10       | OpenLayers 5          |
+| Language  | JavaScript (ESM)        | TypeScript (strict) | JavaScript            |
+| Linting   | ESLint 9 + Prettier     | ESLint 9 + Prettier | Prettier only         |
 
 ### Critical Configuration Files
 
@@ -100,6 +100,7 @@ cd apps/admin && npm run build
   - Client UI consumes: `/api/v2/`
   - Admin UI consumes: `/api/v2/mapconfig/` for admin operations
   - ActiveDirectory auth (when enabled) affects `/config` vs `/mapconfig` responses
+  - API Error Handling: The backend uses `handleStandardResponse` to standardize API outputs. Custom errors should extend `Error` and define a `statusCode` property to control the HTTP response.
 
 ### Noteworthy Quirks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backend: Upgraded `write-excel-file` from 3.x to 4.x.
 - Backend: Enhance detailed request logger with structured output and file logging configuration [#1836](https://github.com/hajkmap/Hajk/pull/1836)
 - Backend: Bumped the [API Explorer](https://github.com/swagger-api/swagger-ui) to v5.32.6.
-- Backend: Refactored `handleStandardResponse` and custom error classes to standardize API error outputs as JSON and move status code logic into the error classes.
 - Client: AppModel refactored — split the 1444-line class into 8 focused modules under `appModel/` (urlParamsMerger, configTranslator, backgroundLayers, clickBindings, mapFactory, layerLoader, layerVisibility, pluginManager). No behavior change; all public methods preserved. [#1826](https://github.com/hajkmap/Hajk/pull/1826)
 - Client: New Mobile UI etc, see [#1778](https://github.com/hajkmap/Hajk/issues/1778).
 - Client: New CQL filter UI, PR [#1756](https://github.com/hajkmap/Hajk/pull/1756).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backend: Upgraded `write-excel-file` from 3.x to 4.x.
 - Backend: Enhance detailed request logger with structured output and file logging configuration [#1836](https://github.com/hajkmap/Hajk/pull/1836)
 - Backend: Bumped the [API Explorer](https://github.com/swagger-api/swagger-ui) to v5.32.6.
+- Backend: Refactored `handleStandardResponse` and custom error classes to standardize API error outputs as JSON and move status code logic into the error classes.
 - Client: AppModel refactored — split the 1444-line class into 8 focused modules under `appModel/` (urlParamsMerger, configTranslator, backgroundLayers, clickBindings, mapFactory, layerLoader, layerVisibility, pluginManager). No behavior change; all public methods preserved. [#1826](https://github.com/hajkmap/Hajk/pull/1826)
 - Client: New Mobile UI etc, see [#1778](https://github.com/hajkmap/Hajk/issues/1778).
 - Client: New CQL filter UI, PR [#1756](https://github.com/hajkmap/Hajk/pull/1756).

--- a/apps/backend/server/apis/v2/utils/AccessError.js
+++ b/apps/backend/server/apis/v2/utils/AccessError.js
@@ -10,7 +10,6 @@
 export class AccessError extends Error {
   constructor(message, options) {
     super(message, options);
-    this.statusCode = 403;
   }
 
   get name() {

--- a/apps/backend/server/apis/v2/utils/AccessError.js
+++ b/apps/backend/server/apis/v2/utils/AccessError.js
@@ -10,6 +10,7 @@
 export class AccessError extends Error {
   constructor(message, options) {
     super(message, options);
+    this.statusCode = 403;
   }
 
   get name() {

--- a/apps/backend/server/apis/v2/utils/ActiveDirectoryError.js
+++ b/apps/backend/server/apis/v2/utils/ActiveDirectoryError.js
@@ -7,11 +7,6 @@
  * @extends {Error}
  */
 export default class ActiveDirectoryError extends Error {
-  constructor(message, options) {
-    super(message, options);
-    this.statusCode = 500;
-  }
-
   get name() {
     return "ActiveDirectoryError";
   }

--- a/apps/backend/server/apis/v2/utils/ActiveDirectoryError.js
+++ b/apps/backend/server/apis/v2/utils/ActiveDirectoryError.js
@@ -7,6 +7,11 @@
  * @extends {Error}
  */
 export default class ActiveDirectoryError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.statusCode = 500;
+  }
+
   get name() {
     return "ActiveDirectoryError";
   }

--- a/apps/backend/server/apis/v2/utils/ConfigParseError.js
+++ b/apps/backend/server/apis/v2/utils/ConfigParseError.js
@@ -12,7 +12,6 @@ export class ConfigParseError extends Error {
   constructor(message, configName, options) {
     super(message, options);
     this.configName = configName;
-    this.statusCode = 500;
   }
 
   get name() {

--- a/apps/backend/server/apis/v2/utils/ConfigParseError.js
+++ b/apps/backend/server/apis/v2/utils/ConfigParseError.js
@@ -12,6 +12,7 @@ export class ConfigParseError extends Error {
   constructor(message, configName, options) {
     super(message, options);
     this.configName = configName;
+    this.statusCode = 500;
   }
 
   get name() {

--- a/apps/backend/server/apis/v2/utils/FmeServerError.js
+++ b/apps/backend/server/apis/v2/utils/FmeServerError.js
@@ -7,6 +7,11 @@
  * @extends {Error}
  */
 export default class FmeServerError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.statusCode = 502;
+  }
+
   get name() {
     return "FmeServerError";
   }

--- a/apps/backend/server/apis/v2/utils/FmeServerError.js
+++ b/apps/backend/server/apis/v2/utils/FmeServerError.js
@@ -7,11 +7,6 @@
  * @extends {Error}
  */
 export default class FmeServerError extends Error {
-  constructor(message, options) {
-    super(message, options);
-    this.statusCode = 502;
-  }
-
   get name() {
     return "FmeServerError";
   }

--- a/apps/backend/server/apis/v2/utils/handleStandardResponse.js
+++ b/apps/backend/server/apis/v2/utils/handleStandardResponse.js
@@ -10,27 +10,25 @@
  */
 export default function handleStandardResponse(res, data, successStatus = 200) {
   // If we encountered a error…
-  if (data.error) {
-    // Check if it's ConfigParseError. If so, send a 500 Internal Server Error
-    // along with structured info about which config file failed to parse.
-    if (data.error.name === "ConfigParseError") {
-      res.status(500).json({
-        error: data.error.message,
-        config: data.error.configName,
-      });
-      return;
+  if (data?.error) {
+    const error = data.error;
+
+    // 1. Determine Status Code
+    // Priority: Explicit statusCode property -> Node.js ENOENT (404) -> Default (500)
+    let status = error.statusCode || 500;
+    if (error.code === "ENOENT") {
+      status = 404;
     }
 
-    // Check if it's AccessError. If so, send a 403 Forbidden.
-    // If error.code is ENOENT, send a 404 Not Found.
-    // Otherwise, send a generic status 500.
-    let status = 500;
-    if (data.error.code === "ENOENT") {
-      status = 404;
-    } else if (data.error.name === "AccessError") {
-      status = 403;
-    }
-    res.status(status).send(data.error.toString());
+    // 2. Standardize Error Payload
+    // Always return a JSON object with 'error' and optional 'details'
+    const errorPayload = {
+      error: error.message || error.toString(),
+      ...(error.details && { details: error.details }),
+      ...(error.configName && { config: error.configName }),
+    };
+
+    return res.status(status).json(errorPayload);
   }
   // If there's no error, send the response
   else {

--- a/apps/backend/server/apis/v2/utils/handleStandardResponse.js
+++ b/apps/backend/server/apis/v2/utils/handleStandardResponse.js
@@ -10,25 +10,27 @@
  */
 export default function handleStandardResponse(res, data, successStatus = 200) {
   // If we encountered a error…
-  if (data?.error) {
-    const error = data.error;
-
-    // 1. Determine Status Code
-    // Priority: Explicit statusCode property -> Node.js ENOENT (404) -> Default (500)
-    let status = error.statusCode || 500;
-    if (error.code === "ENOENT") {
-      status = 404;
+  if (data.error) {
+    // Check if it's ConfigParseError. If so, send a 500 Internal Server Error
+    // along with structured info about which config file failed to parse.
+    if (data.error.name === "ConfigParseError") {
+      res.status(500).json({
+        error: data.error.message,
+        config: data.error.configName,
+      });
+      return;
     }
 
-    // 2. Standardize Error Payload
-    // Always return a JSON object with 'error' and optional 'details'
-    const errorPayload = {
-      error: error.message || error.toString(),
-      ...(error.details && { details: error.details }),
-      ...(error.configName && { config: error.configName }),
-    };
-
-    return res.status(status).json(errorPayload);
+    // Check if it's AccessError. If so, send a 403 Forbidden.
+    // If error.code is ENOENT, send a 404 Not Found.
+    // Otherwise, send a generic status 500.
+    let status = 500;
+    if (data.error.code === "ENOENT") {
+      status = 404;
+    } else if (data.error.name === "AccessError") {
+      status = 403;
+    }
+    res.status(status).send(data.error.toString());
   }
   // If there's no error, send the response
   else {


### PR DESCRIPTION
While working on #1883 I noticed that the responses aren't standardized for our errors. Mainly I don't know why I ever chose to send errors as text responses. Could be due to some legacy compatibility with the Admin app, I can't think of any other reason (but it's like 7 years ago so don't blame me…). 

Anyway, here's a proposal for fixing this and sending proper JSON error messages that actually say what the problem is. Along with correct HTTP status, of course. 