### PR TITLE
Feature/x kml gpx refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client: TypeScript is now supported, see [#1824.](https://github.com/hajkmap/Hajk/pull/1824)
 - Client: Upgraded MUI packages to v9. Completed the migration steps not covered by the codemods — Autocomplete `renderInput` now reads `params.slotProps` (fixes a startup crash in the search bar), `PopperComponent`/`PaperComponent` moved to `slots`, Dialog `PaperComponent`/`PaperProps`/`BackdropProps`/`onBackdropClick` and Tooltip `TransitionProps` moved to `slots`/`slotProps`, remaining `InputProps` on TextField moved to `slotProps.input`, `SpeedDialAction` tooltip props moved to `slotProps.tooltip`, and CSS props inside `ListItemText` Typography slots moved into `sx` (silences DOM prop warnings and restores layer-name truncation).
 - Client: Location plugin now has an optional follow location toggle. Enabling it will re-center the map on user's location when location changes. [#1875](https://github.com/hajkmap/Hajk/issues/1875)
+- Client: Anchor plugin refactored from class to function components with hooks, replacing the deprecated `document.execCommand("copy")` clipboard handling with the async Clipboard API and the legacy `withSnackbar` HOC with notistack's `useSnackbar`. The "Öppna länk" button is now shown even when the Clipboard API is unavailable (e.g. insecure contexts). No other behavior change.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backend: Enhance detailed request logger with structured output and file logging configuration [#1836](https://github.com/hajkmap/Hajk/pull/1836)
 - Backend: Bumped the [API Explorer](https://github.com/swagger-api/swagger-ui) to v5.32.6.
 - Client: AppModel refactored — split the 1444-line class into 8 focused modules under `appModel/` (urlParamsMerger, configTranslator, backgroundLayers, clickBindings, mapFactory, layerLoader, layerVisibility, pluginManager). No behavior change; all public methods preserved. [#1826](https://github.com/hajkmap/Hajk/pull/1826)
+- Client: KmlModel and GpxModel unified — the near-identical import/export flows now live in a shared base class (`VectorImportModel`), with each model reduced to a format-specific profile and small overrides (KML keeps its style round-trip pipeline, GPX keeps its geometry filtering). No behavior change; all public methods preserved.
 - Client: New Mobile UI etc, see [#1778](https://github.com/hajkmap/Hajk/issues/1778).
 - Client: New CQL filter UI, PR [#1756](https://github.com/hajkmap/Hajk/pull/1756).
 - Client: TypeScript is now supported, see [#1824.](https://github.com/hajkmap/Hajk/pull/1824)

--- a/apps/client/src/models/GpxModel.js
+++ b/apps/client/src/models/GpxModel.js
@@ -1,10 +1,10 @@
-import { Vector as VectorLayer } from "ol/layer";
-import VectorSource from "ol/source/Vector";
 import GPX from "ol/format/GPX";
-import { saveAs } from "file-saver";
+import VectorImportModel from "./VectorImportModel";
 
 /*
- * A model supplying useful GPX-functionality.
+ * A model supplying useful GPX-functionality. Extends the generic
+ * VectorImportModel with a GPX-specific profile and export handling.
+ *
  * Required settings:
  * - layerName: (string): The name of the layer that should be connected to the GPX-model.
  *   If it already exists a layer in the map with the same name, the model will be connected
@@ -13,387 +13,41 @@ import { saveAs } from "file-saver";
  * Optional settings:
  * - enableDragAndDrop: (boolean): If true, drag-and-drop of .gpx-files will be active.
  * - drawModel (DrawModel): If supplied, imported features will be drawn using the draw-model.
+ * - observer (Observer): Will receive "gpxModel.fileImported" when a file has been dropped.
  *
- * Exposes a couple of methods:
- * - parseFeatures(gpxString, settings): Accepts a GPX-string and tries to parse it to OL-features.
- * - import(gpxString, settings): Accepts a GPX-string and adds the GPX-features to the layer.
- * - export(): Exports all features in the current gpx-layer.
- * - zoomToCurrentExtent(): Zooms the map to the current extent of the gpx-source.
- * - setLayer(layerName): Accepts a string containing a layer name. Will set current layer.
- * - getCurrentLayerName(): Returns the name of the vectorLayer that is currently connected to the model.
- * - getCurrentExtent(): Returns the current extent of the gpx-source.
+ * The complete public API is documented in VectorImportModel. On top of that,
+ * this class keeps the legacy alias importedGpxStillHasFeatures(id).
  */
-class GpxModel {
-  #map;
-  #layerName;
-  #drawModel;
-  #observer;
-  #gpxSource;
-  #gpxLayer;
-  #parser;
-  #currentExtent;
-
+class GpxModel extends VectorImportModel {
   constructor(settings) {
-    // Let's make sure that we don't allow initiation if required settings
-    // are missing.
-    if (!settings.map || !settings.layerName) {
-      return this.#handleInitiationParametersMissing();
-    }
-    // Make sure that we keep track of the supplied settings.
-    this.#map = settings.map;
-    this.#layerName = settings.layerName;
-    this.#drawModel = settings.drawModel || null;
-    this.#observer = settings.observer || null;
-    // If a setting to enable drag-and-drop has been passed, we have to initiate
-    // the listeners for that.
-    settings.enableDragAndDrop && this.#addMapDropListeners();
-    // We are gonna need a gpx parser obviously.
-    this.#parser = new GPX();
-    // We are going to be keeping track of the current extent of the gpx-source.
-    this.#currentExtent = null;
-    // A GPX-model is not really useful without a vector-layer, let's initiate it
-    // right away, either by creating a new layer, or connect to an existing layer.
-    this.#initiateGpxLayer();
+    super(settings, {
+      displayName: "GPX",
+      parserFactory: () => new GPX(),
+      acceptedFileTypes: ["gpx", "application/gpx+xml"],
+      fileExtension: "gpx",
+      importTagPropertyName: "GPX_IMPORT",
+      setShowTextOnImport: false,
+      idPropertyName: "GPX_ID",
+      observerSubject: "gpxModel.fileImported",
+      layerCaption: "GPX model",
+      layerZIndex: 5001,
+      exportMimeType: "application/gpx+xml;charset=utf-8",
+      exportFileNamePrefix: "Gpxexport",
+      exportDocSuffix: "-gpx-export",
+    });
   }
 
-  // If required parameters are missing, we have to make sure we abort the
-  // initiation of the GPX-model.
-  #handleInitiationParametersMissing = () => {
-    throw new Error(
-      "Failed to initiate GPX-model, - required parameters missing. \n Required parameters: map, layerName"
-    );
-  };
-
-  // We have to initiate a vector layer that can be used to display the imported features.
-  #initiateGpxLayer = () => {
-    if (this.#vectorLayerExists()) {
-      return this.#connectExistingVectorLayer();
-    }
-    return this.#createNewGpxLayer();
-  };
-
-  // Adds listeners so that .gpx-files can be drag-and-dropped into the map,
-  // triggering an import.
-  #addMapDropListeners = () => {
-    const mapDiv = document.getElementById("map");
-    ["drop", "dragover", "dragend", "dragleave", "dragenter"].forEach(
-      (eventName) => {
-        mapDiv.addEventListener(
-          eventName,
-          this.#preventDefaultDropBehavior,
-          false
-        );
-      }
-    );
-
-    mapDiv.addEventListener("drop", this.#handleDrop, false);
-  };
-
-  // Prevents the default behaviors connected to drag-and-drop.
-  #preventDefaultDropBehavior = (e) => {
-    e.stopPropagation();
-    e.preventDefault();
-  };
-
-  // Handles the event when a file has been dropped. Tries to import the file as a .gpx.
-  #handleDrop = async (e) => {
-    try {
-      for await (const file of e.dataTransfer.files) {
-        const fileType = file.type ? file.type : file.name.split(".").pop();
-        if (fileType === "gpx" || fileType === "application/gpx+xml") {
-          this.#importDroppedGpx(file);
-        }
-      }
-    } catch (error) {
-      console.error(`Error importing GPX-file... ${error}`);
-    }
-  };
-
-  #importDroppedGpx = (file) => {
-    const reader = new FileReader();
-    // We're gonna want to set a random id on all features belonging
-    // to the current file. That way we can keep track of which features
-    // belongs to each file.
-    const id = Math.random().toString(36).slice(2, 9);
-    // Let's handle the onload-event and import the features!
-    reader.onload = () => {
-      this.import(reader.result, {
-        zoomToExtent: true,
-        setProperties: { GPX_ID: id },
-      });
-      // We also want to publish an event on the observer so that we can update potential views.
-      this.#observer &&
-        this.#observer.publish("gpxModel.fileImported", {
-          id,
-        });
-    };
-    reader.readAsText(file);
-  };
-
-  // Checks whether the layerName supplied when initiating the GPX-model
-  // corresponds to an already existing vector-layer.
-  #vectorLayerExists = () => {
-    // Get all the layers from the map
-    const allMapLayers = this.#getAllMapLayers();
-    // Check whether any of the layers has the same name (type)
-    // as the supplied layerName. Also makes sure that the found
-    // layer is a vectorLayer.
-    return allMapLayers.some((layer) => {
-      return this.#layerHasCorrectNameAndType(layer);
-    });
-  };
-
-  // Returns all layers connected to the map-object supplied
-  // when initiating the model.
-  #getAllMapLayers = () => {
-    return this.#map.getLayers().getArray();
-  };
-
-  // Checks whether the name (type) of the supplied layer matches
-  // the layerName supplied when initiating the model. Also makes
-  // sure that the layer is a vectorLayer.
-  #layerHasCorrectNameAndType = (layer) => {
-    return layer.get("name") === this.#layerName && this.#isVectorLayer(layer);
-  };
-
-  // Checks whether the supplied layer is a vectorLayer or not.
-  #isVectorLayer = (layer) => {
-    return layer instanceof VectorLayer;
-  };
-
-  // Connects the private fields of the GPX-model to an already existing
-  // vectorLayer.
-  #connectExistingVectorLayer = () => {
-    // Get all the layers from the map
-    const allMapLayers = this.#getAllMapLayers();
-    // Then we'll grab the layer corresponding to the supplied layerName.
-    const connectedLayer = allMapLayers.find((layer) => {
-      return this.#layerHasCorrectNameAndType(layer);
-    });
-    // Then we'll set the private fields
-    this.#gpxLayer = connectedLayer;
-    this.#gpxSource = connectedLayer.getSource();
-  };
-
-  // Creates a new vector layer that can be used to display GPX-features.
-  #createNewGpxLayer = () => {
-    // Let's grab a vector-source.
-    this.#gpxSource = this.#getNewVectorSource();
-    // Let's create a layer
-    this.#gpxLayer = this.#getNewVectorLayer(this.#gpxSource);
-    // Make sure to set a unique name
-    this.#gpxLayer.set("name", this.#layerName);
-    // Then we can add the layer to the map.
-    this.#map.addLayer(this.#gpxLayer);
-  };
-
-  // Returns a new vector source.
-  #getNewVectorSource = () => {
-    return new VectorSource({ wrapX: false });
-  };
-
-  // Returns a new vector layer connected to the supplied source.
-  #getNewVectorLayer = (source) => {
-    return new VectorLayer({
-      source: source,
-      layerType: "system",
-      zIndex: 5001,
-      caption: "GPX model",
-    });
-  };
-
-  // Translates the supplied feature to the map-views coordinate system.
-  #translateFeatureToViewSrs = (feature) => {
-    // Let's get the geometry-type to begin with
-    const baseGeometryType = feature?.getGeometry?.().getType?.() ?? null;
-    // If no geometry-type could be fetched from the supplied feature, we make sure
-    // to terminate to avoid errors.
-    if (baseGeometryType === null) return null;
-    // We are going to be using the view of the map when translating, let's get it
-    const mapViewProjection = this.#map.getView().getProjection();
-    // Finally we translate the feature to the view-projection.
-    feature.getGeometry().transform("EPSG:4326", mapViewProjection);
-  };
-
-  // Prepares the supplied features for injection in the map.
-  // Includes translating and styling of the features.
-  #prepareForMapInjection = (features) => {
-    // If no features are supplied, we abort!
-    if (!features || features?.length === 0) {
-      return null;
-    }
-    // Otherwise we check if the features are to be added via the drawModel. If they are, we set
-    // the USER_DRAWN-prop to true since all features in the draw-source _can_ be altered by the user.
-    // We also have to translate every feature to the map-views coordinate system.
-    features.forEach((feature) => {
-      this.#translateFeatureToViewSrs(feature);
-      // this.#setFeatureStyle(feature);
-      this.#drawModel && feature.set("USER_DRAWN", true);
-    });
-  };
-
-  #tagFeaturesAsImported = (features) => {
-    // If no features are supplied, we abort!
-    if (!features || features?.length === 0) {
-      return null;
-    }
-    // Otherwise we set the "GPX_IMPORT" property to true.
-    features.forEach((feature) => {
-      feature.set("GPX_IMPORT", true);
-    });
-  };
-
-  // Checks whether there are any features in the gpx-source or not.
-  #gpxSourceHasFeatures = () => {
-    return this.#gpxSource.getFeatures().length > 0;
-  };
-
-  // Fits the map to the current extent of the gpx-source (with some padding).
-  #fitMapToExtent = () => {
-    this.#map.getView().fit(this.#currentExtent, {
-      size: this.#map.getSize(),
-      padding: [20, 20, 20, 20],
-      maxZoom: 7,
-    });
-  };
-
-  // Sets the supplied properties on the supplied features
-  #setFeatureProperties = (features, properties) => {
-    for (const feature of features) {
-      feature.setProperties(properties);
-    }
-  };
-
-  // Accepts an id and checks if the current source still contains features
-  // with the supplied gpx-id.
+  // Kept for backwards-compatibility with the pre-refactor public API.
   importedGpxStillHasFeatures = (id) => {
-    return (
-      this.#gpxSource.getFeatures().filter((f) => f.get("GPX_ID") === id)
-        .length > 0
-    );
+    return this.importedFileStillHasFeatures(id);
   };
 
-  // Tries to parse features from the supplied gpx-string.
-  // Accepts a gpxString and an optional second parameter stating if
-  // the features should be translated to the map-views srs or not.
-  // Returns an object on the following form:
-  // {features: <Array of ol-features>, error: <String with potential error message>}
-  // **The returned features are translated to the map-views coordinate system.**
-  parseFeatures = (gpxString, settings = { prepareForMapInjection: true }) => {
-    // The method accepts a setting-object, lets extract the settings we need.
-    // The settings includes a possibility to set prepareForMapInjection to false,
-    // (default to true), allowing for the return-object to contain the pure parsed
-    // features (not styled or translated).
-    const prepareForMapInjection = settings.prepareForMapInjection;
-    // Then we start parsing
-    try {
-      // First we must parse the string to ol-features
-      const features = this.#parser.readFeatures(gpxString) ?? [];
-      // Let's make sure to tag all imported features so that we can
-      // distinguish them from "ordinary" features.
-      this.#tagFeaturesAsImported(features);
-      // Then we must make sure to prepare all the features for
-      // map-injection. This includes translating the features to
-      // the current map-views coordinate system, and setting some style.
-      prepareForMapInjection && this.#prepareForMapInjection(features);
-      // Then we can return the features
-      return { features: features, error: null };
-    } catch (error) {
-      // If we happen to hit a mine, we make sure to return the error
-      // message and an empty array.
-      return { features: [], error: error };
-    }
-  };
-
-  // Tries to parse features from a GPX-string and then add them to
-  // the gpx-source.
-  // Accepts a gpxString and an optional parameter stating if the map should
-  // zoom the the imported features extent or not.
-  import = (gpxString, settings = { zoomToExtent: true }) => {
-    // Start by trying to parse the gpx-string
-    const { features, error } = this.parseFeatures(gpxString);
-    // If the parsing led to any kind of error, we make sure to abort
-    // and return the error to the initiator.
-    if (error !== null) {
-      return { status: "FAILED", error: error };
-    }
-    // If "setProperties" was supplied in the settings, we have to make sure
-    // to set the supplied properties on all features.
-    settings.setProperties &&
-      this.#setFeatureProperties(features, settings.setProperties);
-
-    // If we have a drawModel, use it to add the features
-    if (this.#drawModel) {
-      this.#drawModel.addGpxFeatures(features);
-    } else {
-      // Otherwise add to the GPX source
-      this.#gpxSource.addFeatures(features);
-    }
-
-    // We have to make sure to update the current extent when we've added
-    // features to the gpx-source.
-    this.#currentExtent = this.#gpxSource.getExtent();
-    // Then we make sure to zoom to the current extent (unless the initiator
-    // has told us not to!).
-    settings.zoomToExtent && this.zoomToCurrentExtent();
-    // Finally we return a success message to the initiator.
-    return { status: "SUCCESS", error: null };
-  };
-
-  // Tries to export all the features in the current gpx-layer
-  export = () => {
-    // First we need to get all the features from the current gpx-source
-    // (except for hidden features, the users might be confused if hidden features are exported).
-    const features = this.#gpxSource
-      .getFeatures()
-      .filter((f) => f.get("HIDDEN") !== true);
-    // Then we have to make sure that there were some feature there to export.
-    if (!features || features?.length === 0) {
-      return {
-        status: "FAILED",
-        error: "No features exist in the current gpx-layer.",
-      };
-    }
-    // Then we'll do some transformations on the features to make sure
-    // that they are gpx-compatible.
-    const compatibleFeatures = this.#getGpxCompatibleFeatures(features);
-    // Let's make sure that we have some compatible features to return,
-    // if we don't, we make sure to abort.
-    if (compatibleFeatures.length === 0) {
-      return {
-        status: "FAILED",
-        error: "Could not transform any features to the .gpx standard.",
-      };
-    }
-    // If we do have compatible features, we can create the gpx-xml
-    const postData = this.#parser.writeFeatures(
-      compatibleFeatures,
-      `${this.#layerName}-gpx-export`
-    );
-    // Then we'll call the save-as method from file-saver, which will
-    // initiate the download-process for the user.
-    try {
-      saveAs(
-        new Blob([postData], {
-          type: "application/gpx+xml;charset=utf-8",
-        }),
-        `Gpxexport - ${new Date().toLocaleString()}.gpx`
-      );
-      return {
-        status: "SUCCESS",
-        error: null,
-      };
-    } catch (_error) {
-      return {
-        status: "FAILED",
-        error: "Could not save the GPX-file. File-saver Error.",
-      };
-    }
-  };
+  // Note: _prepareImportedFeatureForMapInjection is intentionally not
+  // overridden - GPX features are shown as parsed, no styling is applied.
 
   // Clones the supplied features and returns new features which are transformed
   // so that they are compatible with the .gpx-format.
-  #getGpxCompatibleFeatures = (features) => {
+  _makeExportCompatibleFeatures(features, { viewProjection }) {
     // Declare an array where we can push the transformed features.
     const transformedFeatures = [];
     // Looping trough all the features, creating a clone of each, this clone
@@ -407,58 +61,14 @@ class GpxModel {
         // Create the feature-clone
         const clonedFeature = feature.clone();
         // Transform the geometry to WGS:84 so the gpx-interpreters will be happy.
-        clonedFeature
-          .getGeometry()
-          .transform(this.#map.getView().getProjection(), "EPSG:4326");
+        clonedFeature.getGeometry().transform(viewProjection, "EPSG:4326");
         // Finally, we can push the transformed feature to the
         // transformedFeatures-array.
         transformedFeatures.push(clonedFeature);
       }
     });
     return transformedFeatures;
-  };
-
-  // Fits the map to the extent of the features currently in the gpx-layer
-  zoomToCurrentExtent = () => {
-    // First we make sure to check whether the gpx-source has any features
-    // or not. If none exist, what would we zoom to?!
-    if (!this.#gpxSourceHasFeatures()) {
-      return;
-    }
-    // Let's also make sure that the current extent is not null.
-    if (this.#currentExtent === null) {
-      return;
-    }
-
-    // If there are features, and the extent is not null, we'll check
-    // that the current extent is finite
-    if (this.#currentExtent.map(Number.isFinite).includes(false) === false) {
-      // If it is, we can fit the map to that extent!
-      this.#fitMapToExtent(this.#currentExtent);
-    }
-  };
-
-  // Set:er allowing us to change which layer the gpx-model will interact with
-  setLayer = (layerName) => {
-    // First we must update the private field holding the current layer name
-    this.#layerName = layerName;
-    // Then we must initiate the gpx-layer. This will either get the layer
-    // corresponding to the supplied name, or create a new one.
-    this.#initiateGpxLayer();
-    // When the current layer changes, the current extent will obviously
-    // change as well.
-    this.#currentExtent = this.#gpxSource.getExtent();
-  };
-
-  // Get:er returning the name of the GPX-layer.
-  getCurrentLayerName = () => {
-    return this.#layerName;
-  };
-
-  // Get:er returning the current extent of the gpx-source.
-  getCurrentExtent = () => {
-    return this.#currentExtent;
-  };
+  }
 }
 
 export default GpxModel;

--- a/apps/client/src/models/KmlModel.js
+++ b/apps/client/src/models/KmlModel.js
@@ -1,13 +1,14 @@
-import { Vector as VectorLayer } from "ol/layer";
-import VectorSource from "ol/source/Vector";
 import KML from "ol/format/KML";
 import { Circle } from "ol/geom";
 import { fromCircle } from "ol/geom/Polygon";
-import { saveAs } from "file-saver";
 import { Circle as CircleStyle, Fill, Stroke, Style, Text } from "ol/style";
+import VectorImportModel from "./VectorImportModel";
 
 /*
- * A model supplying useful KML-functionality.
+ * A model supplying useful KML-functionality. Extends the generic
+ * VectorImportModel with a KML-specific profile, styling of imported
+ * features, and style-preserving export handling.
+ *
  * Required settings:
  * - layerName: (string): The name of the layer that should be connected to the KML-model.
  *   If it already exists a layer in the map with the same name, the model will be connected
@@ -16,213 +17,61 @@ import { Circle as CircleStyle, Fill, Stroke, Style, Text } from "ol/style";
  * Optional settings:
  * - enableDragAndDrop: (boolean): If true, drag-and-drop of .kml-files will be active.
  * - drawModel (DrawModel): If supplied, imported features will be drawn using the draw-model.
+ * - observer (Observer): Will receive "kmlModel.fileImported" when a file has been dropped.
  *
- * Exposes a couple of methods:
- * - parseFeatures(kmlString, settings): Accepts a KML-string and tries to parse it to OL-features.
- * - import(kmlString, settings): Accepts a KML-string and adds the KML-features to the layer.
- * - export(): Exports all features in the current kml-layer.
- * - removeImportedFeatures(): Removes all imported features from the kml-source.
- * - zoomToCurrentExtent(): Zooms the map to the current extent of the kml-source.
- * - setLayer(layerName): Accepts a string containing a layer name. Will set current layer.
- * - getCurrentLayerName(): Returns the name of the vectorLayer that is currently connected to the model.
- * - getCurrentExtent(): Returns the current extent of the kml-source.
+ * The complete public API is documented in VectorImportModel. On top of that,
+ * this class keeps the legacy alias importedKmlStillHasFeatures(id), and
+ * removeImportedFeatures() is inherited from the base class.
  */
-class KmlModel {
-  #map;
-  #layerName;
-  #drawModel;
-  #observer;
-  #kmlSource;
-  #kmlLayer;
-  #parser;
-  #currentExtent;
-
+class KmlModel extends VectorImportModel {
   constructor(settings) {
-    // Let's make sure that we don't allow initiation if required settings
-    // are missing.
-    if (!settings.map || !settings.layerName) {
-      return this.#handleInitiationParametersMissing();
-    }
-    // Make sure that we keep track of the supplied settings.
-    this.#map = settings.map;
-    this.#layerName = settings.layerName;
-    this.#drawModel = settings.drawModel || null;
-    this.#observer = settings.observer || null;
-    // If a setting to enable drag-and-drop has been passes, we have to initiate
-    // the listeners for that.
-    settings.enableDragAndDrop && this.#addMapDropListeners();
-    // We are gonna need a kml parser obviously.
-    this.#parser = new KML();
-    // We are going to be keeping track of the current extent of the kml-source.
-    this.#currentExtent = null;
-    // A KML-model is not really useful without a vector-layer, let's initiate it
-    // right away, either by creating a new layer, or connect to an existing layer.
-    this.#initiateKmlLayer();
+    super(settings, {
+      displayName: "KML",
+      parserFactory: () => new KML(),
+      acceptedFileTypes: ["kml", "application/vnd.google-earth.kml+xml"],
+      fileExtension: "kml",
+      importTagPropertyName: "KML_IMPORT",
+      setShowTextOnImport: true,
+      idPropertyName: "KML_ID",
+      observerSubject: "kmlModel.fileImported",
+      layerCaption: "KML model",
+      layerZIndex: 5000,
+      exportMimeType: "application/vnd.google-earth.kml+xml;charset=utf-8",
+      exportFileNamePrefix: "Ritexport",
+      exportDocSuffix: "-kml-export",
+    });
   }
 
-  // If required parameters are missing, we have to make sure we abort the
-  // initiation of the KML-model.
-  #handleInitiationParametersMissing = () => {
-    throw new Error(
-      "Failed to initiate KML-model, - required parameters missing. \n Required parameters: map, layerName"
-    );
-  };
-
-  // We have to initiate a vector layer that can be used to display the imported features.
-  #initiateKmlLayer = () => {
-    if (this.#vectorLayerExists()) {
-      return this.#connectExistingVectorLayer();
-    }
-    return this.#createNewKmlLayer();
-  };
-
-  // Adds listeners so that .kml-files can be drag-and-dropped into the map,
-  // triggering an import.
-  #addMapDropListeners = () => {
-    const mapDiv = document.getElementById("map");
-    ["drop", "dragover", "dragend", "dragleave", "dragenter"].forEach(
-      (eventName) => {
-        mapDiv.addEventListener(
-          eventName,
-          this.#preventDefaultDropBehavior,
-          false
-        );
-      }
-    );
-    // We're gonna need to add some more listeners (for dragEnter etc.).
-    mapDiv.addEventListener("drop", this.#handleDrop, false);
-  };
-
-  // Prevents the default behaviors connected to drag-and-drop.
-  #preventDefaultDropBehavior = (e) => {
-    e.stopPropagation();
-    e.preventDefault();
-  };
-
-  // Handles the event when a file has been dropped. Tries to import the file as a .kml.
-  #handleDrop = async (e) => {
-    try {
-      for await (const file of e.dataTransfer.files) {
-        const fileType = file.type ? file.type : file.name.split(".").pop();
-        // Not sure about filetype for kml... Qgis- and Hajk-generated kml:s does not contain any information about type.
-        // The application/vnd is... a guess.
-        if (
-          fileType === "kml" ||
-          fileType === "application/vnd.google-earth.kml+xml"
-        ) {
-          this.#importDroppedKml(file);
-        }
-      }
-    } catch (error) {
-      console.error(`Error importing KML-file... ${error}`);
-    }
-  };
-
-  #importDroppedKml = (file) => {
-    const reader = new FileReader();
-    // We're gonna want to set a random id on all features belonging
-    // to the current file. That way we can keep track of which features
-    // belongs to each file.
-    const id = Math.random().toString(36).slice(2, 9);
-    // Let's handle the onload-event and import the features!
-    reader.onload = () => {
-      this.import(reader.result, {
-        zoomToExtent: true,
-        setProperties: { KML_ID: id },
-      });
-      // We also want to publish an event on the observer so that we can update potential views.
-      this.#observer && this.#observer.publish("kmlModel.fileImported", { id });
-    };
-    reader.readAsText(file);
-  };
-
-  // Checks wether the layerName supplied when initiating the KML-model
-  // corresponds to an already existing vector-layer.
-  #vectorLayerExists = () => {
-    // Get all the layers from the map
-    const allMapLayers = this.#getAllMapLayers();
-    // Check wether any of the layers has the same name (type)
-    // as the supplied layerName. Also makes sure that the found
-    // layer is a vectorLayer. (We cannot add features to an imageLayer...).
-    return allMapLayers.some((layer) => {
-      return this.#layerHasCorrectNameAndType(layer);
-    });
-  };
-
-  // Returns all layers connected to the map-object supplied
-  // when initiating the model.
-  #getAllMapLayers = () => {
-    return this.#map.getLayers().getArray();
-  };
-
-  // Checks wether the name (type) of the supplied layer matches
-  // the layerName supplied when initiating the model. Also makes
-  // sure that the layer is a vectorLayer.
-  #layerHasCorrectNameAndType = (layer) => {
-    return layer.get("name") === this.#layerName && this.#isVectorLayer(layer);
-  };
-
-  // Checks wether the supplied layer is a vectorLayer or not.
-  #isVectorLayer = (layer) => {
-    return layer instanceof VectorLayer;
-  };
-
-  // Connects the private fields of the KML-model to an already existing
-  // vectorLayer.
-  #connectExistingVectorLayer = () => {
-    // Get all the layers from the map
-    const allMapLayers = this.#getAllMapLayers();
-    // Then we'll grab the layer corresponding to the supplied layerName.
-    const connectedLayer = allMapLayers.find((layer) => {
-      return this.#layerHasCorrectNameAndType(layer);
-    });
-    // Then we'll set the private fields
-    this.#kmlLayer = connectedLayer;
-    this.#kmlSource = connectedLayer.getSource();
-  };
-
-  // Creates a new vector layer that can be used to display KML-features.
-  #createNewKmlLayer = () => {
-    // Let's grab a vector-source.
-    this.#kmlSource = this.#getNewVectorSource();
-    // Let's create a layer
-    this.#kmlLayer = this.#getNewVectorLayer(this.#kmlSource);
-    // Make sure to set a unique name
-    this.#kmlLayer.set("name", this.#layerName);
-    // Then we can add the layer to the map.
-    this.#map.addLayer(this.#kmlLayer);
-  };
-
-  // Returns a new vector source.
-  #getNewVectorSource = () => {
-    return new VectorSource({ wrapX: false });
-  };
-
-  // Returns a new vector layer connected to the supplied source.
-  #getNewVectorLayer = (source) => {
-    return new VectorLayer({
-      source: source,
-      layerType: "system",
-      zIndex: 5000,
-      caption: "KML model",
-    });
-  };
-
-  // Translates the supplied feature to the map-views coordinate system.
-  #translateFeatureToViewSrs = (feature) => {
-    // Let's get the geometry-type to begin with
-    const baseGeometryType = feature?.getGeometry?.().getType?.() ?? null;
-    // If no geometry-type could be fetched from the supplied feature, we make sure
-    // to terminate to avoid errors.
-    if (baseGeometryType === null) return null;
-    // We are going to be using the view of the map when translating, let's get it
-    const mapViewProjection = this.#map.getView().getProjection();
-    // Finally we translate the feature to the view-projection.
-    feature.getGeometry().transform("EPSG:4326", mapViewProjection);
+  // Kept for backwards-compatibility with the pre-refactor public API.
+  importedKmlStillHasFeatures = (id) => {
+    return this.importedFileStillHasFeatures(id);
   };
 
   // Extracts style from the feature props or style func and applies it.
-  #setFeatureStyle = (feature) => {
+  // Called for each feature during map-injection (via the base class hook),
+  // making KML the only format where imported features get styled on import.
+  _prepareImportedFeatureForMapInjection = (feature, { viewResolution }) => {
+    this.#setFeatureStyle(feature, viewResolution);
+  };
+
+  // When a draw-model is supplied, the features are added via it, so that
+  // they can be altered by the user just like ordinary drawn features.
+  _addParsedFeaturesToTarget = (features, { drawModel, source }) => {
+    if (drawModel) {
+      drawModel.addKmlFeatures(features);
+    } else {
+      source.addFeatures(features);
+    }
+  };
+
+  // Clones the supplied features and returns new features which are transformed
+  // so that they are compatible with the .kml-format.
+  _makeExportCompatibleFeatures = (features, { viewProjection, drawModel }) => {
+    return this.#getKmlCompatibleFeatures(features, viewProjection, drawModel);
+  };
+
+  // Extracts style from the feature props or style func and applies it.
+  #setFeatureStyle = (feature, viewResolution) => {
     if (!feature) {
       console.warn(
         "Cannot apply a style on nothing. (Supplied feature is nullish)."
@@ -239,7 +88,11 @@ class KmlModel {
     // to style the feature.
     const styleFunc = feature.getStyleFunction() ?? null;
     if (styleFunc !== null) {
-      return this.#setStyleFromStyleFunction(feature, styleFunc);
+      return this.#setStyleFromStyleFunction(
+        feature,
+        styleFunc,
+        viewResolution
+      );
     }
   };
 
@@ -270,10 +123,10 @@ class KmlModel {
   };
 
   // Extracts the style from the style function and applies it.
-  #setStyleFromStyleFunction = (feature, styleFunction) => {
+  #setStyleFromStyleFunction = (feature, styleFunction, viewResolution) => {
     // Let's create the style using the style function. The views resolution
     // must be passed since the style might behave differently when resolution change.
-    const style = styleFunction(feature, this.#map.getView().getResolution());
+    const style = styleFunction(feature, viewResolution);
     // Checks if the fill is nullish, if it is, we must make sure to set _something_
     // to avoid issues when adding the feature to the map.
     if (this.#styleFillIsNullish(style)) {
@@ -404,196 +257,9 @@ class KmlModel {
     });
   };
 
-  // Prepares the supplied features for injection in the map.
-  // Includes translating and styling of the features.
-  #prepareForMapInjection = (features) => {
-    // If no features are supplied, we abort!
-    if (!features || features?.length === 0) {
-      return null;
-    }
-    // Otherwise we check if the features are to be added via the drawModel. If they are, we set
-    // the USER_DRAWN-prop to true since all features in the draw-source _can_ be altered by the user.
-    // We also have to translate every feature to the map-views coordinate system.
-    features.forEach((feature) => {
-      this.#translateFeatureToViewSrs(feature);
-      this.#setFeatureStyle(feature);
-      this.#drawModel && feature.set("USER_DRAWN", true);
-    });
-  };
-
-  #tagFeaturesAsImported = (features) => {
-    // If no features are supplied, we abort!
-    if (!features || features?.length === 0) {
-      return null;
-    }
-    // Otherwise we set the "KML_IMPORT" property to true. We also want
-    // to set the "SHOW_TEXT" to true on all features.
-    // Why? Well, kml's created from dgw:s usually contains a lot of text, and
-    // we do not want to provide the user with a possibility to turn text off.
-    features.forEach((feature) => {
-      feature.set("KML_IMPORT", true);
-      feature.set("SHOW_TEXT", true);
-    });
-  };
-
-  // Returns all features from the kml-source that are tagged
-  // as imported.
-  #getAllImportedFeatures = () => {
-    return this.#kmlSource.getFeatures().filter((feature) => {
-      return feature.get("KML_IMPORT") === true;
-    });
-  };
-
-  // Checks wether there are any features in the kml-source or not.
-  #kmlSourceHasFeatures = () => {
-    return this.#kmlSource.getFeatures().length > 0;
-  };
-
-  // Fits the map to the current extent of the kml-source (with some padding).
-  #fitMapToExtent = () => {
-    this.#map.getView().fit(this.#currentExtent, {
-      size: this.#map.getSize(),
-      padding: [20, 20, 20, 20],
-      maxZoom: 7,
-    });
-  };
-
-  // Sets the supplied properties on the supplied features
-  #setFeatureProperties = (features, properties) => {
-    for (const feature of features) {
-      feature.setProperties(properties);
-    }
-  };
-
-  // Accepts an id and checks if the current source still contains features
-  // with the supplied kml-id.
-  importedKmlStillHasFeatures = (id) => {
-    return (
-      this.#kmlSource.getFeatures().filter((f) => f.get("KML_ID") === id)
-        .length > 0
-    );
-  };
-
-  // Tries to parse features from the supplied kml-string.
-  // Accepts a kmlString and an optional second parameter stating if
-  // the features should be translated to the map-views srs or not.
-  // Returns an object on the following form:
-  // {features: <Array of ol-features>, error: <String with potential error message>}
-  // **The returned features are translated to the map-views coordinate system.**
-  parseFeatures = (kmlString, settings = { prepareForMapInjection: true }) => {
-    // The method accepts a setting-object, lets extract the settings we need.
-    // The settings includes a possibility to set prepareForMapInjection to false,
-    // (default to true), allowing for the return-object to contain the pure parsed
-    // features (not styled or translated).
-    const prepareForMapInjection = settings.prepareForMapInjection;
-    // Then we start parsing
-    try {
-      // First we must parse the string to ol-features
-      const features = this.#parser.readFeatures(kmlString) ?? [];
-      // Let's make sure to tag all imported features so that we can
-      // distinguish them from "ordinary" features.
-      this.#tagFeaturesAsImported(features);
-      // Then we must make sure to prepare all the features for
-      // map-injection. This includes translating the features to
-      // the current map-views coordinate system, and setting some style.
-      prepareForMapInjection && this.#prepareForMapInjection(features);
-      // Then we can return the features
-      return { features: features, error: null };
-    } catch (error) {
-      // If we happen to hit a mine, we make sure to return the error
-      // message and an empty array.
-      return { features: [], error: error };
-    }
-  };
-
-  // Tries to parse features from a KML-string and then add them to
-  // the kml-source.
-  // Accepts an kmlString and an optional parameter stating if the map should
-  // zoom the the imported features extent or not.
-  import = (kmlString, settings = { zoomToExtent: true }) => {
-    // Start by trying to parse the kml-string
-    const { features, error } = this.parseFeatures(kmlString);
-    // If the parsing led to any kind of error, we make sure to abort
-    // and return the error to the initiator.
-    if (error !== null) {
-      return { status: "FAILED", error: error };
-    }
-    // If "setProperties" was supplied in the settings, we have to make sure
-    // to set the supplied properties on all features.
-    settings.setProperties &&
-      this.#setFeatureProperties(features, settings.setProperties);
-    // If a draw-model has been supplied, we use that model to add the
-    // features to the map.
-    if (this.#drawModel) {
-      this.#drawModel.addKmlFeatures(features);
-    } else {
-      // Otherwise we add the parsed features directly to the kml-source.
-      this.#kmlSource.addFeatures(features);
-    }
-    // We have to make sure to update the current extent when we've added
-    // features to the kml-source.
-    this.#currentExtent = this.#kmlSource.getExtent();
-    // Then we make sure to zoom to the current extent (unless the initiator
-    // has told us not to!).
-    settings.zoomToExtent && this.zoomToCurrentExtent();
-    // Finally we return a success message to the initiator.
-    return { status: "SUCCESS", error: null };
-  };
-
-  // Tries to export all the features in the current kml-layer
-  export = () => {
-    // First we need to get all the features from the current kml-source
-    // (except for hidden features, the users might be confused if hidden features are exported).
-    const features = this.#kmlSource
-      .getFeatures()
-      .filter((f) => f.get("HIDDEN") !== true);
-    // Then we have to make sure that there were some feature there to export.
-    if (!features || features?.length === 0) {
-      return {
-        status: "FAILED",
-        error: "No features exist in the current kml-layer.",
-      };
-    }
-    // Then we'll do some transformations on the features to make sure
-    // that they are kml-compatible.
-    const compatibleFeatures = this.#getKmlCompatibleFeatures(features);
-    // Let's make sure that we have some compatible features to return,
-    // if we don't, we make sure to abort.
-    if (compatibleFeatures.length === 0) {
-      return {
-        status: "FAILED",
-        error: "Could not transform any features to the .kml standard.",
-      };
-    }
-    // If we do have compatible features, we can create the kml-xml
-    const postData = this.#parser.writeFeatures(
-      compatibleFeatures,
-      `${this.#layerName}-kml-export`
-    );
-    // Then we'll call the save-as method from file-saver, which will
-    // initiate the download-process for the user.
-    try {
-      saveAs(
-        new Blob([postData], {
-          type: "application/vnd.google-earth.kml+xml;charset=utf-8",
-        }),
-        `Ritexport - ${new Date().toLocaleString()}.kml`
-      );
-      return {
-        status: "SUCCESS",
-        error: null,
-      };
-    } catch (_error) {
-      return {
-        status: "FAILED",
-        error: "Could not save the KML-file. File-saver Error.",
-      };
-    }
-  };
-
   // Clones the supplied features and returns new features which are transformed
   // so that they are compatible with the .kml-format.
-  #getKmlCompatibleFeatures = (features) => {
+  #getKmlCompatibleFeatures = (features, viewProjection, drawModel) => {
     // Declare an array where we can push the transformed features.
     const transformedFeatures = [];
     // Looping trough all the features, creating a clone of each, this clone
@@ -608,10 +274,10 @@ class KmlModel {
       // to stringify the information, since the kml-format does not handle objects.
       // We also have to extract and stringify eventual text-settings used. (Used for
       // the text-features in the sketch-plugin to determine text-size etc.).
-      if (this.#drawModel) {
+      if (drawModel) {
         clonedFeature.set(
           "EXTRACTED_STYLE",
-          JSON.stringify(this.#drawModel.extractFeatureStyleInfo(feature))
+          JSON.stringify(drawModel.extractFeatureStyleInfo(feature))
         );
         clonedFeature.set(
           "TEXT_SETTINGS",
@@ -636,72 +302,12 @@ class KmlModel {
         clonedFeature.setGeometry(simplifiedGeometry);
       }
       // Transform the geometry to WGS:84 so the kml-interpreters will be happy.
-      clonedFeature
-        .getGeometry()
-        .transform(this.#map.getView().getProjection(), "EPSG:4326");
+      clonedFeature.getGeometry().transform(viewProjection, "EPSG:4326");
       // Finally, we can push the transformed feature to the
       // transformedFeatures-array.
       transformedFeatures.push(clonedFeature);
     });
     return transformedFeatures;
-  };
-
-  // Fits the map to the extent of the features currently in the kml-layer
-  zoomToCurrentExtent = () => {
-    // First we make sure to check wether the kml-source has any features
-    // or not. If none exist, what would we zoom to?!
-    if (!this.#kmlSourceHasFeatures()) {
-      return;
-    }
-    // Let's also make sure that the current extent is not null.
-    if (this.#currentExtent === null) {
-      return;
-    }
-    // If there are features, and the extent is not null, we'll check
-    // that the current extent is finite
-    if (this.#currentExtent.map(Number.isFinite).includes(false) === false) {
-      // If it is, we can fit the map to that extent!
-      this.#fitMapToExtent(this.#currentExtent);
-    }
-  };
-
-  // We will need a way to remove all imported features from the kml-source.
-  // Why aren't we using a simple "clear()" one might ask =>  simply because
-  // the kml-source might be the draw-source, and we don't want to remove
-  // all drawn features, only the imported ones.
-  removeImportedFeatures = () => {
-    // Let's get all the features in the kml-source that have been imported
-    const importedFeatures = this.#getAllImportedFeatures();
-    // Since OL does not supply a "removeFeatures" method, we have to map
-    // over the array, and remove every single feature one by one...
-    importedFeatures.forEach((feature) => {
-      this.#kmlSource.removeFeature(feature);
-    });
-    // When the imported features has been removed, we have to make sure
-    // to update the current extent.
-    this.#currentExtent = this.#kmlSource.getExtent();
-  };
-
-  // Set:er allowing us to change which layer the kml-model will interact with
-  setLayer = (layerName) => {
-    // First we must update the private field holding the current layer name
-    this.#layerName = layerName;
-    // Then we must initiate the kml-layer. This will either get the layer
-    // corresponding to the supplied name, or create a new one.
-    this.#initiateKmlLayer();
-    // When the current layer changes, the current extent will obviously
-    // change as well.
-    this.#currentExtent = this.#kmlSource.getExtent();
-  };
-
-  // Get:er returning the name of the KML-layer.
-  getCurrentLayerName = () => {
-    return this.#layerName;
-  };
-
-  // Get:er returning the current extent of the kml-source.
-  getCurrentExtent = () => {
-    return this.#currentExtent;
   };
 }
 export default KmlModel;

--- a/apps/client/src/models/VectorImportModel.js
+++ b/apps/client/src/models/VectorImportModel.js
@@ -1,0 +1,587 @@
+import { Vector as VectorLayer } from "ol/layer";
+import VectorSource from "ol/source/Vector";
+import { saveAs } from "file-saver";
+
+/*
+ * A base model supplying functionality for importing and exporting vector
+ * files (such as KML or GPX) to/from an OpenLayers map. It implements the
+ * entire flow: connecting to (or creating) a vector layer, drag-and-drop
+ * handling, parsing, importing, exporting, and zooming.
+ *
+ * Everything that differs between file formats is either supplied via a
+ * "profile" (a plain configuration object passed to the constructor by each
+ * subclass), or by overriding one of the @protected hooks listed below.
+ *
+ * Required settings:
+ * - layerName: (string): The name of the layer that should be connected to the model.
+ *   If there already is a layer in the map with the same name, the model will be
+ *   connected to that layer. Otherwise, a new vector-layer will be created and added.
+ * - map: (olMap): The current map-object.
+ * Optional settings:
+ * - enableDragAndDrop: (boolean): If true, drag-and-drop of supported files will be active.
+ * - drawModel (DrawModel): If supplied, imported features will be drawn using the draw-model.
+ * - observer (Observer): Will receive a publish when a file has been imported.
+ *
+ * Required profile properties:
+ * - displayName (string): Human readable name, e.g. "KML". Used in messages.
+ * - parserFactory (Function): Returns a new OL format-instance, e.g. () => new KML().
+ * - acceptedFileTypes (Array<string>): File extensions/MIME types accepted on drop.
+ * - fileExtension (string): E.g. "kml". Used for the export filename.
+ * - importTagPropertyName (string): Property set to true on all imported features.
+ * - idPropertyName (string): Property used to group features per imported file.
+ * - observerSubject (string): Subject published on the observer after a drop-import.
+ * - layerCaption (string): Caption used if a new layer has to be created.
+ * - layerZIndex (number): ZIndex used if a new layer has to be created.
+ * - exportMimeType (string): MIME type of the exported blob.
+ * - exportFileNamePrefix (string): Prefix of the export filename.
+ * - exportDocSuffix (string): Suffix passed as second argument to writeFeatures().
+ * Optional profile properties:
+ * - setShowTextOnImport (boolean): If true, "SHOW_TEXT" is set on imported features.
+ *
+ * @protected hooks (may be overridden by subclasses):
+ * - _prepareImportedFeatureForMapInjection(feature, { viewResolution }): Called
+ *   for each parsed feature after it has been translated to the map-view SRS.
+ * - _addParsedFeaturesToTarget(features, { drawModel, source }): Decides where
+ *   parsed features are added. Defaults to adding them to the source.
+ * - _makeExportCompatibleFeatures(features, { viewProjection, drawModel }):
+ *   Returns clones transformed to EPSG:4326, ready for writeFeatures().
+ *
+ * Exposed methods:
+ * - parseFeatures(fileContentsString, settings)
+ * - import(fileContentsString, settings)
+ * - export()
+ * - removeImportedFeatures()
+ * - importedFileStillHasFeatures(id)
+ * - zoomToCurrentExtent()
+ * - setLayer(layerName)
+ * - getCurrentLayerName()
+ * - getCurrentExtent()
+ */
+class VectorImportModel {
+  #map;
+  #layerName;
+  #drawModel;
+  #observer;
+  #source;
+  #layer;
+  #parser;
+  #currentExtent;
+  #profile;
+
+  constructor(settings, profile) {
+    // A missing profile property is a programming error in a subclass and
+    // should fail loudly rather than surface somewhere deep in a flow.
+    this.#assertProfileIsValid(profile);
+    // Make sure the profile is available before any potential early return
+    // below (the error-handler reads displayName from it).
+    this.#profile = Object.freeze({ ...profile });
+    // Let's make sure that we don't allow initiation if required settings
+    // are missing.
+    if (!settings.map || !settings.layerName) {
+      return this.#handleInitiationParametersMissing();
+    }
+    // Make sure that we keep track of the supplied settings.
+    this.#map = settings.map;
+    this.#layerName = settings.layerName;
+    this.#drawModel = settings.drawModel || null;
+    this.#observer = settings.observer || null;
+    // If a setting to enable drag-and-drop has been passed, we have to initiate
+    // the listeners for that.
+    settings.enableDragAndDrop && this.#addMapDropListeners();
+    // We are gonna need a parser obviously.
+    this.#parser = profile.parserFactory();
+    // We are going to be keeping track of the current extent of the source.
+    this.#currentExtent = null;
+    // The model is not really useful without a vector-layer, let's initiate it
+    // right away, either by creating a new layer, or connect to an existing one.
+    this.#initiateLayer();
+  }
+
+  // Makes sure that all required profile properties have been supplied.
+  #assertProfileIsValid = (profile) => {
+    const requiredProperties = [
+      "displayName",
+      "parserFactory",
+      "acceptedFileTypes",
+      "fileExtension",
+      "importTagPropertyName",
+      "idPropertyName",
+      "observerSubject",
+      "layerCaption",
+      "layerZIndex",
+      "exportMimeType",
+      "exportFileNamePrefix",
+      "exportDocSuffix",
+    ];
+    const missingProperties = requiredProperties.filter(
+      (property) => profile[property] === undefined
+    );
+    if (missingProperties.length > 0) {
+      throw new Error(
+        `Failed to initiate VectorImportModel - invalid profile. Missing properties: ${missingProperties.join(", ")}`
+      );
+    }
+  };
+
+  // If required parameters are missing, we have to make sure we abort the
+  // initiation of the model.
+  #handleInitiationParametersMissing = () => {
+    throw new Error(
+      `Failed to initiate ${this.#profile.displayName}-model, - required parameters missing. \n Required parameters: map, layerName`
+    );
+  };
+
+  // We have to initiate a vector layer that can be used to display the imported features.
+  #initiateLayer = () => {
+    if (this.#vectorLayerExists()) {
+      return this.#connectExistingVectorLayer();
+    }
+    return this.#createNewLayer();
+  };
+
+  // Adds listeners so that supported files can be drag-and-dropped into the map,
+  // triggering an import.
+  #addMapDropListeners = () => {
+    const mapDiv = document.getElementById("map");
+    ["drop", "dragover", "dragend", "dragleave", "dragenter"].forEach(
+      (eventName) => {
+        mapDiv.addEventListener(
+          eventName,
+          this.#preventDefaultDropBehavior,
+          false
+        );
+      }
+    );
+    // We're gonna need to add some more listeners (for dragEnter etc.).
+    mapDiv.addEventListener("drop", this.#handleDrop, false);
+  };
+
+  // Prevents the default behaviors connected to drag-and-drop.
+  #preventDefaultDropBehavior = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  // Handles the event when a file has been dropped. Tries to import the file
+  // if it is of a type accepted by the profile.
+  #handleDrop = async (e) => {
+    try {
+      for await (const file of e.dataTransfer.files) {
+        const fileType = file.type ? file.type : file.name.split(".").pop();
+        if (this.#profile.acceptedFileTypes.includes(fileType)) {
+          this.#importDroppedFile(file);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `Error importing ${this.#profile.displayName}-file... ${error}`
+      );
+    }
+  };
+
+  #importDroppedFile = (file) => {
+    const reader = new FileReader();
+    // We're gonna want to set a random id on all features belonging
+    // to the current file. That way we can keep track of which features
+    // belongs to each file.
+    const id = Math.random().toString(36).slice(2, 9);
+    // Let's handle the onload-event and import the features!
+    reader.onload = () => {
+      this.import(reader.result, {
+        zoomToExtent: true,
+        setProperties: { [this.#profile.idPropertyName]: id },
+      });
+      // We also want to publish an event on the observer so that we can update potential views.
+      this.#observer &&
+        this.#observer.publish(this.#profile.observerSubject, { id });
+    };
+    reader.readAsText(file);
+  };
+
+  // Checks wether the layerName supplied when initiating the model
+  // corresponds to an already existing vector-layer.
+  #vectorLayerExists = () => {
+    // Get all the layers from the map
+    const allMapLayers = this.#getAllMapLayers();
+    // Check wether any of the layers has the same name (type)
+    // as the supplied layerName. Also makes sure that the found
+    // layer is a vectorLayer. (We cannot add features to an imageLayer...).
+    return allMapLayers.some((layer) => {
+      return this.#layerHasCorrectNameAndType(layer);
+    });
+  };
+
+  // Returns all layers connected to the map-object supplied
+  // when initiating the model.
+  #getAllMapLayers = () => {
+    return this.#map.getLayers().getArray();
+  };
+
+  // Checks wether the name (type) of the supplied layer matches
+  // the layerName supplied when initiating the model. Also makes
+  // sure that the layer is a vectorLayer.
+  #layerHasCorrectNameAndType = (layer) => {
+    return layer.get("name") === this.#layerName && this.#isVectorLayer(layer);
+  };
+
+  // Checks wether the supplied layer is a vectorLayer or not.
+  #isVectorLayer = (layer) => {
+    return layer instanceof VectorLayer;
+  };
+
+  // Connects the private fields of the model to an already existing
+  // vectorLayer.
+  #connectExistingVectorLayer = () => {
+    // Get all the layers from the map
+    const allMapLayers = this.#getAllMapLayers();
+    // Then we'll grab the layer corresponding to the supplied layerName.
+    const connectedLayer = allMapLayers.find((layer) => {
+      return this.#layerHasCorrectNameAndType(layer);
+    });
+    // Then we'll set the private fields
+    this.#layer = connectedLayer;
+    this.#source = connectedLayer.getSource();
+  };
+
+  // Creates a new vector layer that can be used to display imported features.
+  #createNewLayer = () => {
+    // Let's grab a vector-source.
+    this.#source = this.#getNewVectorSource();
+    // Let's create a layer
+    this.#layer = this.#getNewVectorLayer(this.#source);
+    // Make sure to set a unique name
+    this.#layer.set("name", this.#layerName);
+    // Then we can add the layer to the map.
+    this.#map.addLayer(this.#layer);
+  };
+
+  // Returns a new vector source.
+  #getNewVectorSource = () => {
+    return new VectorSource({ wrapX: false });
+  };
+
+  // Returns a new vector layer connected to the supplied source.
+  #getNewVectorLayer = (source) => {
+    return new VectorLayer({
+      source: source,
+      layerType: "system",
+      zIndex: this.#profile.layerZIndex,
+      caption: this.#profile.layerCaption,
+    });
+  };
+
+  // Translates the supplied feature to the map-views coordinate system.
+  #translateFeatureToViewSrs = (feature) => {
+    // Let's get the geometry-type to begin with
+    const baseGeometryType = feature?.getGeometry?.().getType?.() ?? null;
+    // If no geometry-type could be fetched from the supplied feature, we make sure
+    // to terminate to avoid errors.
+    if (baseGeometryType === null) return null;
+    // We are going to be using the view of the map when translating, let's get it
+    const mapViewProjection = this.#map.getView().getProjection();
+    // Finally we translate the feature to the view-projection.
+    feature.getGeometry().transform("EPSG:4326", mapViewProjection);
+  };
+
+  // Prepares the supplied features for injection in the map.
+  // Includes translating and styling of the features.
+  #prepareForMapInjection = (features) => {
+    // If no features are supplied, we abort!
+    if (!features || features?.length === 0) {
+      return null;
+    }
+    // Otherwise we check if the features are to be added via the drawModel. If they are, we set
+    // the USER_DRAWN-prop to true since all features in the draw-source _can_ be altered by the user.
+    // We also have to translate every feature to the map-views coordinate system.
+    features.forEach((feature) => {
+      this.#translateFeatureToViewSrs(feature);
+      this._prepareImportedFeatureForMapInjection(feature, {
+        viewResolution: this.#map.getView().getResolution(),
+      });
+      this.#drawModel && feature.set("USER_DRAWN", true);
+    });
+  };
+
+  #tagFeaturesAsImported = (features) => {
+    // If no features are supplied, we abort!
+    if (!features || features?.length === 0) {
+      return null;
+    }
+    // Otherwise we set the import-property (from the profile) to true on all
+    // features, and, if the profile demands it, also make sure text is shown.
+    features.forEach((feature) => {
+      feature.set(this.#profile.importTagPropertyName, true);
+      this.#profile.setShowTextOnImport === true &&
+        feature.set("SHOW_TEXT", true);
+    });
+  };
+
+  // Checks wether there are any features in the source or not.
+  #sourceHasFeatures = () => {
+    return this.#source.getFeatures().length > 0;
+  };
+
+  // Fits the map to the current extent of the source (with some padding).
+  #fitMapToExtent = () => {
+    this.#map.getView().fit(this.#currentExtent, {
+      size: this.#map.getSize(),
+      padding: [20, 20, 20, 20],
+      maxZoom: 7,
+    });
+  };
+
+  // Sets the supplied properties on the supplied features
+  #setFeatureProperties = (features, properties) => {
+    for (const feature of features) {
+      feature.setProperties(properties);
+    }
+  };
+
+  // Returns all features from the source that are tagged
+  // as imported.
+  #getAllImportedFeatures = () => {
+    return this.#source.getFeatures().filter((feature) => {
+      return feature.get(this.#profile.importTagPropertyName) === true;
+    });
+  };
+
+  // Accepts an id and checks if the current source still contains features
+  // with the supplied id.
+  importedFileStillHasFeatures = (id) => {
+    return (
+      this.#source
+        .getFeatures()
+        .filter((f) => f.get(this.#profile.idPropertyName) === id).length > 0
+    );
+  };
+
+  // Tries to parse features from the supplied string.
+  // Accepts a string and an optional second parameter stating if
+  // the features should be translated to the map-views srs or not.
+  // Returns an object on the following form:
+  // {features: <Array of ol-features>, error: <String with potential error message>}
+  // **The returned features are translated to the map-views coordinate system.**
+  parseFeatures = (
+    fileContentsString,
+    settings = { prepareForMapInjection: true }
+  ) => {
+    // The method accepts a setting-object, lets extract the settings we need.
+    // The settings includes a possibility to set prepareForMapInjection to false,
+    // (default to true), allowing for the return-object to contain the pure parsed
+    // features (not styled or translated).
+    const prepareForMapInjection = settings.prepareForMapInjection;
+    // Then we start parsing
+    try {
+      // First we must parse the string to ol-features
+      const features = this.#parser.readFeatures(fileContentsString) ?? [];
+      // Let's make sure to tag all imported features so that we can
+      // distinguish them from "ordinary" features.
+      this.#tagFeaturesAsImported(features);
+      // Then we must make sure to prepare all the features for
+      // map-injection. This includes translating the features to
+      // the current map-views coordinate system, and setting some style.
+      prepareForMapInjection && this.#prepareForMapInjection(features);
+      // Then we can return the features
+      return { features: features, error: null };
+    } catch (error) {
+      // If we happen to hit a mine, we make sure to return the error
+      // message and an empty array.
+      return { features: [], error: error };
+    }
+  };
+
+  // Tries to parse features from the supplied string and then add them to
+  // the source.
+  // Accepts a string and an optional parameter stating if the map should
+  // zoom the the imported features extent or not.
+  import = (fileContentsString, settings = { zoomToExtent: true }) => {
+    // Start by trying to parse the supplied string
+    const { features, error } = this.parseFeatures(fileContentsString);
+    // If the parsing led to any kind of error, we make sure to abort
+    // and return the error to the initiator.
+    if (error !== null) {
+      return { status: "FAILED", error: error };
+    }
+    // If "setProperties" was supplied in the settings, we have to make sure
+    // to set the supplied properties on all features.
+    settings.setProperties &&
+      this.#setFeatureProperties(features, settings.setProperties);
+    // Then we add the features to their target (which might be the draw-model,
+    // depending on the format-specific hook).
+    this._addParsedFeaturesToTarget(features, {
+      drawModel: this.#drawModel,
+      source: this.#source,
+    });
+    // We have to make sure to update the current extent when we've added
+    // features to the source.
+    this.#currentExtent = this.#source.getExtent();
+    // Then we make sure to zoom to the current extent (unless the initiator
+    // has told us not to!).
+    settings.zoomToExtent && this.zoomToCurrentExtent();
+    // Finally we return a success message to the initiator.
+    return { status: "SUCCESS", error: null };
+  };
+
+  // Tries to export all the features in the current layer
+  export = () => {
+    // First we need to get all the features from the current source
+    // (except for hidden features, the users might be confused if hidden features are exported).
+    const features = this.#source
+      .getFeatures()
+      .filter((f) => f.get("HIDDEN") !== true);
+    // Then we have to make sure that there were some feature there to export.
+    if (!features || features?.length === 0) {
+      return {
+        status: "FAILED",
+        error: `No features exist in the current ${this.#profile.displayName.toLowerCase()}-layer.`,
+      };
+    }
+    // Then we'll do some transformations on the features to make sure
+    // that they are compatible with the format handled by this model.
+    const compatibleFeatures = this._makeExportCompatibleFeatures(features, {
+      viewProjection: this.#map.getView().getProjection(),
+      drawModel: this.#drawModel,
+    });
+    // Let's make sure that we have some compatible features to return,
+    // if we don't, we make sure to abort.
+    if (compatibleFeatures.length === 0) {
+      return {
+        status: "FAILED",
+        error: `Could not transform any features to the .${this.#profile.displayName.toLowerCase()} standard.`,
+      };
+    }
+    // If we do have compatible features, we can create the output
+    const postData = this.#parser.writeFeatures(
+      compatibleFeatures,
+      `${this.#layerName}${this.#profile.exportDocSuffix}`
+    );
+    // Then we'll call the save-as method from file-saver, which will
+    // initiate the download-process for the user.
+    try {
+      saveAs(
+        new Blob([postData], {
+          type: this.#profile.exportMimeType,
+        }),
+        `${this.#profile.exportFileNamePrefix} - ${new Date().toLocaleString()}.${this.#profile.fileExtension}`
+      );
+      return {
+        status: "SUCCESS",
+        error: null,
+      };
+    } catch (_error) {
+      return {
+        status: "FAILED",
+        error: `Could not save the ${this.#profile.displayName}-file. File-saver Error.`,
+      };
+    }
+  };
+
+  // We will need a way to remove all imported features from the source.
+  // Why aren't we using a simple "clear()" one might ask =>  simply because
+  // the source might be the draw-source, and we don't want to remove
+  // all drawn features, only the imported ones.
+  removeImportedFeatures = () => {
+    // Let's get all the features in the source that have been imported
+    const importedFeatures = this.#getAllImportedFeatures();
+    // Since OL does not supply a "removeFeatures" method, we have to map
+    // over the array, and remove every single feature one by one...
+    importedFeatures.forEach((feature) => {
+      this.#source.removeFeature(feature);
+    });
+    // When the imported features has been removed, we have to make sure
+    // to update the current extent.
+    this.#currentExtent = this.#source.getExtent();
+  };
+
+  // Fits the map to the extent of the features currently in the layer
+  zoomToCurrentExtent = () => {
+    // First we make sure to check wether the source has any features
+    // or not. If none exist, what would we zoom to?!
+    if (!this.#sourceHasFeatures()) {
+      return;
+    }
+    // Let's also make sure that the current extent is not null.
+    if (this.#currentExtent === null) {
+      return;
+    }
+    // If there are features, and the extent is not null, we'll check
+    // that the current extent is finite
+    if (this.#currentExtent.map(Number.isFinite).includes(false) === false) {
+      // If it is, we can fit the map to that extent!
+      this.#fitMapToExtent(this.#currentExtent);
+    }
+  };
+
+  // Set:er allowing us to change which layer the model will interact with
+  setLayer = (layerName) => {
+    // First we must update the private field holding the current layer name
+    this.#layerName = layerName;
+    // Then we must initiate the layer. This will either get the layer
+    // corresponding to the supplied name, or create a new one.
+    this.#initiateLayer();
+    // When the current layer changes, the current extent will obviously
+    // change as well.
+    this.#currentExtent = this.#source.getExtent();
+  };
+
+  // Get:er returning the name of the layer.
+  getCurrentLayerName = () => {
+    return this.#layerName;
+  };
+
+  // Get:er returning the current extent of the source.
+  getCurrentExtent = () => {
+    return this.#currentExtent;
+  };
+
+  /**
+   * Called for each parsed feature after it has been translated to the
+   * map-view SRS and before USER_DRAWN is potentially set. Subclasses that
+   * have to do format-specific preparation (e.g. apply styling) override
+   * this hook. The default implementation does nothing.
+   *
+   * @protected
+   */
+  _prepareImportedFeatureForMapInjection(_feature, _context) {
+    // Intentionally left empty, see JSDoc above.
+  }
+
+  /**
+   * Adds the parsed features to their target. The default implementation
+   * adds them directly to the source. Subclasses whose features should be
+   * routed via the draw-model override this hook.
+   *
+   * @protected
+   */
+  _addParsedFeaturesToTarget(features, context) {
+    const { source } = context;
+    source.addFeatures(features);
+  }
+
+  /**
+   * Returns clones of the supplied features, transformed to EPSG:4326, ready
+   * to be written by the OL format-writer. Subclasses needing extra handling
+   * (e.g. style extraction or geometry filtering) override this hook.
+   *
+   * @protected
+   */
+  _makeExportCompatibleFeatures(features, context) {
+    const { viewProjection } = context;
+    // Declare an array where we can push the transformed features.
+    const transformedFeatures = [];
+    // Looping trough all the features, creating a clone of each, this clone
+    // will be transformed and then pushed to the transformedFeatures-array.
+    features.forEach((feature) => {
+      // Create the feature-clone
+      const clonedFeature = feature.clone();
+      // Transform the geometry to WGS:84 so the interpreters will be happy.
+      clonedFeature.getGeometry().transform(viewProjection, "EPSG:4326");
+      // Finally, we can push the transformed feature to the
+      // transformedFeatures-array.
+      transformedFeatures.push(clonedFeature);
+    });
+    return transformedFeatures;
+  }
+}
+
+export default VectorImportModel;

--- a/apps/client/src/plugins/Anchor/Anchor.jsx
+++ b/apps/client/src/plugins/Anchor/Anchor.jsx
@@ -1,51 +1,44 @@
-import React from "react";
 import propTypes from "prop-types";
+
 import DialogWindowPlugin from "../DialogWindowPlugin";
 
 import ShareIcon from "@mui/icons-material/Share";
 
 import AnchorView from "./AnchorView";
 
-class Anchor extends React.PureComponent {
-  static propTypes = {
-    app: propTypes.object.isRequired,
-    map: propTypes.object.isRequired,
-    options: propTypes.object.isRequired,
-  };
+const Anchor = (props) => {
+  const { app, map, options } = props;
+  const title = options.title || "Dela";
 
-  constructor(props) {
-    super(props);
-    this.title = this.props.options.title || "Dela";
-  }
+  return (
+    <DialogWindowPlugin
+      options={options}
+      map={map}
+      app={app}
+      type="Anchor"
+      defaults={{
+        icon: <ShareIcon />,
+        title: title,
+        description:
+          "Skapa en länk med kartans synliga lager, aktuella zoomnivå och utbredning",
+        headerText: "Dela",
+        abortText: "Stäng",
+      }}
+    >
+      <AnchorView
+        globalObserver={app.globalObserver}
+        model={app.anchorModel}
+        options={options}
+        enableAppStateInHash={app?.config?.mapConfig?.map?.enableAppStateInHash}
+      />
+    </DialogWindowPlugin>
+  );
+};
 
-  render() {
-    return (
-      <DialogWindowPlugin
-        options={this.props.options}
-        map={this.props.map}
-        app={this.props.app}
-        type="Anchor"
-        defaults={{
-          icon: <ShareIcon />,
-          title: this.title,
-          description:
-            "Skapa en länk med kartans synliga lager, aktuella zoomnivå och utbredning",
-          headerText: "Dela",
-          abortText: "Stäng",
-          onAbort: this.onAbort,
-        }}
-      >
-        <AnchorView
-          globalObserver={this.props.app.globalObserver}
-          model={this.props.app.anchorModel}
-          options={this.props.options}
-          enableAppStateInHash={
-            this.props.app?.config?.mapConfig?.map?.enableAppStateInHash
-          }
-        />
-      </DialogWindowPlugin>
-    );
-  }
-}
+Anchor.propTypes = {
+  app: propTypes.object.isRequired,
+  map: propTypes.object.isRequired,
+  options: propTypes.object.isRequired,
+};
 
 export default Anchor;

--- a/apps/client/src/plugins/Anchor/AnchorView.jsx
+++ b/apps/client/src/plugins/Anchor/AnchorView.jsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { styled } from "@mui/material/styles";
-import withSnackbar from "components/WithSnackbar";
 import QRCode from "qrcode";
 import HajkToolTip from "components/HajkToolTip";
 import ShareIcon from "@mui/icons-material/Share";
+import { useSnackbar } from "notistack";
 
 import Alert from "@mui/material/Alert";
 
@@ -38,14 +38,6 @@ const StyledAlert = styled(Alert)(({ theme }) => ({
   },
 }));
 
-const StyledButton = styled(Button)(({ _theme }) => ({
-  minHeight: { xs: "48px", sm: "36px" },
-  height: "auto",
-  whiteSpace: { xs: "normal", sm: "nowrap" },
-  lineHeight: { xs: 1.2, sm: 1.75 },
-  textAlign: "center",
-}));
-
 // Hide icons on small screens
 const ResponsiveIcon = styled("span")(({ theme }) => ({
   display: "inline-flex",
@@ -55,211 +47,212 @@ const ResponsiveIcon = styled("span")(({ theme }) => ({
   },
 }));
 
-class AnchorView extends React.PureComponent {
-  static propTypes = {
-    closeSnackbar: PropTypes.func.isRequired,
-    enqueueSnackbar: PropTypes.func.isRequired,
-    globalObserver: PropTypes.object.isRequired,
-    model: PropTypes.object.isRequired,
-  };
+const AnchorView = (props) => {
+  const { globalObserver, model, options, enableAppStateInHash } = props;
+  const { enqueueSnackbar } = useSnackbar();
 
-  state = {
-    anchor: "",
-    cleanUrl: false,
-    qrCode: null,
-  };
+  const [anchor, setAnchor] = useState("");
+  const [cleanUrl, setCleanUrl] = useState(false);
+  const [qrCode, setQrCode] = useState(null);
 
-  async componentDidMount() {
-    // Subscribe to changes to anchor URL caused by other components. This ensure
+  // Keep a mirror of cleanUrl so the mapUpdated subscription
+  // (which is registered only once) always reads the current value.
+  // Maintained by toggleCleanUrl, do not write to it during render.
+  const cleanUrlRef = useRef(false);
+
+  // Clipboard API is only available in secure contexts.
+  const canCopyToClipboard =
+    typeof navigator.clipboard?.writeText === "function";
+
+  const appendCleanModeIfActive = useCallback(
+    (url) => (cleanUrlRef.current ? `${url}&clean` : url),
+    []
+  );
+
+  const generateQr = useCallback(
+    (url) => QRCode.toDataURL(appendCleanModeIfActive(url)),
+    [appendCleanModeIfActive]
+  );
+
+  useEffect(() => {
+    // Subscribe to changes to anchor URL caused by other components. This ensures
     // that we have a live update of the anchor whether user does anything in the map.
-    this.mapUpdatedSubscription = this.props.globalObserver.subscribe(
+    const mapUpdatedSubscription = globalObserver.subscribe(
       "core.mapUpdated",
       ({ url }) => {
-        this.generateQr(url).then((data) => {
-          this.setState({
-            anchor: this.appendCleanModeIfActive(url),
-            qrCode: data,
-          });
+        generateQr(url).then((data) => {
+          setAnchor(appendCleanModeIfActive(url));
+          setQrCode(data);
         });
       }
     );
 
     // Initiate the anchor-url on mount
-    const a = await this.props.model.getAnchor();
-    const qrData = await this.generateQr(a);
-    this.setState({
-      anchor: a,
-      qrCode: qrData,
+    model.getAnchor().then(async (a) => {
+      const qrData = await generateQr(a);
+      setAnchor(a);
+      setQrCode(qrData);
     });
-  }
 
-  componentWillUnmount() {
-    this.mapUpdatedSubscription?.unsubscribe();
-  }
+    return () => {
+      mapUpdatedSubscription?.unsubscribe();
+    };
+  }, [globalObserver, model, generateQr, appendCleanModeIfActive]);
 
-  generateQr = (url) => {
-    return QRCode.toDataURL(this.appendCleanModeIfActive(url));
+  const toggleCleanUrl = async () => {
+    const newCleanState = !cleanUrl;
+    cleanUrlRef.current = newCleanState;
+    setCleanUrl(newCleanState);
+    const newUrl = await model.getAnchor();
+    setAnchor(appendCleanModeIfActive(newUrl));
   };
 
-  appendCleanModeIfActive = (url) =>
-    this.state.cleanUrl ? (url += "&clean") : url;
-
-  toggleCleanUrl = () => {
-    const newCleanState = !this.state.cleanUrl;
-    this.setState(
-      {
-        cleanUrl: newCleanState,
-      },
-      async () => {
-        const newUrl = await this.props.model.getAnchor();
-        this.setState({ anchor: this.appendCleanModeIfActive(newUrl) });
-      }
-    );
-  };
-
-  handleClickOnCopyToClipboard = (_e) => {
-    const input = document.getElementById("anchorUrl");
-    input.select();
-    document.execCommand("copy") &&
-      this.props.enqueueSnackbar("Kopiering till urklipp lyckades!", {
+  const handleClickOnCopyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(anchor);
+      enqueueSnackbar("Kopiering till urklipp lyckades!", {
         variant: "info",
       });
+    } catch {
+      enqueueSnackbar("Kopiering till urklipp misslyckades.", {
+        variant: "warning",
+      });
+    }
   };
 
-  render() {
-    const allowCreatingCleanUrls =
-      this.props.options.allowCreatingCleanUrls ?? true;
-    const appStateInHashEnabled = this.props.enableAppStateInHash === true;
+  const allowCreatingCleanUrls = options.allowCreatingCleanUrls ?? true;
+  const appStateInHashEnabled = enableAppStateInHash === true;
 
-    return (
-      <Grid container direction="column" sx={{ maxWidth: 400 }}>
-        <Grid>
-          <StyledAlert icon={<ShareIcon />} variant="info">
-            Skapa en länk med kartans synliga lager, aktuella zoomnivå och
-            utbredning.
-          </StyledAlert>
+  return (
+    <Grid container direction="column" sx={{ maxWidth: 400 }}>
+      <Grid>
+        <StyledAlert icon={<ShareIcon />} variant="info">
+          Skapa en länk med kartans synliga lager, aktuella zoomnivå och
+          utbredning.
+        </StyledAlert>
+      </Grid>
+      {allowCreatingCleanUrls && (
+        <Grid sx={{ mb: 1.5, display: { xs: "none", sm: "block" } }}>
+          <RadioGroup
+            aria-label="copy-url"
+            name="copy-url"
+            onChange={toggleCleanUrl}
+          >
+            <FormControlLabel
+              checked={!cleanUrl}
+              value="default"
+              control={<Radio color="primary" />}
+              label="Skapa länk till karta"
+            />
+            <FormControlLabel
+              checked={cleanUrl}
+              value="clean"
+              control={<Radio color="primary" />}
+              label="Skapa länk till karta utan verktyg etc."
+            />
+          </RadioGroup>
         </Grid>
-        {allowCreatingCleanUrls && (
-          <Grid sx={{ mb: 1.5, display: { xs: "none", sm: "block" } }}>
-            <RadioGroup
-              aria-label="copy-url"
-              name="copy-url"
-              onChange={this.toggleCleanUrl}
-            >
-              <FormControlLabel
-                checked={!this.state.cleanUrl}
-                value="default"
-                control={<Radio color="primary" />}
-                label="Skapa länk till karta"
-              />
-              <FormControlLabel
-                checked={this.state.cleanUrl}
-                value="clean"
-                control={<Radio color="primary" />}
-                label="Skapa länk till karta utan verktyg etc."
-              />
-            </RadioGroup>
-          </Grid>
-        )}
-        <Grid sx={{ mb: 1, display: { xs: "none", sm: "block" } }}>
-          <StyledTextField
-            fullWidth={true}
-            id="anchorUrl"
-            slotProps={{ input: { readOnly: true } }}
-            value={this.state.anchor}
-            variant="outlined"
-            size="small"
-          />
-        </Grid>
-        {document.queryCommandSupported("copy") && (
-          <Grid sx={{ mb: 0 }}>
-            <Grid container spacing={2}>
-              <Grid size={6} sx={{ display: "flex" }}>
-                <HajkToolTip title="Kopiera länk till urklipp">
-                  <StyledButton
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    component="a"
-                    endIcon={
-                      <ResponsiveIcon>
-                        <FileCopyIcon />
-                      </ResponsiveIcon>
-                    }
-                    sx={{
-                      minHeight: { xs: "48px", sm: "36px" },
-                      height: "auto",
-                      whiteSpace: { xs: "normal", sm: "nowrap" },
-                      lineHeight: { xs: 1.2, sm: 1.75 },
-                      textAlign: "center",
-                    }}
-                    onClick={this.handleClickOnCopyToClipboard}
-                  >
-                    Kopiera länk
-                  </StyledButton>
-                </HajkToolTip>
-              </Grid>
-              <Grid size={6} sx={{ display: "flex" }}>
-                <HajkToolTip title="Öppna länk i nytt fönster">
-                  <StyledButton
-                    fullWidth
-                    variant="contained"
-                    color="primary"
-                    endIcon={
-                      <ResponsiveIcon>
-                        <OpenInNewIcon />
-                      </ResponsiveIcon>
-                    }
-                    href={this.state.anchor || null}
-                    target="_blank"
-                    sx={{
-                      minHeight: { xs: "48px", sm: "36px" },
-                      height: "auto",
-                      whiteSpace: { xs: "normal", sm: "nowrap" },
-                      lineHeight: { xs: 1.2, sm: 1.75 },
-                      textAlign: "center",
-                    }}
-                  >
-                    Öppna länk
-                  </StyledButton>
-                </HajkToolTip>
-              </Grid>
+      )}
+      <Grid sx={{ mb: 1, display: { xs: "none", sm: "block" } }}>
+        <StyledTextField
+          fullWidth={true}
+          id="anchorUrl"
+          slotProps={{ input: { readOnly: true } }}
+          value={anchor}
+          variant="outlined"
+          size="small"
+        />
+      </Grid>
+      <Grid sx={{ mb: 0 }}>
+        <Grid container spacing={2}>
+          {canCopyToClipboard && (
+            <Grid size={6} sx={{ display: "flex" }}>
+              <HajkToolTip title="Kopiera länk till urklipp">
+                <Button
+                  fullWidth
+                  variant="contained"
+                  color="primary"
+                  endIcon={
+                    <ResponsiveIcon>
+                      <FileCopyIcon />
+                    </ResponsiveIcon>
+                  }
+                  sx={{
+                    minHeight: { xs: "48px", sm: "36px" },
+                    height: "auto",
+                    whiteSpace: { xs: "normal", sm: "nowrap" },
+                    lineHeight: { xs: 1.2, sm: 1.75 },
+                    textAlign: "center",
+                  }}
+                  onClick={handleClickOnCopyToClipboard}
+                >
+                  Kopiera länk
+                </Button>
+              </HajkToolTip>
             </Grid>
-          </Grid>
-        )}
-        {appStateInHashEnabled && (
-          <Grid>
-            <Paper sx={{ p: 1, mt: 2 }}>
-              <Grid
-                container
+          )}
+          <Grid size={canCopyToClipboard ? 6 : 12} sx={{ display: "flex" }}>
+            <HajkToolTip title="Öppna länk i nytt fönster">
+              <Button
+                fullWidth
+                variant="contained"
+                color="primary"
+                endIcon={
+                  <ResponsiveIcon>
+                    <OpenInNewIcon />
+                  </ResponsiveIcon>
+                }
+                href={anchor || null}
+                target="_blank"
                 sx={{
-                  justifyContent: "center",
+                  minHeight: { xs: "48px", sm: "36px" },
+                  height: "auto",
+                  whiteSpace: { xs: "normal", sm: "nowrap" },
+                  lineHeight: { xs: 1.2, sm: 1.75 },
+                  textAlign: "center",
                 }}
               >
-                <Grid size={12}>
-                  <Box
-                    sx={{
-                      minHeight: 200,
-                      display: "flex",
-                      justifyContent: "center",
-                    }}
-                  >
-                    {this.state.qrCode && (
-                      <img
-                        src={this.state.qrCode}
-                        alt="QR-kod"
-                        style={{ minHeight: 200 }}
-                      />
-                    )}
-                  </Box>
-                </Grid>
-              </Grid>
-            </Paper>
+                Öppna länk
+              </Button>
+            </HajkToolTip>
           </Grid>
-        )}
+        </Grid>
       </Grid>
-    );
-  }
-}
+      {appStateInHashEnabled && (
+        <Grid>
+          <Paper sx={{ p: 1, mt: 2 }}>
+            <Grid
+              container
+              sx={{
+                justifyContent: "center",
+              }}
+            >
+              <Grid size={12}>
+                <Box
+                  sx={{
+                    minHeight: 200,
+                    display: "flex",
+                    justifyContent: "center",
+                  }}
+                >
+                  {qrCode && (
+                    <img src={qrCode} alt="QR-kod" style={{ minHeight: 200 }} />
+                  )}
+                </Box>
+              </Grid>
+            </Grid>
+          </Paper>
+        </Grid>
+      )}
+    </Grid>
+  );
+};
 
-export default withSnackbar(AnchorView);
+AnchorView.propTypes = {
+  enableAppStateInHash: PropTypes.bool,
+  globalObserver: PropTypes.object.isRequired,
+  model: PropTypes.object.isRequired,
+  options: PropTypes.object.isRequired,
+};
+
+export default AnchorView;


### PR DESCRIPTION
KmlModel and GpxModel unified. The near-identical import/export flows now live in a shared base class (`VectorImportModel`), with each model reduced to a format-specific profile and small overrides (KML keeps its style round-trip pipeline, GPX keeps its geometry filtering). No behavior change; all public methods preserved.