### PR TITLE
Client: Refactor Print plugin internals, no functional changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backend: Upgraded `write-excel-file` from 3.x to 4.x.
 - Backend: Enhance detailed request logger with structured output and file logging configuration [#1836](https://github.com/hajkmap/Hajk/pull/1836)
 - Backend: Bumped the [API Explorer](https://github.com/swagger-api/swagger-ui) to v5.32.6.
+- Client: Print plugin refactored — split the PrintModel "god class" into focused modules under `options/`, `layout/`, `layers/` and `utils/` (defaults, text measurement, scale bar math, element placement, tile math, image helpers). The print pipeline was decomposed into named steps, PrintLayout no longer mutates model state (explicit per-build context), and dead code was removed. No behavior change; the public `PrintModel` API consumed by TimeSlider is preserved.
 - Client: AppModel refactored — split the 1444-line class into 8 focused modules under `appModel/` (urlParamsMerger, configTranslator, backgroundLayers, clickBindings, mapFactory, layerLoader, layerVisibility, pluginManager). No behavior change; all public methods preserved. [#1826](https://github.com/hajkmap/Hajk/pull/1826)
 - Client: New Mobile UI etc, see [#1778](https://github.com/hajkmap/Hajk/issues/1778).
 - Client: New CQL filter UI, PR [#1756](https://github.com/hajkmap/Hajk/pull/1756).

--- a/apps/client/src/plugins/Print/AdvancedOptions.jsx
+++ b/apps/client/src/plugins/Print/AdvancedOptions.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Grid from "@mui/material/Grid";
 import { styled } from "@mui/material/styles";
-import withSnackbar from "components/WithSnackbar";
 import {
   Badge,
   Checkbox,
@@ -19,6 +18,7 @@ import {
 import PaletteIcon from "@mui/icons-material/Palette";
 import { TwitterPicker as ColorPicker } from "react-color";
 import HajkToolTip from "components/HajkToolTip";
+import { MAP_TEXT_AVAILABLE_COLORS } from "./constants";
 
 const Root = styled(Grid)(() => ({
   display: "flex",
@@ -35,24 +35,6 @@ class AdvancedOptions extends React.PureComponent {
   state = {
     anchorEl: null,
   };
-
-  // Default colors for color picker used to set text color (used in map title, scale, etc)
-  mapTextAvailableColors = [
-    "#FFFFFF",
-    "#D0021B",
-    "#F5A623",
-    "#F8E71C",
-    "#8B572A",
-    "#7ED321",
-    "#417505",
-    "#9013FE",
-    "#4A90E2",
-    "#50E3C2",
-    "#B8E986",
-    "#000000",
-    "#4A4A4A",
-    "#9B9B9B",
-  ];
 
   placementOverlaps = {
     northArrow: false,
@@ -446,7 +428,7 @@ class AdvancedOptions extends React.PureComponent {
                 name: "mapTextColor",
               }}
               color={mapTextColor}
-              colors={this.mapTextAvailableColors}
+              colors={MAP_TEXT_AVAILABLE_COLORS}
               onChangeComplete={this.handleMapTextColorChangeComplete}
             />
           </Popover>
@@ -456,4 +438,4 @@ class AdvancedOptions extends React.PureComponent {
   }
 }
 
-export default withSnackbar(AdvancedOptions);
+export default AdvancedOptions;

--- a/apps/client/src/plugins/Print/GeneralOptions.jsx
+++ b/apps/client/src/plugins/Print/GeneralOptions.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Grid from "@mui/material/Grid";
 import { styled } from "@mui/material/styles";
-import withSnackbar from "components/WithSnackbar";
 import {
   FormControl,
   FormHelperText,
@@ -27,27 +26,8 @@ const StyledFormControl = styled(FormControl)(({ theme }) => ({
 
 class GeneralOptions extends React.PureComponent {
   state = {
-    anchorEl: null,
     useCustomScale: false,
   };
-
-  // Default colors for color picker used to set text color (used in map title, scale, etc)
-  mapTextAvailableColors = [
-    "#FFFFFF",
-    "#D0021B",
-    "#F5A623",
-    "#F8E71C",
-    "#8B572A",
-    "#7ED321",
-    "#417505",
-    "#9013FE",
-    "#4A90E2",
-    "#50E3C2",
-    "#B8E986",
-    "#000000",
-    "#4A4A4A",
-    "#9B9B9B",
-  ];
 
   // Handles interaction with the scale-selector. We cannot let the
   // parent handler (handleChange) take care of this on its own since
@@ -291,4 +271,4 @@ class GeneralOptions extends React.PureComponent {
   }
 }
 
-export default withSnackbar(GeneralOptions);
+export default GeneralOptions;

--- a/apps/client/src/plugins/Print/Print.jsx
+++ b/apps/client/src/plugins/Print/Print.jsx
@@ -6,30 +6,11 @@ import PrintView from "./PrintView";
 import Observer from "react-event-observer";
 import PrintIcon from "@mui/icons-material/Print";
 
+import { PAPER_DIMS_MM, normalizePrintOptions } from "./options/defaults";
+
 class Print extends React.PureComponent {
   // Paper dimensions: Array[width, height]
-  dims = {
-    a0: [1189, 841],
-    a1: [841, 594],
-    a2: [594, 420],
-    a3: [420, 297],
-    a4: [297, 210],
-    a5: [210, 148],
-  };
-
-  // Default DPIs, used if none supplied in options
-  dpis = [72, 150, 300];
-
-  // Default paperFormats a0-a5, used if none supplied in options
-  paperFormats = Object.keys(this.dims);
-
-  // Default scales, used if none supplied in options
-  scales = [
-    100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 200000,
-    500000,
-  ];
-
-  scaleMeters = [20, 40, 40, 100, 200, 200, 400, 600, 2000, 4000, 10000, 20000];
+  dims = PAPER_DIMS_MM;
 
   static propTypes = {
     app: PropTypes.object.isRequired,
@@ -40,105 +21,19 @@ class Print extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    // Prepare scales from admin options, fallback to default if needed
-    const propScales = props?.options?.scales;
-    if (Array.isArray(propScales)) {
-      props.options.scales = propScales;
-    } else if (
-      typeof propScales === "string" &&
-      propScales?.split(",").length > 1
-    ) {
-      props.options.scales = propScales.replace(/\s/g, "").split(",");
-    } else {
-      props.options.scales = this.scales;
-    }
-
-    // Prepare scaleMeters from admin options, fallback to default if needed
-    const propScaleMeters = props?.options?.scaleMeters;
-    if (Array.isArray(propScaleMeters)) {
-      props.options.scaleMeters = propScaleMeters;
-    } else if (
-      typeof propScaleMeters === "string" &&
-      propScaleMeters?.split(",").length > 1
-    ) {
-      props.options.scaleMeters = propScaleMeters.replace(/\s/g, "").split(",");
-    } else {
-      props.options.scaleMeters = this.scaleMeters;
-    }
-
-    // Prepare dpis from admin options, fallback to default if needed
-    const propDpis = props?.options?.dpis;
-    if (Array.isArray(propDpis)) {
-      props.options.dpis = propDpis;
-    } else if (
-      typeof propDpis === "string" &&
-      propDpis?.split(",").length > 1
-    ) {
-      props.options.dpis = propDpis
-        .replace(/\s/g, "")
-        .split(",")
-        .map((el) => {
-          return parseInt(el);
-        });
-    } else {
-      props.options.dpis = this.dpis;
-    }
-
-    // Prepare paperFormats from admin options, fallback to default if needed
-    const propPaperFormats = props?.options?.paperFormats;
-    if (Array.isArray(propPaperFormats)) {
-      props.options.paperFormats = propPaperFormats;
-    } else if (
-      typeof propPaperFormats === "string" &&
-      propPaperFormats?.split(",").length > 1
-    ) {
-      props.options.paperFormats = propPaperFormats
-        .replace(/\s/g, "")
-        .split(",")
-        .map((el) => {
-          return el.toLowerCase();
-        });
-    } else {
-      props.options.paperFormats = this.paperFormats;
-    }
-
-    // If no valid max logo width is supplied, use a hard-coded default
-    props.options.logoMaxWidth =
-      typeof props.options?.logoMaxWidth === "number"
-        ? props.options.logoMaxWidth
-        : 40;
-
-    props.options.northArrowMaxWidth =
-      typeof props.options?.northArrowMaxWidth === "number"
-        ? props.options.northArrowMaxWidth
-        : 10;
-
-    // If no path to north-arrow image is supplied, use fallback
-    props.options.northArrow = props.options.northArrow || "/north_arrow.png";
-
-    props.options.includeImageBorder =
-      typeof props.options?.includeImageBorder === "boolean"
-        ? props.options.includeImageBorder
-        : false;
-    props.options.allowLegendsInPdfOutput =
-      typeof props.options?.allowLegendsInPdfOutput === "boolean"
-        ? props.options.allowLegendsInPdfOutput
-        : false;
-    props.options.generateLegendsByDefault =
-      typeof props.options?.generateLegendsByDefault === "boolean"
-        ? props.options.generateLegendsByDefault
-        : false;
-
-    // Ensure we have a value for the crossOrigin parameter
-    props.options.crossOrigin =
-      props.app.config.mapConfig.map?.crossOrigin || "anonymous";
+    // Normalize admin-supplied options (scales, dpis, paper formats etc),
+    // falling back to defaults where needed. Returns a new object.
+    this.options = normalizePrintOptions(
+      props.options,
+      props.app.config.mapConfig.map
+    );
 
     this.localObserver = Observer();
 
     this.printModel = new PrintModel({
       localObserver: this.localObserver,
       map: props.map,
-      options: props.options,
+      options: this.options,
       dims: this.dims,
       proxy: props.app.config.proxy,
       mapConfig: props.app.config.mapConfig.map,
@@ -171,11 +66,10 @@ class Print extends React.PureComponent {
       >
         <PrintView
           model={this.printModel}
-          options={this.props.options}
+          options={this.options}
           localObserver={this.localObserver}
-          scales={this.props.options.scales}
-          visibleAtStart={this.props.options.visibleAtStart}
-          dims={this.dims}
+          scales={this.options.scales}
+          visibleAtStart={this.options.visibleAtStart}
           enableAppStateInHash={
             this.props.app.config.mapConfig.map.enableAppStateInHash
           }

--- a/apps/client/src/plugins/Print/PrintDialog.jsx
+++ b/apps/client/src/plugins/Print/PrintDialog.jsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { createPortal } from "react-dom";
-import withSnackbar from "components/WithSnackbar";
-
 import BaseDialog from "components/Dialog/BaseDialog";
 import {
   Button,
@@ -41,4 +39,4 @@ class PrintDialog extends React.PureComponent {
   }
 }
 
-export default withSnackbar(PrintDialog);
+export default PrintDialog;

--- a/apps/client/src/plugins/Print/PrintLayout.js
+++ b/apps/client/src/plugins/Print/PrintLayout.js
@@ -14,9 +14,12 @@
  * Colors are plain { r, g, b } objects in the 0–1 normalized range.
  */
 
+import { createLayoutContext } from "./layout/context";
+
 /**
  * Build the complete layout for a print page.
- * @param {import("./PrintModel").default} model - PrintModel instance (provides helpers and configuration)
+ * @param {import("./PrintModel").default} model - PrintModel instance. Only used
+ * to create a per-build layout context; no model state is read or written after that.
  * @param {string} mapDataUrl - data URL of the rendered map canvas
  * @param {Object} options - print options
  * @param {number} pageWidth - page width in PDF points
@@ -34,12 +37,16 @@ export async function buildLayout(
   scaleResolution,
   windowUrl
 ) {
+  // Snapshot everything we need from the model into an explicit context.
+  // All layout work below operates on this context only.
+  const ctx = createLayoutContext(model);
+
   const elements = [];
   const pdfBottomRightTexts = [];
 
   // Load the bold font since the browser has not loaded it yet. We need it to be loaded before measuring it using the canvas.
   await document.fonts.load(
-    `700 ${model.textFontSize}px Roboto, roboto, sans-serif`
+    `700 ${ctx.textFontSize}px Roboto, roboto, sans-serif`
   );
 
   // 1. Map image (full page background)
@@ -53,7 +60,7 @@ export async function buildLayout(
   });
 
   // 2. Margins
-  if (model.margin > 0) {
+  if (ctx.margin > 0) {
     if (!options.useTextIconsInMargin) {
       // Single uniform margin around all edges
       elements.push({
@@ -66,7 +73,7 @@ export async function buildLayout(
           { x: 0, y: 0 },
         ],
         color: { r: 1, g: 1, b: 1 },
-        lineWidth: 5.5 * model.margin,
+        lineWidth: 5.5 * ctx.margin,
         closePath: true,
       });
     } else {
@@ -79,7 +86,7 @@ export async function buildLayout(
           { x: pageWidth, y: 0 },
         ],
         color: { r: 1, g: 1, b: 1 },
-        lineWidth: 16 * model.margin,
+        lineWidth: 16 * ctx.margin,
         closePath: false,
       });
       // Right edge
@@ -90,7 +97,7 @@ export async function buildLayout(
           { x: pageWidth, y: pageHeight },
         ],
         color: { r: 1, g: 1, b: 1 },
-        lineWidth: 5.5 * model.margin,
+        lineWidth: 5.5 * ctx.margin,
         closePath: false,
       });
       // Top edge — extra height for title/subtitle in the top margin.
@@ -101,7 +108,7 @@ export async function buildLayout(
           { x: 0, y: pageHeight },
         ],
         color: { r: 1, g: 1, b: 1 },
-        lineWidth: 20 * model.margin,
+        lineWidth: 20 * ctx.margin,
         closePath: false,
       });
       // Left edge
@@ -112,32 +119,32 @@ export async function buildLayout(
           { x: 0, y: 0 },
         ],
         color: { r: 1, g: 1, b: 1 },
-        lineWidth: 5.5 * model.margin,
+        lineWidth: 5.5 * ctx.margin,
         closePath: false,
       });
     }
   }
 
   // 3. QR Code
-  if (options.includeQrCode && model.mapConfig.enableAppStateInHash) {
+  if (options.includeQrCode && ctx.enableAppStateInHash) {
     try {
-      const qrCode = await model.generateQR(windowUrl, 20);
+      const qrCode = await ctx.generateQR(windowUrl, 20);
       let qrWidth = qrCode.width;
       let qrHeight = qrCode.height;
 
       // Same height clamping as logo/north arrow — see comment in section 4.
       if (
-        model.textIconsMargin === 0 &&
+        ctx.textIconsMargin === 0 &&
         options.qrCodePlacement.startsWith("top")
       ) {
-        const maxHeight = 5.25 * model.margin;
+        const maxHeight = 5.25 * ctx.margin;
         if (qrHeight > maxHeight) {
           qrWidth *= maxHeight / qrHeight;
           qrHeight = maxHeight;
         }
       }
 
-      const qrCodePlacement = model.getPlacement(
+      const qrCodePlacement = ctx.getPlacement(
         options.qrCodePlacement,
         qrWidth,
         qrHeight,
@@ -154,7 +161,7 @@ export async function buildLayout(
         height: qrHeight,
       });
     } catch (error) {
-      model.localObserver.publish("error-loading-image", {
+      ctx.localObserver.publish("error-loading-image", {
         error,
         type: "QR-koden",
       });
@@ -162,31 +169,31 @@ export async function buildLayout(
   }
 
   // 4. Logo
-  if (options.includeLogo && model.logoUrl.trim().length >= 5) {
+  if (options.includeLogo && ctx.logoUrl.trim().length >= 5) {
     try {
       let {
         data: logoData,
         width: logoWidth,
         height: logoHeight,
-      } = await model.getImageForPdfFromUrl(model.logoUrl, model.logoMaxWidth);
+      } = await ctx.getImageForPdfFromUrl(ctx.logoUrl, ctx.logoMaxWidth);
 
       // In margin mode (textIconsMargin === 0), the top/bottom white border has
-      // lineWidth = 16 * model.margin, so its inner edge is 8 * model.margin from
-      // the page edge. Elements are placed with their top at 2.75 * model.margin
-      // from the page top (via getPlacement), leaving only (8 - 2.75) * model.margin
+      // lineWidth = 16 * ctx.margin, so its inner edge is 8 * ctx.margin from
+      // the page edge. Elements are placed with their top at 2.75 * ctx.margin
+      // from the page top (via getPlacement), leaving only (8 - 2.75) * ctx.margin
       // pts of space before the map boundary. Clamp height to fit within that space.
       if (
-        model.textIconsMargin === 0 &&
+        ctx.textIconsMargin === 0 &&
         options.logoPlacement.startsWith("top")
       ) {
-        const maxHeight = 5.25 * model.margin;
+        const maxHeight = 5.25 * ctx.margin;
         if (logoHeight > maxHeight) {
           logoWidth *= maxHeight / logoHeight;
           logoHeight = maxHeight;
         }
       }
 
-      const logoPlacement = model.getPlacement(
+      const logoPlacement = ctx.getPlacement(
         options.logoPlacement,
         logoWidth,
         logoHeight,
@@ -202,7 +209,7 @@ export async function buildLayout(
         height: logoHeight,
       });
     } catch (error) {
-      model.localObserver.publish("error-loading-image", {
+      ctx.localObserver.publish("error-loading-image", {
         error,
         type: "Logotypbilden",
       });
@@ -210,30 +217,30 @@ export async function buildLayout(
   }
 
   // 5. North Arrow
-  if (options.includeNorthArrow && model.northArrowUrl.trim().length >= 5) {
+  if (options.includeNorthArrow && ctx.northArrowUrl.trim().length >= 5) {
     try {
       let {
         data: arrowData,
         width: arrowWidth,
         height: arrowHeight,
-      } = await model.getImageForPdfFromUrl(
-        model.northArrowUrl,
-        model.northArrowMaxWidth
+      } = await ctx.getImageForPdfFromUrl(
+        ctx.northArrowUrl,
+        ctx.northArrowMaxWidth
       );
 
       // Same height clamping as logo — see comment above.
       if (
-        model.textIconsMargin === 0 &&
+        ctx.textIconsMargin === 0 &&
         options.northArrowPlacement.startsWith("top")
       ) {
-        const maxHeight = 5.25 * model.margin;
+        const maxHeight = 5.25 * ctx.margin;
         if (arrowHeight > maxHeight) {
           arrowWidth *= maxHeight / arrowHeight;
           arrowHeight = maxHeight;
         }
       }
 
-      const arrowPlacement = model.getPlacement(
+      const arrowPlacement = ctx.getPlacement(
         options.northArrowPlacement,
         arrowWidth,
         arrowHeight,
@@ -249,7 +256,7 @@ export async function buildLayout(
         height: arrowHeight,
       });
     } catch (error) {
-      model.localObserver.publish("error-loading-image", {
+      ctx.localObserver.publish("error-loading-image", {
         error,
         type: "Norrpilen",
       });
@@ -259,7 +266,7 @@ export async function buildLayout(
   // 6. Scale bar
   if (options.includeScaleBar) {
     buildScaleBarElements(
-      model,
+      ctx,
       elements,
       { r: 0, g: 0, b: 0 },
       options.scale,
@@ -280,8 +287,8 @@ export async function buildLayout(
   let titleVerticalMargin;
   let subtitleFallbackVerticalMargin;
   if (options.useTextIconsInMargin) {
-    titleVerticalMargin = model.margin + 45;
-    subtitleFallbackVerticalMargin = model.margin + 60;
+    titleVerticalMargin = ctx.margin + 45;
+    subtitleFallbackVerticalMargin = ctx.margin + 60;
   } else if (options.useMargin) {
     titleVerticalMargin = 60;
     subtitleFallbackVerticalMargin = 70;
@@ -297,7 +304,7 @@ export async function buildLayout(
   if (options.mapTitle.trim().length > 0) {
     const titleTopY = pageHeight - titleVerticalMargin;
     const titleLineHeight = titleSize * 1.3; // Room for Å/Ä/Ö rings above each line.
-    const titleLines = model.wrapTextToLines(
+    const titleLines = ctx.wrapTextToLines(
       options.mapTitle,
       titleSize,
       maxTextWidth
@@ -306,11 +313,11 @@ export async function buildLayout(
       elements.push({
         type: "text",
         text: line,
-        x: model.getCenteredX(line, titleSize, pageWidth),
+        x: ctx.getCenteredX(line, titleSize, pageWidth),
         y: titleTopY - i * titleLineHeight,
         size: titleSize,
         fontStyle: "normal",
-        color: model.textColor,
+        color: ctx.textColor,
         maxWidth: maxTextWidth, // Avoid PDF renderer re-wrap at 200pt default.
       });
     });
@@ -323,7 +330,7 @@ export async function buildLayout(
   if (options.printComment.trim().length > 0) {
     const subtitleLineHeight = subtitleSize * 1.3;
     const subtitleTopY = titleBaselineAnchor - subtitleGap;
-    const subtitleLines = model.wrapTextToLines(
+    const subtitleLines = ctx.wrapTextToLines(
       options.printComment,
       subtitleSize,
       maxTextWidth
@@ -332,11 +339,11 @@ export async function buildLayout(
       elements.push({
         type: "text",
         text: line,
-        x: model.getCenteredX(line, subtitleSize, pageWidth),
+        x: ctx.getCenteredX(line, subtitleSize, pageWidth),
         y: subtitleTopY - i * subtitleLineHeight,
         size: subtitleSize,
         fontStyle: "normal",
-        color: model.textColor,
+        color: ctx.textColor,
         maxWidth: maxTextWidth, // Avoid PDF renderer re-wrap at 200pt default.
       });
     });
@@ -345,15 +352,15 @@ export async function buildLayout(
   // For PNG, the right-edge x margin mirrors the PDF textEdgeMargin: align with the
   // map's right boundary (2.75 * margin) plus padding when not in margin mode.
   const pngXMargin =
-    model.margin > 0 && model.textIconsMargin === 0
-      ? 2.75 * model.margin
-      : 2.75 * model.margin + 10;
+    ctx.margin > 0 && ctx.textIconsMargin === 0
+      ? 2.75 * ctx.margin
+      : 2.75 * ctx.margin + 10;
 
   // lineHeight drives the y-stacking: each successive line is one lineHeight higher.
   // Texts sit near the bottom page edge, naturally inside the white margin area.
-  const pngLineHeight = model.getTextHeight(
-    model.date || model.copyright || model.disclaimer,
-    model.textFontSize
+  const pngLineHeight = ctx.getTextHeight(
+    ctx.date || ctx.copyright || ctx.disclaimer,
+    ctx.textFontSize
   );
 
   // We have to keep track of the number of lines we are adding to the page to correctly calculate the y-position for each line.
@@ -362,120 +369,120 @@ export async function buildLayout(
   let numberOfLinesAdded = options.useTextIconsInMargin ? -1 : 0;
 
   // 9. Date text
-  if (model.date.length > 0) {
+  if (ctx.date.length > 0) {
     numberOfLinesAdded++;
-    const dateText = model.date.replace(
+    const dateText = ctx.date.replace(
       "{date}",
       new Date().toLocaleDateString()
     );
-    if (model.saveAsType === "PDF") {
+    if (ctx.saveAsType === "PDF") {
       pdfBottomRightTexts.push(dateText);
     } else {
-      const position = model.getRightAlignedPositions(
+      const position = ctx.getRightAlignedPositions(
         dateText,
-        model.textFontSize,
+        ctx.textFontSize,
         pngXMargin,
         0,
         pageWidth,
         options,
-        model.textFontWeight
+        ctx.textFontWeight
       );
       elements.push({
         type: "text",
         text: dateText,
         x: position.x,
-        y: 2.75 * model.margin + pngLineHeight * numberOfLinesAdded,
-        size: model.textFontSize,
-        fontStyle: model.textFontWeight,
-        color: model.textColor,
+        y: 2.75 * ctx.margin + pngLineHeight * numberOfLinesAdded,
+        size: ctx.textFontSize,
+        fontStyle: ctx.textFontWeight,
+        color: ctx.textColor,
       });
     }
   }
 
   // 10. Copyright text
-  if (model.copyright.length > 0) {
+  if (ctx.copyright.length > 0) {
     numberOfLinesAdded++;
-    if (model.saveAsType === "PDF") {
-      pdfBottomRightTexts.push(model.copyright);
+    if (ctx.saveAsType === "PDF") {
+      pdfBottomRightTexts.push(ctx.copyright);
     } else {
-      const position = model.getRightAlignedPositions(
-        model.copyright,
-        model.textFontSize,
+      const position = ctx.getRightAlignedPositions(
+        ctx.copyright,
+        ctx.textFontSize,
         pngXMargin,
         0,
         pageWidth,
         options,
-        model.textFontWeight
+        ctx.textFontWeight
       );
       elements.push({
         type: "text",
-        text: model.copyright,
+        text: ctx.copyright,
         x: position.x,
-        y: 2.75 * model.margin + pngLineHeight * numberOfLinesAdded,
-        size: model.textFontSize,
-        fontStyle: model.textFontWeight,
-        color: model.textColor,
+        y: 2.75 * ctx.margin + pngLineHeight * numberOfLinesAdded,
+        size: ctx.textFontSize,
+        fontStyle: ctx.textFontWeight,
+        color: ctx.textColor,
       });
     }
   }
 
   // 11. Disclaimer text
-  if (model.disclaimer.length > 0) {
-    if (model.saveAsType === "PDF") {
-      pdfBottomRightTexts.push(model.disclaimer);
+  if (ctx.disclaimer.length > 0) {
+    if (ctx.saveAsType === "PDF") {
+      pdfBottomRightTexts.push(ctx.disclaimer);
     } else {
       // The disclaimer text might contain multiple lines separated by newlines.
       // Let's add each line individually and bump the y-position for each line.
       // The reverse is used to start from the bottom of the page and work our way up.
-      const disclaimerTextLines = model.disclaimer.split("\n").reverse();
+      const disclaimerTextLines = ctx.disclaimer.split("\n").reverse();
 
       disclaimerTextLines.forEach((line) => {
         numberOfLinesAdded++;
-        const position = model.getRightAlignedPositions(
+        const position = ctx.getRightAlignedPositions(
           line,
-          model.textFontSize,
+          ctx.textFontSize,
           pngXMargin,
           0,
           pageWidth,
           options,
-          model.textFontWeight
+          ctx.textFontWeight
         );
         elements.push({
           type: "text",
           text: line,
           x: position.x,
-          y: 2.75 * model.margin + pngLineHeight * numberOfLinesAdded,
-          size: model.textFontSize,
-          fontStyle: model.textFontWeight,
-          color: model.textColor,
+          y: 2.75 * ctx.margin + pngLineHeight * numberOfLinesAdded,
+          size: ctx.textFontSize,
+          fontStyle: ctx.textFontWeight,
+          color: ctx.textColor,
         });
       });
     }
   }
 
   // If we are printing a PNG we combine the strings as one element, PNG strings is allready handled separatly.
-  if (model.saveAsType === "PDF") {
+  if (ctx.saveAsType === "PDF") {
     // Now combine Copyrigth/Disclaimer/Date to one text and align them to the right.
 
     // Value set in the text for multiline purposes when building the text in PrintLayout.
     // This is required for aligning text in libpdf, upside: we know the width, downside: text longer than 400 points will wrap.
     // Set as 400 points as approx half of a landscape a4 page.
     const maxWidthBeforeWrap = pageWidth;
-    // Align the text's right edge with the map's right boundary (2.75 * model.margin from page edge).
+    // Align the text's right edge with the map's right boundary (2.75 * ctx.margin from page edge).
     // When textIconsMargin=0 (icons in margin mode), use exactly 2.75 * margin so the text
     // right-aligns with the map edge. Otherwise add 10 pts of extra inward padding.
     const textEdgeMargin =
-      model.margin > 0 && model.textIconsMargin === 0
-        ? 2.75 * model.margin
-        : 2.75 * model.margin + 10;
-    const position = model.getRightAlignedPositions(
+      ctx.margin > 0 && ctx.textIconsMargin === 0
+        ? 2.75 * ctx.margin
+        : 2.75 * ctx.margin + 10;
+    const position = ctx.getRightAlignedPositions(
       pdfBottomRightTexts,
-      model.textFontSize,
+      ctx.textFontSize,
       textEdgeMargin,
       textEdgeMargin,
       pageWidth,
       options,
-      model.textFontWeight,
+      ctx.textFontWeight,
       maxWidthBeforeWrap
     );
 
@@ -484,9 +491,9 @@ export async function buildLayout(
       text: pdfBottomRightTexts.reverse().join("\n"),
       x: position.x,
       y: position.y,
-      size: model.textFontSize,
-      fontStyle: model.textFontWeight,
-      color: model.textColor,
+      size: ctx.textFontSize,
+      fontStyle: ctx.textFontWeight,
+      color: ctx.textColor,
       alignment: "right",
       maxWidth: maxWidthBeforeWrap,
     });
@@ -515,10 +522,10 @@ export async function buildLayout(
  * The scale bar consists of two text labels (the length text and the "Skala: 1:X..." text),
  * along with all the divider lines and optional divider numbers.
  *
- * We also have to set `model.scaleText` here since `getPlacement` relies on it when calculating
+ * We also have to set `ctx.scaleText` here since `getPlacement` relies on it when calculating
  * the position (specifically for the "bottomRight" case where the text width matters).
  *
- * @param {import("./PrintModel").default} model - PrintModel instance
+ * @param {Object} ctx - Per-build layout context.
  * @param {Array} elements - The array of layout elements
  * @param {Object} color - The color of the scale bar.
  * @param {number} scale - The current scale.
@@ -530,7 +537,7 @@ export async function buildLayout(
  * @returns {void}
  */
 function buildScaleBarElements(
-  model,
+  ctx,
   elements,
   color,
   scale,
@@ -552,7 +559,7 @@ function buildScaleBarElements(
   //    at the final value we can actually position on the page.
 
   // 1. Get the length that the scalebar should represent
-  const scaleBarLengthInMeters = model.getFittingScaleBarLength(scale);
+  const scaleBarLengthInMeters = ctx.getFittingScaleBarLength(scale);
 
   // 2. Convert those meters to inches for the scale
   const scaleBarLengthInInches = scaleBarLengthInMeters / scale / mPerInch;
@@ -563,14 +570,14 @@ function buildScaleBarElements(
   // The height of the scale bar, could be configurable later but for now it's a constant.
   const scaleBarHeight = 6;
 
-  model.scaleText = `Skala: ${model.getUserFriendlyScale(
+  ctx.scaleText = `Skala: ${ctx.getUserFriendlyScale(
     scale
   )} (vid ${format.toUpperCase()} ${
     orientation === "landscape" ? "liggande" : "stående"
   })`;
 
   // Determine the position of the scale bar on the page.
-  const scaleBarPosition = model.getPlacement(
+  const scaleBarPosition = ctx.getPlacement(
     scaleBarPlacement,
     scaleBarLengthInPoints,
     scaleBarHeight,
@@ -580,7 +587,7 @@ function buildScaleBarElements(
   );
 
   // Length text (e.g. "500 m")
-  const lengthText = model.getLengthText(scaleBarLengthInMeters);
+  const lengthText = ctx.getLengthText(scaleBarLengthInMeters);
   elements.push({
     type: "text",
     text: lengthText,
@@ -594,7 +601,7 @@ function buildScaleBarElements(
   // Scale text (e.g. "Skala: 1:5 000 (vid A4 liggande)")
   elements.push({
     type: "text",
-    text: model.scaleText,
+    text: ctx.scaleText,
     x: scaleBarPosition.x,
     y: scaleBarPosition.y + 20,
     size: 10,
@@ -606,7 +613,7 @@ function buildScaleBarElements(
   // Please note that it will mutate the `elements` array directly, just
   // as the rest of this function does.
   buildDividerLines(
-    model,
+    ctx,
     elements,
     scaleBarPosition,
     scaleBarLengthInPoints,
@@ -618,9 +625,9 @@ function buildScaleBarElements(
   // current scale is one of the admin-configured scales. Why? Because the numbers are
   // derived from that configuration, and if the scale isn't in there, the labels wouldn't
   // line up with the tick marks — which would be more confusing than having no labels at all.
-  if (model.scaleBarLengths[scale]) {
+  if (ctx.scaleBarLengths[scale]) {
     buildDividerTexts(
-      model,
+      ctx,
       elements,
       scaleBarPosition,
       scaleBarLengthInPoints,
@@ -639,7 +646,7 @@ function buildScaleBarElements(
  * Without this extra calculation, the bar would look like it was missing some lines. And
  * if we'd always add the lines, the bar would look way too crowded.
  *
- * @param {import("./PrintModel").default} model - PrintModel instance
+ * @param {Object} ctx - Per-build layout context.
  * @param {Array} elements - The array of layout elements.
  * @param {Object} scaleBarPosition - The position of the scale bar.
  * @param {number} scaleBarLength - The length of the scale bar.
@@ -648,7 +655,7 @@ function buildScaleBarElements(
  * @returns {void}
  */
 function buildDividerLines(
-  model,
+  ctx,
   elements,
   scaleBarPosition,
   scaleBarLength,
@@ -688,7 +695,7 @@ function buildDividerLines(
     thickness: 1,
   });
 
-  const { divLinesArray } = model.getDivLinesArrayAndDivider(
+  const { divLinesArray } = ctx.getDivLinesArrayAndDivider(
     scaleBarLengthMeters,
     scaleBarLength
   );
@@ -733,7 +740,7 @@ function buildDividerLines(
  * Builds the text labels for the scale bar divider lines.
  * This one is invoked from the buildScaleBarElements function.
  *
- * @param {import("./PrintModel").default} model - PrintModel instance
+ * @param {Object} ctx - Per-build layout context.
  * @param {Array} elements - The array of layout elements.
  * @param {Object} scaleBarPosition - The position of the scale bar.
  * @param {number} scaleBarLength - The length of the scale bar.
@@ -742,7 +749,7 @@ function buildDividerLines(
  * @returns {void}
  */
 function buildDividerTexts(
-  model,
+  ctx,
   elements,
   scaleBarPosition,
   scaleBarLength,
@@ -765,7 +772,7 @@ function buildDividerTexts(
       ? (scaleBarLengthMeters / 1000).toString()
       : scaleBarLengthMeters;
 
-  const { divLinesArray, divider } = model.getDivLinesArrayAndDivider(
+  const { divLinesArray, divider } = ctx.getDivLinesArrayAndDivider(
     scaleBarLengthMeters,
     scaleBarLength
   );

--- a/apps/client/src/plugins/Print/PrintModel.js
+++ b/apps/client/src/plugins/Print/PrintModel.js
@@ -16,34 +16,56 @@ import TileLayer from "ol/layer/Tile";
 import TileWMS from "ol/source/TileWMS";
 import ImageWMS from "ol/source/ImageWMS";
 
-import QRCode from "qrcode";
+import {
+  PAPER_DIMS_MM,
+  PAPER_SIZE_PT,
+  buildScaleBarLengths,
+} from "./options/defaults";
+import {
+  getTextHeight,
+  getTextWidth,
+  wrapTextToLines,
+  getCenteredX,
+  getRightAlignedPositions,
+} from "./layout/textMeasure";
+
+import {
+  getFittingScaleBarLength,
+  getLengthText,
+  getDivLinesArrayAndDivider,
+} from "./layout/scaleBarMath";
+import {
+  getBoundingBoxFromUrl,
+  loadImageTile,
+  getTileColumn,
+  getVersionThreeBoundingBox,
+  getVersionOneBoundingBox,
+  appendBoundingBox,
+  getTileInformation,
+} from "./layers/tileMath";
+import {
+  getImageDataBlobFromUrl,
+  getImageForPdfFromUrl,
+  generateQR,
+} from "./utils/images";
+import { getProxiedUrl, toUrlString } from "./utils/proxyUrl";
+import {
+  getMapScaleFromView,
+  findClosestScale,
+  calculateScaleResolution,
+  getUserFriendlyScale,
+} from "./utils/scale";
 
 import { buildLayout } from "./PrintLayout";
 import { renderToPdf } from "./PdfRenderer";
 import { renderToPng } from "./PngRenderer";
 import { buildLegendPdfPages, getLegendInfoForLayer } from "./LegendUtil";
 
-const DEFAULT_DIMS = {
-  a0: [1189, 841],
-  a1: [841, 594],
-  a2: [594, 420],
-  a3: [420, 297],
-  a4: [297, 210],
-  a5: [210, 148],
-};
-
-// Paper sizes in points assuming landscape
-const DEFAULT_PAPER_SIZE = {
-  a2: { width: 1684, height: 1190 },
-  a3: { width: 1190, height: 842 },
-  a4: { width: 842, height: 595 },
-};
-
 export default class PrintModel {
   constructor(settings) {
     this.proxy = settings.proxy;
     this.map = settings.map;
-    this.dims = settings.dims || DEFAULT_DIMS;
+    this.dims = settings.dims || PAPER_DIMS_MM;
     this.logoUrl = settings.options.logo || "";
     this.northArrowUrl = settings.options.northArrow || "";
     this.logoMaxWidth = settings.options.logoMaxWidth;
@@ -51,7 +73,7 @@ export default class PrintModel {
     this.northArrowMaxWidth = settings.options.northArrowMaxWidth;
     this.scales = settings.options.scales;
     this.scaleMeters = settings.options.scaleMeters;
-    this.scaleBarLengths = this.calculateScaleBarLengths();
+    this.scaleBarLengths = buildScaleBarLengths(this.scales, this.scaleMeters);
     this.copyright = settings.options.copyright || "";
     this.textFontSize = settings.options.textFontSize || 8;
     this.textFontWeight = settings.options.textFontWeight || "normal";
@@ -98,22 +120,6 @@ export default class PrintModel {
     });
   }
 
-  defaultScaleBarLengths = {
-    200: 10,
-    500: 50,
-    1000: 100,
-    2000: 200,
-    5000: 500,
-    10000: 1000,
-    20000: 2000,
-    50000: 5000,
-    100000: 10000,
-    200000: 20000,
-    300000: 20000,
-  };
-
-  fakeBase = "https://hajk.js.internal";
-
   previewLayer = null;
   previewFeature = null;
 
@@ -130,32 +136,7 @@ export default class PrintModel {
 
   // Gets the height in points or pixels of the combined texts in the array with newlines, or just a string.
   getTextHeight = (text, fontSize) => {
-    // If we are generating a PDF, an array of text is passed. Otherwise just a string.
-    let numberOfLines = 1;
-    if (typeof text === "object") {
-      // Let's see if our texts (disclaimer, copyright)contain newlines, and if
-      // so, ensure that they count towards the total height.
-      let lineBreaks = 0;
-      for (let i = 0; i < text.length; i++) {
-        // Count how many newlines exist in the specific text part. Bear in mind that \n
-        // is not the only possible newline, let's also count \r. \r\n is also a possibility,
-        // but since it contains both \r and \n, we will count it as two newlines, which is correct.
-        const newlineCount = (text[i].match(/\n|\r/g) || []).length;
-
-        lineBreaks = lineBreaks + newlineCount;
-      }
-      numberOfLines = text.length + lineBreaks;
-    }
-    // Estimate lineheight and calculate the height in points over number of lines.
-    const lineHeight = fontSize * 1.2;
-    const totalHeight = lineHeight * numberOfLines;
-    // Calculate points if we are creating a pdf
-    const totalHeightInPoints = totalHeight * (72 / 96);
-    // Return pixels if PNG or points if PDF
-    if (this.saveAsType === "PDF") {
-      return totalHeightInPoints;
-    }
-    return totalHeight;
+    return getTextHeight(text, fontSize, this.saveAsType);
   };
 
   getRightAlignedPositions = (
@@ -168,126 +149,53 @@ export default class PrintModel {
     fontWeight,
     maxWidth
   ) => {
-    // If we are printing a PNG we assign the maxWidth to the width of the separate text string.
-    if (this.saveAsType !== "PDF") {
-      const canvas = document.createElement("canvas");
-      const context = canvas.getContext("2d");
-      context.font = `${fontWeight === "bold" ? "700" : "400"} ${fontSize}px Roboto, roboto, sans-serif`;
-      maxWidth = context.measureText(text).width;
-    }
-    // If QrCode is placed in the bottom right corner, move text to the left of it (its wider)
-    // Otherwise its a logo or northarrow, needs less text movement.
-    // Also take care of scalebar placement bottomRight
-    let x;
-    if (options.includeQrCode && options.qrCodePlacement === "bottomRight") {
-      x = paperWidth - maxWidth - xmargin - 90;
-    } else if (
-      options.includeNorthArrow &&
-      options.northArrowPlacement === "bottomRight"
-    ) {
-      x = paperWidth - maxWidth - xmargin - this.northArrowMaxWidth * 3 - 10;
-    } else if (
-      options.includeScaleBar &&
-      options.scaleBarPlacement === "bottomRight"
-    ) {
-      // Use the scalebarMaxWidth that either is the text or the scalebar length, to align ex copyright
-      // and disclaimer/date correctly to the left of the scalebar when bottomRight
-      x = paperWidth - maxWidth - xmargin - this.scalebarMaxWidth - 10;
-    } else if (options.includeLogo && options.logoPlacement === "bottomRight") {
-      x =
-        paperWidth -
-        maxWidth -
-        xmargin -
-        this.logoMaxWidth * this.mmPerPoint -
-        10;
-    } else {
-      x = paperWidth - maxWidth - xmargin;
-    }
-    const y = this.getTextHeight(text, fontSize) + ymargin;
-    return { x, y };
-  };
-
-  getCenterAlignedPositions = (
-    text,
-    fontSize,
-    ymargin,
-    paperWidth,
-    paperHeight
-  ) => {
-    const canvas = document.createElement("canvas");
-    const context = canvas.getContext("2d");
-    context.font = `${fontSize}px Roboto, roboto, sans-serif`;
-    const textWidth = context.measureText(text).width;
-
-    const x = (paperWidth - textWidth) / 2;
-    const y = paperHeight - ymargin;
-    return { x, y };
+    return getRightAlignedPositions(
+      {
+        text,
+        fontSize,
+        xmargin,
+        ymargin,
+        paperWidth,
+        fontWeight,
+        maxWidth,
+        saveAsType: this.saveAsType,
+        northArrowMaxWidth: this.northArrowMaxWidth,
+        logoMaxWidth: this.logoMaxWidth,
+        mmPerPoint: this.mmPerPoint,
+        scalebarMaxWidth: this.scalebarMaxWidth,
+      },
+      options
+    );
   };
 
   /** Word-wrap text to maxWidth. Honours explicit newlines. */
   wrapTextToLines = (text, fontSize, maxWidth, fontWeight = "normal") => {
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    const weight = fontWeight === "bold" ? "700" : "400";
-    ctx.font = `${weight} ${fontSize}px Roboto, roboto, sans-serif`;
-
-    const measure = (str) => ctx.measureText(str).width;
-
-    const lines = [];
-    for (const segment of text.split("\n")) {
-      if (measure(segment) <= maxWidth) {
-        lines.push(segment);
-        continue;
-      }
-      const words = segment.split(" ");
-      let current = "";
-      for (const word of words) {
-        const candidate = current ? `${current} ${word}` : word;
-        if (measure(candidate) <= maxWidth) {
-          current = candidate;
-        } else {
-          if (current) lines.push(current);
-          current = word;
-        }
-      }
-      if (current) lines.push(current);
-    }
-    return lines.length ? lines : [""];
+    return wrapTextToLines(text, fontSize, maxWidth, fontWeight);
   };
 
   /** Centred x for text within paperWidth. */
   getCenteredX = (text, fontSize, paperWidth, fontWeight = "normal") => {
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    const weight = fontWeight === "bold" ? "700" : "400";
-    ctx.font = `${weight} ${fontSize}px Roboto, roboto, sans-serif`;
-    const textWidth = ctx.measureText(text).width;
-    return (paperWidth - textWidth) / 2;
+    return getCenteredX(text, fontSize, paperWidth, fontWeight);
+  };
+
+  getTextWidth = (text, size) => {
+    return getTextWidth(text, size);
+  };
+
+  /**
+   * @summary Returns a Promise which resolves if image loading succeeded.
+   * @description The Promise will contain an object with data blob of the loaded image. If loading fails, the Promise rejects
+   *
+   * @param {*} url
+   * @returns {Promise}
+   */
+  getImageDataBlobFromUrl = (url) => {
+    return getImageDataBlobFromUrl(url);
   };
 
   generateQR = async (url, qrSize) => {
-    try {
-      return {
-        data: await QRCode.toDataURL(url),
-        width: qrSize * 4,
-        height: qrSize * 4,
-      };
-    } catch (err) {
-      console.warn(err);
-      return "";
-    }
+    return generateQR(url, qrSize);
   };
-
-  calculateScaleBarLengths() {
-    if (this.scales.length === this.scaleMeters.length) {
-      return this.scales.reduce((acc, curr, index) => {
-        acc[curr] = this.scaleMeters[index];
-        return acc;
-      }, {});
-    } else {
-      return this.defaultScaleBarLengths;
-    }
-  }
 
   addPreviewLayer() {
     if (this.previewLayer) return;
@@ -312,17 +220,12 @@ export default class PrintModel {
 
   getMapScale = () => {
     // We have to make sure to get (and set on the printView) the current zoom
-    //  of the "original" view. Otherwise, the scale calculation could be wrong
+    // of the "original" view. Otherwise, the scale calculation could be wrong
     // since it depends on the static zoom of the printView.
     this.printView.setZoom(this.originalView.getZoom());
     // When this is updated, we're ready to calculate the scale, which depends on the
-    // dpi, mpu, inchPerMeter, and resolution. (TODO: (@hallbergs) Clarify these calculations).
-    const dpi = 25.4 / 0.28,
-      mpu = this.printView.getProjection().getMetersPerUnit(),
-      inchesPerMeter = 39.37,
-      res = this.printView.getResolution();
-
-    return res * mpu * inchesPerMeter * dpi;
+    // dpi, mpu, inchPerMeter, and resolution.
+    return getMapScaleFromView(this.printView);
   };
 
   getFittingScale = () => {
@@ -330,11 +233,7 @@ export default class PrintModel {
     const proposedScale = this.getMapScale();
 
     //Get the scale closest to the proposed scale.
-    return this.scales.reduce((prev, curr) => {
-      return Math.abs(curr - proposedScale) < Math.abs(prev - proposedScale)
-        ? curr
-        : prev;
-    });
+    return findClosestScale(proposedScale, this.scales);
   };
 
   removePreview = () => {
@@ -475,69 +374,14 @@ export default class PrintModel {
   };
 
   /**
-   * @summary Returns a Promise which resolves if image loading succeeded.
-   * @description The Promise will contain an object with data blob of the loaded image. If loading fails, the Promise rejects
-   *
-   * @param {*} url
-   * @returns {Promise}
-   */
-  getImageDataBlobFromUrl = (url) => {
-    return new Promise((resolve, reject) => {
-      const image = new Image();
-      image.setAttribute("crossOrigin", "anonymous"); //getting images from external domain
-
-      // We must resolve the promise even if
-      image.onerror = function (err) {
-        reject(err);
-      };
-
-      // When load succeeds
-      image.onload = function () {
-        const imgCanvas = document.createElement("canvas");
-        imgCanvas.width = this.naturalWidth;
-        imgCanvas.height = this.naturalHeight;
-
-        // Draw the image on canvas so that we can read the data blob later on
-        imgCanvas.getContext("2d").drawImage(this, 0, 0);
-
-        resolve({
-          data: imgCanvas.toDataURL("image/png"), // read data blob from canvas
-          width: imgCanvas.width, // also return dimensions so we can use them later
-          height: imgCanvas.height,
-        });
-      };
-
-      // Go, load!
-      image.src = url;
-    });
-  };
-  /**
    * @summary Helper function that takes a URL and max width and returns the ready data blob as well as width/height which fit into the specified max value.
    *
    * @param {*} url
    * @param {*} maxWidth
-   * @returns {Object} image data blob, image width, image height
+   * @returns {Promise<Object>} image data blob, image width, image height
    */
   getImageForPdfFromUrl = async (url, maxWidth) => {
-    // Use the supplied logo URL to get img data blob and dimensions
-    const {
-      data,
-      width: sourceWidth,
-      height: sourceHeight,
-    } = await this.getImageDataBlobFromUrl(url);
-
-    // We must ensure that the logo will be printed with a max width of X, while keeping the aspect ratio between width and height
-    const ratio = (maxWidth * 3) / sourceWidth;
-    const width = sourceWidth * ratio;
-    const height = sourceHeight * ratio;
-    return { data, width, height };
-  };
-
-  getTextWidth = (text, size) => {
-    const canvas = document.createElement("canvas");
-    const context = canvas.getContext("2d");
-    context.font = `${size}px roboto`;
-    return context.measureText(text).width;
+    return getImageForPdfFromUrl(url, maxWidth);
   };
 
   /**
@@ -619,70 +463,16 @@ export default class PrintModel {
    * @returns {Float} Fitting number of meters for current scale.
    */
   getFittingScaleBarLength = (scale) => {
-    const length = this.scaleBarLengths[scale];
-
-    if (length) {
-      return length;
-    } else {
-      if (scale < 250) {
-        return 5;
-      } else if (scale < 2500) {
-        return scale * 0.02;
-      } else {
-        return scale * 0.05;
-      }
-    }
+    return getFittingScaleBarLength(this.scaleBarLengths, scale);
   };
 
   //Formats the text for the scale bar
   getLengthText = (scaleBarLengthMeters) => {
-    let units = "m";
-    if (scaleBarLengthMeters > 1000) {
-      scaleBarLengthMeters /= 1000;
-      units = "km";
-    }
-    return `${Number(scaleBarLengthMeters).toLocaleString()} ${units}`;
+    return getLengthText(scaleBarLengthMeters);
   };
 
-  // Divides scaleBarLength with correct number to get divisions lines every 1, 10 or 100 m or km.
-  // Example 1: If scaleBarLengthMeters is 1000 we divide by 10 to get 10 division lines every 100 meters.
-  // Example 2: If _scaleBarLengthMeters is 500 we divide by 5 to get 5 division lines every 10 meters.
   getDivLinesArrayAndDivider = (scaleBarLengthMeters, scaleBarLength) => {
-    const scaleBarLengthMetersStr = scaleBarLengthMeters.toString();
-    // Here we get the lengthMeters first two numbers.
-    const scaleBarFirstDigits = parseInt(
-      scaleBarLengthMetersStr.substring(0, 2)
-    );
-    // We want to check if lengthMeters starts with 10 through 19 to make sure we divide correctly later.
-    const startsWithDoubleDigits =
-      scaleBarFirstDigits >= 10 && scaleBarFirstDigits <= 19;
-
-    // Here we set the scaleLength variable to the length of lengthMeters.
-    // For example, if lengthMeters is 1000 we want the scaleLength to be 10.
-    // And if lengthMeters is 500 we want the scaleLength to be 5.
-    const scaleLength = startsWithDoubleDigits
-      ? scaleBarLengthMetersStr.length - 2
-      : scaleBarLengthMetersStr.length - 1;
-
-    // Here we set the divider by dividing lengthMeters with 10 to the power of scaleLength...
-    // For example, if lengthMeters is 500 we want to divide it by 5 to get 5 division lines, each 100 meters...
-    // and if lengthMeters is 1 000 we want to divide it by 100.
-    const divider = scaleBarLengthMeters / Math.pow(10, scaleLength);
-    // Finally, we want to calculate the number of pixels between each division line on the scalebar
-    const divLinePixelsCount = scaleBarLength / divider;
-
-    // We loop through and fill the divLinesArray with the divLinePixelsCount...
-    // to get the correct division line distribution on the scalebar
-    let divLinesArray = [];
-    for (
-      let divLine = divLinePixelsCount;
-      divLine <= scaleBarLength;
-      divLine += divLinePixelsCount
-    ) {
-      divLinesArray.push(divLine);
-    }
-
-    return { divLinesArray, divider };
+    return getDivLinesArrayAndDivider(scaleBarLengthMeters, scaleBarLength);
   };
 
   // Make sure the desired resolution (depending on scale and dpi)
@@ -702,13 +492,11 @@ export default class PrintModel {
   };
 
   getScaleResolution = (scale, resolution, center) => {
-    return (
-      scale /
-      getPointResolution(
-        this.map.getView().getProjection(),
-        resolution / 25.4,
-        center
-      )
+    return calculateScaleResolution(
+      scale,
+      resolution,
+      this.map.getView().getProjection(),
+      center
     );
   };
 
@@ -815,185 +603,55 @@ export default class PrintModel {
     }
   };
 
-  // Returns an array of floats representing the bounding box found
-  // in the 'BBOX' query-parameter in the supplied url.
+  // Returns a string representing the bounding-box found in the 'BBOX'
+  // query-parameter in the supplied url.
   getBoundingBoxFromUrl = (url) => {
-    return url.searchParams
-      .get("BBOX")
-      .split(",")
-      .map((coord) => parseFloat(coord));
+    return getBoundingBoxFromUrl(url);
   };
 
   // Loads an image (tile) and draws it on the supplied canvas-context
   loadImageTile = (canvas, tileOptions) => {
-    // We have to get the context so that we can draw the image
-    const ctx = canvas.getContext("2d");
-    // Then we need some tile-information
-    const { url, x, y, tileWidth, tileHeight } = tileOptions;
-    // Let's return a promise...
-    return new Promise((resolve, reject) => {
-      // Let's create an image-element
-      const tile = document.createElement("img");
-      tile.onload = () => {
-        // When the tile has loaded, we can draw the tile on the canvas.
-        ctx.drawImage(tile, x, y, tileWidth, tileHeight);
-        // The promise can be resolved when the tile has been fetched and
-        // drawn on the canvas.
-        resolve();
-      };
-      // If the fetch fails, we have to reject the promise.
-      tile.onerror = () => {
-        reject();
-      };
-      // Let's set the cross-origin-attribute to prevent cors-problems
-      tile.crossOrigin = "anonymous";
-      // Then we'll set the url so that the image can be fetched.
-      tile.src = url;
-    });
+    return loadImageTile(canvas, tileOptions);
   };
 
   // Creates tile-information-objects for a column (all tiles needed to fill
   // up to the target-height).
   getTileColumn = (targetHeight, x, tileWidth) => {
-    // We're gonna need to store the tile-information in an array
-    const tiles = [];
-    // We'll iterate (and push tiles to the tile-array) until...
-    while (true) {
-      // ... we've reached the target-height. Let's summarize all tile-height
-      // so that we can check if we're done.
-      const accHeight = tiles.reduce((acc, curr) => acc + curr.tileHeight, 0);
-      // If we are, we can return the array of tile-information
-      if (accHeight >= targetHeight) return tiles;
-      // Otherwise we'll calculate how many pixels are left...
-      const remainingHeight = targetHeight - accHeight;
-      // And either create a tile with that height (or the max-height if the remainder is too large).
-      const tileHeight =
-        remainingHeight > this.maxTileSize ? this.maxTileSize : remainingHeight;
-      // Then we have to calculate where the tile is to be placed on the canvas later.
-      const y = targetHeight - accHeight - tileHeight;
-      // And finally we'll push the information to the array.
-      tiles.push({
-        x,
-        y,
-        tileWidth,
-        tileHeight,
-      });
-    }
+    return getTileColumn(targetHeight, x, tileWidth, this.maxTileSize);
   };
 
   // Returns a string representing the bounding-box for the supplied tile.
-  // (WMS-version 1.3.0)
-  // If the WMS-version is set to 1.3.0 the axis-orientation should be set by the
-  // definition of the projection. However, in 'ConfigMapper.js' we specify the
-  // axis-direction as 'NEU' (northing, easting, up). This means we can assume
-  // that the axis-direction is 'NEU' when dealing with version 1.3.0.
+  // (WMS-version 1.3.0, see layers/tileMath.js for details.)
   getVersionThreeBoundingBox = (tile, bBox, height, width) => {
-    // We have to know how much the northing and easting change per pixel, so that we
-    // can calculate proper bounding-boxes for the new tiles.
-    const northingChangePerPixel = (bBox[2] - bBox[0]) / height;
-    const eastingChangePerPixel = (bBox[3] - bBox[1]) / width;
-    // Then we can construct the bounding-box-string:
-    // The bounding-box is calculated by combining how much the bounding-box
-    // changes per pixel, along with the supplied tile height, width, and position
-    // (presented as pixel-values). For information regarding x, and y, see:
-    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-    return `${
-      bBox[0] + northingChangePerPixel * (height - tile.y - tile.tileHeight)
-    },${bBox[1] + eastingChangePerPixel * tile.x},${
-      bBox[0] + northingChangePerPixel * (height - tile.y)
-    }, ${bBox[1] + eastingChangePerPixel * (tile.x + tile.tileWidth)}`;
+    return getVersionThreeBoundingBox(tile, bBox, height, width);
   };
 
   // Returns a string representing the bounding-box for the supplied tile.
-  // (WMS-version 1.1.1)
-  // In version 1.1.1 the axis orientation is always 'ENU' (easting-northing-up).
+  // (WMS-version 1.1.1, see layers/tileMath.js for details.)
   getVersionOneBoundingBox = (tile, bBox, height, width) => {
-    // We have to know how much the northing and easting change per pixel, so that we
-    // can calculate proper bounding-boxes for the new tiles.
-    const northingChangePerPixel = (bBox[3] - bBox[1]) / height;
-    const eastingChangePerPixel = (bBox[2] - bBox[0]) / width;
-    // Then we can construct the bounding-box-string:
-    // The bounding-box is calculated by combining how much the bounding-box
-    // changes per pixel, along with the supplied tile height, width, and position
-    // (presented as pixel-values). For information regarding x, and y, see:
-    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-    return `${bBox[0] + eastingChangePerPixel * tile.x},${
-      bBox[1] + northingChangePerPixel * (height - tile.y - tile.tileHeight)
-    },${bBox[0] + eastingChangePerPixel * (tile.x + tile.tileWidth)},${
-      bBox[1] + northingChangePerPixel * (height - tile.y)
-    }`;
+    return getVersionOneBoundingBox(tile, bBox, height, width);
   };
 
   // Appends a bounding-box to each tile-information-object.
   appendBoundingBox = (tiles, bBox, height, width, wmsVersion) => {
-    // The bounding-box calculations might seem a bit messy... One reason for that
-    // is that the x- and y-values for the tiles are set to match how images are added
-    // to a canvas, and those coordinates go the opposite direction compared to the map-coordinate-axels.
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage for more info.
-    // Let's calculate and set the bounding-box for each tile-information-object.
-    for (const tile of tiles) {
-      // We have to make sure to check if we're dealing with version 1.3.0 or 1.1.1
-      // so that we can handle the axis-orientation properly.
-      if (wmsVersion === "1.3.0") {
-        tile.bBox = this.getVersionThreeBoundingBox(tile, bBox, height, width);
-      } else {
-        // If we're not dealing with version 1.3.0, we're probably dealing with 1.1.1
-        tile.bBox = this.getVersionOneBoundingBox(tile, bBox, height, width);
-      }
-    }
+    return appendBoundingBox(tiles, bBox, height, width, wmsVersion);
   };
 
   // Returns an URL object from the src string, prepended with proxy if any.
-  // Uses a fake base for resolving relative URL:s so we can detect this when
-  // resolving the final URL to string (and remove it).
-  // This let's us work with NodeJS URL API with relative URL:s.
   getURL = (src) => {
-    const location = (this.proxy || "") + src;
-    return new URL(location, this.fakeBase);
+    return getProxiedUrl(this.proxy, src);
   };
 
   // Returns a string with the complete URL, removing fake base if any.
   toURLString = (url) => {
-    const urlString = url.toString();
-    return urlString.replace(this.fakeBase, "");
+    return toUrlString(url);
   };
 
   // Returns an array of objects containing information regarding the tiles
-  // that should be created to comply with the supplied 'MAX_TILE_SIZE' and
-  // also 'fill' the image.
+  // that should be created to comply with the 'MAX_TILE_SIZE' and also
+  // 'fill' the image.
   getTileInformation = (height, width, url) => {
-    // We're gonna want to return an array containing the tile-objects
-    const tiles = [];
-    // We're also gonna need to keep track of the original bounding box. This bounding-box
-    // will be used to calculate the new bounding-boxes for each tile that we're about to create.
-    const bBox = this.getBoundingBoxFromUrl(url);
-    // Since the northing and easting axels are flipped in version 1.1.0 vs 1.3.0 we
-    // have to make sure to check which WMS-version we are dealing with.
-    const wmsVersion = url.searchParams.get("VERSION");
-    // To gather all the required tile-information we will work with 'columns'. This means
-    // we will create all necessary images at a fixed width, and then move to the next width.
-    // We'll do this until we've created enough columns to fill the entire width.
-    let accWidth = 0;
-    while (true) {
-      // If we've created enough columns to fill the supplied width, we can break.
-      if (accWidth >= width) break;
-      // Otherwise we'll check how many pixels remain until we do...
-      const remainingWidth = width - accWidth;
-      // We'll use a tile-width that is either:
-      // - The remaining amount of pixels
-      // - The max tile-size
-      const tileWidth =
-        remainingWidth > this.maxTileSize ? this.maxTileSize : remainingWidth;
-      // Then we'll create a column of tiles
-      tiles.push(...this.getTileColumn(height, accWidth, tileWidth));
-      // And bump the current width
-      accWidth += tileWidth;
-    }
-    // When the tile-information is created, we can append the bounding-box-information
-    // to each tile. The bounding-box-information will be used to fetch the tiles later.
-    this.appendBoundingBox(tiles, bBox, height, width, wmsVersion);
-    // Finally we can return the tile-information.
-    return tiles;
+    return getTileInformation(height, width, url, this.maxTileSize);
   };
 
   // Updates the parameters of the supplied layer to make sure we
@@ -1107,9 +765,118 @@ export default class PrintModel {
     this.addedLayers = new Set();
   };
 
+  // Renders every canvas found in OpenLayer's viewport onto a single,
+  // print-sized canvas and returns it as a PNG data URL.
+  snapshotMapCanvas = (width, height) => {
+    // Create the map canvas that will hold all of our map tiles
+    const mapCanvas = document.createElement("canvas");
+
+    // Set canvas dimensions to the newly calculated ones that take user's desired resolution etc into account
+    mapCanvas.width = width;
+    mapCanvas.height = height;
+
+    const mapContext = mapCanvas.getContext("2d");
+    const backgroundColor = this.getMapBackgroundColor(); // Make sure we use the same background-color as the map
+    mapContext.fillStyle = backgroundColor;
+    mapContext.fillRect(0, 0, width, height);
+
+    // Each canvas element inside OpenLayer's viewport should get printed
+    document.querySelectorAll(".ol-viewport canvas").forEach((canvas) => {
+      if (canvas.width > 0) {
+        const opacity = canvas.parentNode.style.opacity;
+        mapContext.globalAlpha = opacity === "" ? 1 : Number(opacity);
+        // Get the transform parameters from the style's transform matrix
+        if (canvas.style.transform) {
+          const matrix = canvas.style.transform
+            .match(/^matrix\(([^(]*)\)$/)[1]
+            .split(",")
+            .map(Number);
+          // Apply the transform to the export map context
+          CanvasRenderingContext2D.prototype.setTransform.apply(
+            mapContext,
+            matrix
+          );
+        }
+        mapContext.drawImage(canvas, 0, 0);
+      }
+    });
+
+    return mapCanvas.toDataURL("image/png");
+  };
+
+  // Returns the page size (in PDF points) for the selected format, flipped
+  // according to the selected orientation. Falls back to A4.
+  resolvePageSizeInPoints = (format, orientation) => {
+    // Assign our pagewidth and heights
+    let pageWidth = PAPER_SIZE_PT[format]?.width ?? PAPER_SIZE_PT.a4.width;
+    let pageHeight = PAPER_SIZE_PT[format]?.height ?? PAPER_SIZE_PT.a4.height;
+
+    // Flip depending on orientation
+    return {
+      pageWidth: orientation === "landscape" ? pageWidth : pageHeight,
+      pageHeight: orientation === "landscape" ? pageHeight : pageWidth,
+    };
+  };
+
+  // Renders the layout elements using the renderer matching the selected
+  // output type. For PDF, the resulting file is downloaded and null is
+  // returned; for PNG/BLOB a blob is returned.
+  saveOutput = async ({
+    elements,
+    options,
+    width,
+    height,
+    fileName,
+    legendInfosForPdf,
+    pageWidth,
+    pageHeight,
+    orientation,
+  }) => {
+    if (options.saveAsType === "PDF") {
+      // Build one or more extra pages listing the WMS legends for
+      // each visible layer, appended after the map page.
+      // Note: we intentionally don't pass `options.mapTextColorNormRgb`
+      // here – that color is chosen by the user for text overlaid on
+      // the map image (often white, so it pops on dark aerial
+      // backgrounds), which would be invisible on the plain white
+      // legend page. Let the helper's default (black) take over.
+      const legendPages = await buildLegendPdfPages(legendInfosForPdf, {
+        pageWidth,
+        pageHeight,
+        orientation,
+      });
+      const pdf = await renderToPdf(
+        elements,
+        pageWidth,
+        pageHeight,
+        orientation,
+        legendPages
+      );
+      const bytes = await pdf.save();
+      const pdfBlob = new Blob([bytes], { type: "application/pdf" });
+      const url = URL.createObjectURL(pdfBlob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${fileName}.pdf`;
+      link.click();
+      URL.revokeObjectURL(url);
+      return null;
+    } else {
+      // PNG or BLOB
+      return await renderToPng(
+        elements,
+        pageWidth,
+        pageHeight,
+        width,
+        height,
+        fileName,
+        options.saveAsType
+      );
+    }
+  };
+
   print = async (options) => {
     return new Promise((resolve, reject) => {
-      this.saveAsType = options.saveAsType;
       this.saveAsType = options.saveAsType;
       const windowUrl = window.location.href;
       const format = options.format;
@@ -1174,71 +941,11 @@ export default class PrintModel {
         // canvas PDF)
         await delay(500);
 
-        // Create the map canvas that will hold all of our map tiles
-        const mapCanvas = document.createElement("canvas");
-
-        // Set canvas dimensions to the newly calculated ones that take user's desired resolution etc into account
-        mapCanvas.width = width;
-        mapCanvas.height = height;
-
-        const mapContext = mapCanvas.getContext("2d");
-        const backgroundColor = this.getMapBackgroundColor(); // Make sure we use the same background-color as the map
-        mapContext.fillStyle = backgroundColor;
-        mapContext.fillRect(0, 0, width, height);
-
-        // Each canvas element inside OpenLayer's viewport should get printed
-        document.querySelectorAll(".ol-viewport canvas").forEach((canvas) => {
-          if (canvas.width > 0) {
-            const opacity = canvas.parentNode.style.opacity;
-            mapContext.globalAlpha = opacity === "" ? 1 : Number(opacity);
-            // Get the transform parameters from the style's transform matrix
-            if (canvas.style.transform) {
-              const matrix = canvas.style.transform
-                .match(/^matrix\(([^(]*)\)$/)[1]
-                .split(",")
-                .map(Number);
-              // Apply the transform to the export map context
-              CanvasRenderingContext2D.prototype.setTransform.apply(
-                mapContext,
-                matrix
-              );
-            }
-            mapContext.drawImage(canvas, 0, 0);
-          }
-        });
-
-        const dataUrl = mapCanvas.toDataURL("image/png");
-        let pageHeight = 0;
-        let pageWidth = 0;
-
-        // Assign our pagewidth and heights
-        switch (options.format) {
-          case "a4":
-            pageWidth = DEFAULT_PAPER_SIZE.a4.width;
-            pageHeight = DEFAULT_PAPER_SIZE.a4.height;
-            break;
-          case "a3":
-            pageWidth = DEFAULT_PAPER_SIZE.a3.width;
-            pageHeight = DEFAULT_PAPER_SIZE.a3.height;
-            break;
-          case "a2":
-            pageWidth = DEFAULT_PAPER_SIZE.a2.width;
-            pageHeight = DEFAULT_PAPER_SIZE.a2.height;
-            break;
-          default:
-            // Defult to a4
-            pageWidth = DEFAULT_PAPER_SIZE.a4.width;
-            pageHeight = DEFAULT_PAPER_SIZE.a4.height;
-        }
-
-        // Flip depending on orientation
-        const originalPageWidth = pageWidth;
-        const originalPageHeight = pageHeight;
-
-        pageWidth =
-          orientation === "landscape" ? originalPageWidth : originalPageHeight;
-        pageHeight =
-          orientation === "landscape" ? originalPageHeight : originalPageWidth;
+        const dataUrl = this.snapshotMapCanvas(width, height);
+        const { pageWidth, pageHeight } = this.resolvePageSizeInPoints(
+          format,
+          orientation
+        );
 
         try {
           // Build the shared layout (renderer-agnostic element list)
@@ -1253,48 +960,17 @@ export default class PrintModel {
           );
 
           const fileName = `Kartexport - ${new Date().toLocaleString()}`;
-          let blob = null;
-
-          if (options.saveAsType === "PDF") {
-            // Build one or more extra pages listing the WMS legends for
-            // each visible layer, appended after the map page.
-            // Note: we intentionally don't pass `options.mapTextColorNormRgb`
-            // here – that color is chosen by the user for text overlaid on
-            // the map image (often white, so it pops on dark aerial
-            // backgrounds), which would be invisible on the plain white
-            // legend page. Let the helper's default (black) take over.
-            const legendPages = await buildLegendPdfPages(legendInfosForPdf, {
-              pageWidth,
-              pageHeight,
-              orientation,
-            });
-            const pdf = await renderToPdf(
-              elements,
-              pageWidth,
-              pageHeight,
-              orientation,
-              legendPages
-            );
-            const bytes = await pdf.save();
-            const pdfBlob = new Blob([bytes], { type: "application/pdf" });
-            const url = URL.createObjectURL(pdfBlob);
-            const link = document.createElement("a");
-            link.href = url;
-            link.download = `${fileName}.pdf`;
-            link.click();
-            URL.revokeObjectURL(url);
-          } else {
-            // PNG or BLOB
-            blob = await renderToPng(
-              elements,
-              pageWidth,
-              pageHeight,
-              width,
-              height,
-              fileName,
-              options.saveAsType
-            );
-          }
+          const blob = await this.saveOutput({
+            elements,
+            options,
+            width,
+            height,
+            fileName,
+            legendInfosForPdf,
+            pageWidth,
+            pageHeight,
+            orientation,
+          });
 
           this.localObserver.publish("print-completed");
           resolve(blob);
@@ -1356,6 +1032,6 @@ export default class PrintModel {
    * @returns {string} Input parameter, prefixed by "1:" and with spaces as thousands separator, e.g "5000" -> "1:5 000".
    */
   getUserFriendlyScale = (scale) => {
-    return `1:${Number(scale).toLocaleString()}`;
+    return getUserFriendlyScale(scale);
   };
 }

--- a/apps/client/src/plugins/Print/PrintView.jsx
+++ b/apps/client/src/plugins/Print/PrintView.jsx
@@ -101,7 +101,6 @@ class PrintView extends React.PureComponent {
     super(props);
     this.model = this.props.model;
     this.localObserver = this.props.localObserver;
-    this.dims = this.props.dims;
 
     // Add the preview layer to map (it doesn't contain any features yet!)
     this.model.addPreviewLayer();

--- a/apps/client/src/plugins/Print/constants/index.js
+++ b/apps/client/src/plugins/Print/constants/index.js
@@ -1,2 +1,3 @@
 export { ROBOTO_NORMAL } from "./roboto-normal";
 export { ROBOTO_BOLD } from "./roboto-bold";
+export { MAP_TEXT_AVAILABLE_COLORS } from "./mapTextColors";

--- a/apps/client/src/plugins/Print/constants/mapTextColors.js
+++ b/apps/client/src/plugins/Print/constants/mapTextColors.js
@@ -1,0 +1,18 @@
+// Default colors for the color picker used to set text color
+// (used in map title, copyright text, scale bar text etc).
+export const MAP_TEXT_AVAILABLE_COLORS = [
+  "#FFFFFF",
+  "#D0021B",
+  "#F5A623",
+  "#F8E71C",
+  "#8B572A",
+  "#7ED321",
+  "#417505",
+  "#9013FE",
+  "#4A90E2",
+  "#50E3C2",
+  "#B8E986",
+  "#000000",
+  "#4A4A4A",
+  "#9B9B9B",
+];

--- a/apps/client/src/plugins/Print/layers/tileMath.js
+++ b/apps/client/src/plugins/Print/layers/tileMath.js
@@ -1,0 +1,192 @@
+/**
+ * WMS tile math: splitting large WMS GetMap requests into a grid of smaller
+ * tile requests that comply with the server's maximum size, and computing
+ * each tile's bounding box (for WMS versions 1.1.1 and 1.3.0).
+ *
+ * All functions are pure; state such as maxTileSize is passed explicitly.
+ */
+
+/**
+ * Returns an array of floats representing the bounding box found
+ * in the 'BBOX' query-parameter in the supplied url.
+ */
+export const getBoundingBoxFromUrl = (url) => {
+  return url.searchParams
+    .get("BBOX")
+    .split(",")
+    .map((coord) => parseFloat(coord));
+};
+
+/**
+ * Loads an image (tile) and draws it on the supplied canvas-context.
+ */
+export const loadImageTile = (canvas, tileOptions) => {
+  // We have to get the context so that we can draw the image
+  const ctx = canvas.getContext("2d");
+  // Then we need some tile-information
+  const { url, x, y, tileWidth, tileHeight } = tileOptions;
+  // Let's return a promise...
+  return new Promise((resolve, reject) => {
+    // Let's create an image-element
+    const tile = document.createElement("img");
+    tile.onload = () => {
+      // When the tile has loaded, we can draw the tile on the canvas.
+      ctx.drawImage(tile, x, y, tileWidth, tileHeight);
+      // The promise can be resolved when the tile has been fetched and
+      // drawn on the canvas.
+      resolve();
+    };
+    // If the fetch fails, we have to reject the promise.
+    tile.onerror = () => {
+      reject();
+    };
+    // Let's set the cross-origin-attribute to prevent cors-problems
+    tile.crossOrigin = "anonymous";
+    // Then we'll set the url so that the image can be fetched.
+    tile.src = url;
+  });
+};
+
+/**
+ * Creates tile-information-objects for a column (all tiles needed to fill
+ * up to the target-height).
+ */
+export const getTileColumn = (
+  targetHeight,
+  x,
+  tileWidth,
+  maxTileSize,
+  tiles = []
+) => {
+  // We'll iterate (and push tiles to the tile-array) until...
+  while (true) {
+    // ... we've reached the target-height. Let's summarize all tile-height
+    // so that we can check if we're done.
+    const accHeight = tiles.reduce((acc, curr) => acc + curr.tileHeight, 0);
+    // If we are, we can return the array of tile-information
+    if (accHeight >= targetHeight) return tiles;
+    // Otherwise we'll calculate how many pixels are left...
+    const remainingHeight = targetHeight - accHeight;
+    // And either create a tile with that height (or the max-height if the remainder is too large).
+    const tileHeight =
+      remainingHeight > maxTileSize ? maxTileSize : remainingHeight;
+    // Then we have to calculate where the tile is to be placed on the canvas later.
+    const y = targetHeight - accHeight - tileHeight;
+    // And finally we'll push the information to the array.
+    tiles.push({
+      x,
+      y,
+      tileWidth,
+      tileHeight,
+    });
+  }
+};
+
+/**
+ * Returns a string representing the bounding-box for the supplied tile.
+ * (WMS-version 1.3.0)
+ * If the WMS-version is set to 1.3.0 the axis-orientation should be set by the
+ * definition of the projection. However, in 'ConfigMapper.js' we specify the
+ * axis-direction as 'NEU' (northing, easting, up). This means we can assume
+ * that the axis-direction is 'NEU' when dealing with version 1.3.0.
+ */
+export const getVersionThreeBoundingBox = (tile, bBox, height, width) => {
+  // We have to know how much the northing and easting change per pixel, so that we
+  // can calculate proper bounding-boxes for the new tiles.
+  const northingChangePerPixel = (bBox[2] - bBox[0]) / height;
+  const eastingChangePerPixel = (bBox[3] - bBox[1]) / width;
+  // Then we can construct the bounding-box-string:
+  // The bounding-box is calculated by combining how much the bounding-box
+  // changes per pixel, along with the supplied tile height, width, and position
+  // (presented as pixel-values). For information regarding x, and y, see:
+  // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
+  return `${
+    bBox[0] + northingChangePerPixel * (height - tile.y - tile.tileHeight)
+  },${bBox[1] + eastingChangePerPixel * tile.x},${
+    bBox[0] + northingChangePerPixel * (height - tile.y)
+  }, ${bBox[1] + eastingChangePerPixel * (tile.x + tile.tileWidth)}`;
+};
+
+/**
+ * Returns a string representing the bounding-box for the supplied tile.
+ * (WMS-version 1.1.1)
+ * In version 1.1.1 the axis orientation is always 'ENU' (easting-northing-up).
+ */
+export const getVersionOneBoundingBox = (tile, bBox, height, width) => {
+  // We have to know how much the northing and easting change per pixel, so that we
+  // can calculate proper bounding-boxes for the new tiles.
+  const northingChangePerPixel = (bBox[3] - bBox[1]) / height;
+  const eastingChangePerPixel = (bBox[2] - bBox[0]) / width;
+  // Then we can construct the bounding-box-string:
+  return `${bBox[0] + eastingChangePerPixel * tile.x},${
+    bBox[1] + northingChangePerPixel * (height - tile.y - tile.tileHeight)
+  },${bBox[0] + eastingChangePerPixel * (tile.x + tile.tileWidth)},${
+    bBox[1] + northingChangePerPixel * (height - tile.y)
+  }`;
+};
+
+/**
+ * Appends a bounding-box to each tile-information-object.
+ * The bounding-box calculations might seem a bit messy... One reason for that
+ * is that the x- and y-values for the tiles are set to match how images are added
+ * to a canvas, and those coordinates go the opposite direction compared to the map-coordinate-axels.
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage for more info.
+ */
+export const appendBoundingBox = (tiles, bBox, height, width, wmsVersion) => {
+  for (const tile of tiles) {
+    // We have to make sure to check if we're dealing with version 1.3.0 or 1.1.1
+    // so that we can handle the axis-orientation properly.
+    if (wmsVersion === "1.3.0") {
+      tile.bBox = getVersionThreeBoundingBox(tile, bBox, height, width);
+    } else {
+      // If we're not dealing with version 1.3.0, we're probably dealing with 1.1.1
+      tile.bBox = getVersionOneBoundingBox(tile, bBox, height, width);
+    }
+  }
+};
+
+/**
+ * Returns an array of objects containing information regarding the tiles
+ * that should be created to comply with the supplied 'maxTileSize' and
+ * also 'fill' the image.
+ *
+ * @param {number} height Full requested image height in pixels.
+ * @param {number} width Full requested image width in pixels.
+ * @param {URL} url The original request URL (provides BBOX and VERSION).
+ * @param {number} maxTileSize Maximum allowed tile width/height in pixels.
+ * @returns {Array} Tile descriptors including their bounding boxes.
+ */
+export const getTileInformation = (height, width, url, maxTileSize) => {
+  // We're gonna want to return an array containing the tile-objects
+  const tiles = [];
+  // We're also gonna need to keep track of the original bounding box. This bounding-box
+  // will be used to calculate the new bounding-boxes for each tile that we're about to create.
+  const bBox = getBoundingBoxFromUrl(url);
+  // Since the northing and easting axels are flipped in version 1.1.0 vs 1.3.0 we
+  // have to make sure to check which WMS-version we are dealing with.
+  const wmsVersion = url.searchParams.get("VERSION");
+  // To gather all the required tile-information we will work with 'columns'. This means
+  // we will create all necessary images at a fixed width, and then move to the next width.
+  // We'll do this until we've created enough columns to fill the entire width.
+  let accWidth = 0;
+  while (true) {
+    // If we've created enough columns to fill the supplied width, we can break.
+    if (accWidth >= width) break;
+    // Otherwise we'll check how many pixels remain until we do...
+    const remainingWidth = width - accWidth;
+    // We'll use a tile-width that is either:
+    // - The remaining amount of pixels
+    // - The max tile-size
+    const tileWidth =
+      remainingWidth > maxTileSize ? maxTileSize : remainingWidth;
+    // Then we'll create a column of tiles
+    tiles.push(...getTileColumn(height, accWidth, tileWidth, maxTileSize));
+    // And bump the current width
+    accWidth += tileWidth;
+  }
+  // When the tile-information is created, we can append the bounding-box-information
+  // to each tile. The bounding-box-information will be used to fetch the tiles later.
+  appendBoundingBox(tiles, bBox, height, width, wmsVersion);
+  // Finally we can return the tile-information.
+  return tiles;
+};

--- a/apps/client/src/plugins/Print/layout/context.js
+++ b/apps/client/src/plugins/Print/layout/context.js
@@ -1,0 +1,140 @@
+import { MM_PER_POINT } from "../options/defaults";
+import {
+  getTextHeight as measureTextHeight,
+  getTextWidth,
+  wrapTextToLines,
+  getCenteredX,
+  getRightAlignedPositions as computeRightAlignedPositions,
+} from "./textMeasure";
+import {
+  getFittingScaleBarLength,
+  getLengthText,
+  getDivLinesArrayAndDivider,
+} from "./scaleBarMath";
+import { getPlacement } from "./placement";
+import { getUserFriendlyScale } from "../utils/scale";
+import { getImageForPdfFromUrl, generateQR } from "../utils/images";
+
+/**
+ * Creates an explicit, per-build layout context from a PrintModel instance.
+ *
+ * Historically, PrintLayout read and wrote mutable state directly on the
+ * model (margin, textIconsMargin, scaleText, saveAsType, textColor,
+ * scalebarMaxWidth...). This context makes that contract explicit: the
+ * layout builder works only against this plain object for the duration of a
+ * single build. Nothing on the model is mutated.
+ *
+ * The `scaleText` and `scalebarMaxWidth` fields are still mutable – but now
+ * within the scope of one layout build instead of leaking between builds.
+ */
+export const createLayoutContext = (model) => {
+  // ---- Immutable snapshot of model configuration ----
+  const ctx = {
+    margin: model.margin,
+    textIconsMargin: model.textIconsMargin,
+    saveAsType: model.saveAsType,
+    textColor: model.textColor,
+    textFontSize: model.textFontSize,
+    textFontWeight: model.textFontWeight,
+    date: model.date,
+    copyright: model.copyright,
+    disclaimer: model.disclaimer,
+    logoUrl: model.logoUrl,
+    northArrowUrl: model.northArrowUrl,
+    logoMaxWidth: model.logoMaxWidth,
+    northArrowMaxWidth: model.northArrowMaxWidth,
+    mmPerPoint: MM_PER_POINT,
+
+    // Used to gate QR code rendering and to publish image-loading warnings.
+    enableAppStateInHash: model.mapConfig?.enableAppStateInHash,
+    localObserver: model.localObserver,
+
+    // Scale-to-meters mapping, used to decide whether divider texts can be drawn.
+    scaleBarLengths: model.scaleBarLengths,
+
+    // ---- Mutable during a single layout build ----
+    scaleText: "",
+    scalebarMaxWidth: 0,
+
+    // NOTE: intentionally undefined. It is passed to canvas text measurement in
+    // placement.js; the resulting invalid font string has always made the
+    // measurement fall back to the browser's default font. Preserved as-is.
+    fontSize: undefined,
+  };
+
+  // ---- Helper functions (bound to this context) ----
+  ctx.generateQR = (url, qrSize) => generateQR(url, qrSize);
+
+  ctx.getImageForPdfFromUrl = (url, maxWidth) =>
+    getImageForPdfFromUrl(url, maxWidth);
+
+  ctx.getPlacement = (
+    placement,
+    contentWidth,
+    contentHeight,
+    pdfWidth,
+    pdfHeight,
+    contentType
+  ) =>
+    getPlacement(
+      ctx,
+      placement,
+      contentWidth,
+      contentHeight,
+      pdfWidth,
+      pdfHeight,
+      contentType
+    );
+
+  ctx.wrapTextToLines = (text, fontSize, maxWidth, fontWeight = "normal") =>
+    wrapTextToLines(text, fontSize, maxWidth, fontWeight);
+
+  ctx.getCenteredX = (text, fontSize, paperWidth, fontWeight = "normal") =>
+    getCenteredX(text, fontSize, paperWidth, fontWeight);
+
+  ctx.getTextWidth = (text, size) => getTextWidth(text, size);
+
+  ctx.getTextHeight = (text, fontSize) =>
+    measureTextHeight(text, fontSize, ctx.saveAsType);
+
+  ctx.getRightAlignedPositions = (
+    text,
+    fontSize,
+    xmargin,
+    ymargin,
+    paperWidth,
+    options,
+    fontWeight,
+    maxWidth
+  ) =>
+    computeRightAlignedPositions(
+      {
+        text,
+        fontSize,
+        xmargin,
+        ymargin,
+        paperWidth,
+        fontWeight,
+        maxWidth,
+        saveAsType: ctx.saveAsType,
+        northArrowMaxWidth: ctx.northArrowMaxWidth,
+        logoMaxWidth: ctx.logoMaxWidth,
+        mmPerPoint: ctx.mmPerPoint,
+        scalebarMaxWidth: ctx.scalebarMaxWidth,
+      },
+      options
+    );
+
+  ctx.getUserFriendlyScale = (scale) => getUserFriendlyScale(scale);
+
+  ctx.getFittingScaleBarLength = (scale) =>
+    getFittingScaleBarLength(model.scaleBarLengths, scale);
+
+  ctx.getLengthText = (scaleBarLengthMeters) =>
+    getLengthText(scaleBarLengthMeters);
+
+  ctx.getDivLinesArrayAndDivider = (scaleBarLengthMeters, scaleBarLength) =>
+    getDivLinesArrayAndDivider(scaleBarLengthMeters, scaleBarLength);
+
+  return ctx;
+};

--- a/apps/client/src/plugins/Print/layout/placement.js
+++ b/apps/client/src/plugins/Print/layout/placement.js
@@ -1,0 +1,80 @@
+import { getTextWidth } from "./textMeasure";
+
+/**
+ * Computes the x/y position for a piece of content on the page.
+ *
+ * This function used to live on PrintModel and read mutable instance state.
+ * It now operates purely on an explicit layout context (see layout/context.js).
+ *
+ * @param {Object} ctx Layout context.
+ * @param {string} placement Chosen placement on the page.
+ * @param {number} contentWidth
+ * @param {number} contentHeight
+ * @param {number} pdfWidth
+ * @param {number} pdfHeight
+ * @param {string} contentType "qrCode", "scaleBar" or undefined.
+ * @returns {Object} x-axis and y-axis placement in points.
+ */
+export const getPlacement = (
+  ctx,
+  placement,
+  contentWidth,
+  contentHeight,
+  pdfWidth,
+  pdfHeight,
+  contentType
+) => {
+  // We must take the potential margin around the map-image into account (ctx.margin)
+  // And the extra margin for textIconsMargin.
+  // And the extra extra margin for qrcode image
+  //
+  // The white border is drawn as a stroke centered on the page edge, so its visible
+  // inner width = 2.75 * ctx.margin (half of lineWidth 5.5 * margin in PrintLayout).
+  // Using 2.75 * ctx.margin as the base aligns elements with the map's edge boundary.
+  // textIconsMargin adds extra inward padding when elements should NOT be in the margin
+  // (textIconsMargin=6); it is 0 when elements intentionally go in the margin.
+  const margin = 2.75 * ctx.margin + ctx.textIconsMargin;
+  // Here we simply say if content that is going to be placed is a qr code...
+  // we need to adjust it slightly because the qr code is bigger than the other icons.
+  const qrMargin =
+    (contentType === "qrCode" && ctx.textIconsMargin) === 0 ? 3 : 0;
+
+  let pdfPlacement = { x: 0, y: 0 };
+  if (placement === "bottomLeft") {
+    pdfPlacement.x = margin;
+    pdfPlacement.y = margin - qrMargin;
+  } else if (placement === "bottomRight") {
+    if (contentType === "scaleBar") {
+      // Check if the text is longer than the scalebar to get the one with most width.
+      // NOTE: ctx.fontSize is intentionally left undefined by the context – the
+      // resulting invalid canvas font string makes measureText fall back to the
+      // browser default font. This has always been the behavior; preserve it.
+      const textLength = getTextWidth(ctx.scaleText, ctx.fontSize);
+      // If the contentWidth aka the scalebar and not the text, add some extra padding.
+      ctx.scalebarMaxWidth =
+        contentWidth > ctx.scalebarMaxWidth ? contentWidth + 25 : textLength;
+      pdfPlacement.x = pdfWidth - margin - ctx.scalebarMaxWidth;
+      pdfPlacement.y = margin;
+    } else {
+      pdfPlacement.x = pdfWidth - contentWidth - margin;
+      pdfPlacement.y = margin - qrMargin + 10;
+    }
+  } else if (placement === "topRight") {
+    if (contentType === "scaleBar") {
+      // Check if the text is longer than the scalebar to get the one with most width.
+      const scaleTextWidth = getTextWidth(ctx.scaleText, ctx.fontSize);
+      // If the contentWidth aka the scalebar and not the text, add some extra padding.
+      const scalebarMaxWidth =
+        contentWidth > scaleTextWidth ? contentWidth + 25 : scaleTextWidth;
+      pdfPlacement.x = pdfWidth - margin - scalebarMaxWidth;
+      pdfPlacement.y = pdfHeight - contentHeight - margin - 20;
+    } else {
+      pdfPlacement.x = pdfWidth - contentWidth - margin;
+      pdfPlacement.y = pdfHeight - contentHeight - margin + qrMargin;
+    }
+  } else {
+    pdfPlacement.x = margin;
+    pdfPlacement.y = pdfHeight - contentHeight - margin + qrMargin;
+  }
+  return pdfPlacement;
+};

--- a/apps/client/src/plugins/Print/layout/scaleBarMath.js
+++ b/apps/client/src/plugins/Print/layout/scaleBarMath.js
@@ -1,0 +1,93 @@
+/**
+ * Pure math helpers for the scale bar.
+ */
+
+/**
+ * Returns a fitting scale bar length (in meters) for the supplied scale,
+ * given a mapping of scale => meters. Falls back to a proportional estimate
+ * when the scale has no mapped value.
+ *
+ * @param {Object} scaleBarLengths Map from scale to length in meters.
+ * @param {number} scale
+ * @returns {number} Length in meters.
+ */
+export const getFittingScaleBarLength = (scaleBarLengths, scale) => {
+  const length = scaleBarLengths[scale];
+
+  if (length) {
+    return length;
+  } else {
+    if (scale < 250) {
+      return 5;
+    } else if (scale < 2500) {
+      return scale * 0.02;
+    } else {
+      return scale * 0.05;
+    }
+  }
+};
+
+/**
+ * Formats the text for the scale bar, switching between meters and kilometers.
+ * Note: exactly 1000 m is still rendered in meters (strict > comparison).
+ *
+ * @param {number} scaleBarLengthMeters
+ * @returns {string}
+ */
+export const getLengthText = (scaleBarLengthMeters) => {
+  let units = "m";
+  if (scaleBarLengthMeters > 1000) {
+    scaleBarLengthMeters /= 1000;
+    units = "km";
+  }
+  return `${Number(scaleBarLengthMeters).toLocaleString()} ${units}`;
+};
+
+/**
+ * Divides the scale bar length with the correct number to get division lines
+ * every 1, 10 or 100 m or km.
+ * Example 1: If scaleBarLengthMeters is 1000 we divide by 10 to get 10 division lines every 100 meters.
+ * Example 2: If scaleBarLengthMeters is 500 we divide by 5 to get 5 division lines every 10 meters.
+ *
+ * @param {number} scaleBarLengthMeters
+ * @param {number} scaleBarLength The length of the bar in points/pixels.
+ * @returns {Object} { divLinesArray, divider }
+ */
+export const getDivLinesArrayAndDivider = (
+  scaleBarLengthMeters,
+  scaleBarLength
+) => {
+  const scaleBarLengthMetersStr = scaleBarLengthMeters.toString();
+  // Here we get the lengthMeters first two numbers.
+  const scaleBarFirstDigits = parseInt(scaleBarLengthMetersStr.substring(0, 2));
+  // We want to check if lengthMeters starts with 10 through 19 to make sure we divide correctly later.
+  const startsWithDoubleDigits =
+    scaleBarFirstDigits >= 10 && scaleBarFirstDigits <= 19;
+
+  // Here we set the scaleLength variable to the length of lengthMeters.
+  // For example, if lengthMeters is 1000 we want the scaleLength to be 10.
+  // And if lengthMeters is 500 we want the scaleLength to be 5.
+  const scaleLength = startsWithDoubleDigits
+    ? scaleBarLengthMetersStr.length - 2
+    : scaleBarLengthMetersStr.length - 1;
+
+  // Here we set the divider by dividing lengthMeters with 10 to the power of scaleLength...
+  // For example, if lengthMeters is 500 we want to divide it by 5 to get 5 division lines, each 100 meters...
+  // and if lengthMeters is 1 000 we want to divide it by 100.
+  const divider = scaleBarLengthMeters / Math.pow(10, scaleLength);
+  // Finally, we want to calculate the number of pixels between each division line on the scalebar
+  const divLinePixelsCount = scaleBarLength / divider;
+
+  // We loop through and fill the divLinesArray with the divLinePixelsCount...
+  // to get the correct division line distribution on the scalebar
+  let divLinesArray = [];
+  for (
+    let divLine = divLinePixelsCount;
+    divLine <= scaleBarLength;
+    divLine += divLinePixelsCount
+  ) {
+    divLinesArray.push(divLine);
+  }
+
+  return { divLinesArray, divider };
+};

--- a/apps/client/src/plugins/Print/layout/textMeasure.js
+++ b/apps/client/src/plugins/Print/layout/textMeasure.js
@@ -1,0 +1,170 @@
+/**
+ * Text measurement and positioning helpers shared by the layout builder.
+ *
+ * All measurement is done using a canvas 2D context with the Roboto font.
+ * Functions are pure; any state they need is passed in explicitly.
+ */
+
+const FONT_STACK = "Roboto, roboto, sans-serif";
+
+const getFont = (fontSize, fontWeight) =>
+  `${fontWeight === "bold" ? "700" : "400"} ${fontSize}px ${FONT_STACK}`;
+
+/**
+ * Gets the height in points (PDF) or pixels (PNG) of the supplied text(s).
+ *
+ * @param {string|string[]} text A string, or an array of strings when
+ * generating a PDF. Explicit newlines within each string count as extra lines.
+ * @param {number} fontSize
+ * @param {string} saveAsType "PDF" or anything else (pixels vs points).
+ * @returns {number} Height in points (PDF) or pixels (other).
+ */
+export const getTextHeight = (text, fontSize, saveAsType) => {
+  // If we are generating a PDF, an array of text is passed. Otherwise just a string.
+  let numberOfLines = 1;
+  if (typeof text === "object") {
+    // Let's see if our texts (disclaimer, copyright) contain newlines, and if
+    // so, ensure that they count towards the total height.
+    let lineBreaks = 0;
+    for (let i = 0; i < text.length; i++) {
+      // Count how many newlines exist in the specific text part. Bear in mind that \n
+      // is not the only possible newline, let's also count \r. \r\n is also a possibility,
+      // but since it contains both \r and \n, we will count it as two newlines, which is correct.
+      const newlineCount = (text[i].match(/\n|\r/g) || []).length;
+
+      lineBreaks = lineBreaks + newlineCount;
+    }
+    numberOfLines = text.length + lineBreaks;
+  }
+  // Estimate lineheight and calculate the height in points over number of lines.
+  const lineHeight = fontSize * 1.2;
+  const totalHeight = lineHeight * numberOfLines;
+  // Calculate points if we are creating a pdf
+  const totalHeightInPoints = totalHeight * (72 / 96);
+  // Return pixels if PNG or points if PDF
+  return saveAsType === "PDF" ? totalHeightInPoints : totalHeight;
+};
+
+/**
+ * Measures the width of a single-line text.
+ */
+export const getTextWidth = (text, size) => {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  context.font = `${size}px roboto`;
+  return context.measureText(text).width;
+};
+
+/**
+ * Word-wraps text to maxWidth. Honours explicit newlines.
+ */
+export const wrapTextToLines = (
+  text,
+  fontSize,
+  maxWidth,
+  fontWeight = "normal"
+) => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  ctx.font = getFont(fontSize, fontWeight);
+
+  const measure = (str) => ctx.measureText(str).width;
+
+  const lines = [];
+  for (const segment of text.split("\n")) {
+    if (measure(segment) <= maxWidth) {
+      lines.push(segment);
+      continue;
+    }
+    const words = segment.split(" ");
+    let current = "";
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (measure(candidate) <= maxWidth) {
+        current = candidate;
+      } else {
+        if (current) lines.push(current);
+        current = word;
+      }
+    }
+    if (current) lines.push(current);
+  }
+  return lines.length ? lines : [""];
+};
+
+/**
+ * Centred x for text within paperWidth.
+ */
+export const getCenteredX = (
+  text,
+  fontSize,
+  paperWidth,
+  fontWeight = "normal"
+) => {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  ctx.font = getFont(fontSize, fontWeight);
+  const textWidth = ctx.measureText(text).width;
+  return (paperWidth - textWidth) / 2;
+};
+
+/**
+ * Returns the x/y position for text that should be right aligned on the page.
+ *
+ * Depending on what other content occupies the bottom-right corner (QR code,
+ * north arrow, scale bar, logo), the text is moved to the left of it.
+ *
+ * @param {Object} deps Instance state from the print model.
+ * @param {Object} options Current print options.
+ * @returns {Object} { x, y }
+ */
+export const getRightAlignedPositions = (
+  {
+    text,
+    fontSize,
+    xmargin,
+    ymargin,
+    paperWidth,
+    fontWeight = "normal",
+    maxWidth,
+    saveAsType,
+    northArrowMaxWidth,
+    logoMaxWidth,
+    mmPerPoint,
+    scalebarMaxWidth,
+  },
+  options
+) => {
+  // If we are printing a PNG we assign the maxWidth to the width of the separate text string.
+  if (saveAsType !== "PDF") {
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    context.font = `${fontWeight === "bold" ? "700" : "400"} ${fontSize}px Roboto, roboto, sans-serif`;
+    maxWidth = context.measureText(text).width;
+  }
+  // If QrCode is placed in the bottom right corner, move text to the left of it (its wider)
+  // Otherwise its a logo or northarrow, needs less text movement.
+  // Also take care of scalebar placement bottomRight
+  let x;
+  if (options.includeQrCode && options.qrCodePlacement === "bottomRight") {
+    x = paperWidth - maxWidth - xmargin - 90;
+  } else if (
+    options.includeNorthArrow &&
+    options.northArrowPlacement === "bottomRight"
+  ) {
+    x = paperWidth - maxWidth - xmargin - northArrowMaxWidth * 3 - 10;
+  } else if (
+    options.includeScaleBar &&
+    options.scaleBarPlacement === "bottomRight"
+  ) {
+    // Use the scalebarMaxWidth that either is the text or the scalebar length, to align ex copyright
+    // and disclaimer/date correctly to the left of the scalebar when bottomRight
+    x = paperWidth - maxWidth - xmargin - scalebarMaxWidth - 10;
+  } else if (options.includeLogo && options.logoPlacement === "bottomRight") {
+    x = paperWidth - maxWidth - xmargin - logoMaxWidth * mmPerPoint - 10;
+  } else {
+    x = paperWidth - maxWidth - xmargin;
+  }
+  const y = getTextHeight(text, fontSize, saveAsType) + ymargin;
+  return { x, y };
+};

--- a/apps/client/src/plugins/Print/options/defaults.js
+++ b/apps/client/src/plugins/Print/options/defaults.js
@@ -1,0 +1,152 @@
+/**
+ * Default configuration values for the Print plugin, along with helpers to
+ * normalize admin-supplied options.
+ *
+ * Nothing in this module has side effects – it only declares constants and
+ * provides pure helper functions.
+ */
+
+// Paper dimensions in millimeters: Array[width, height], landscape orientation.
+export const PAPER_DIMS_MM = {
+  a0: [1189, 841],
+  a1: [841, 594],
+  a2: [594, 420],
+  a3: [420, 297],
+  a4: [297, 210],
+  a5: [210, 148],
+};
+
+// Paper sizes in points assuming landscape.
+export const PAPER_SIZE_PT = {
+  a2: { width: 1684, height: 1190 },
+  a3: { width: 1190, height: 842 },
+  a4: { width: 842, height: 595 },
+};
+
+// Default DPIs, used if none supplied in options.
+export const DEFAULT_DPIS = [72, 150, 300];
+
+// Default scales, used if none supplied in options.
+export const DEFAULT_SCALES = [
+  100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 200000, 500000,
+];
+
+// Default scale bar lengths (in meters) per scale. Used when the admin-supplied
+// "scales" and "scaleMeters" arrays don't have the same length.
+export const DEFAULT_SCALE_BAR_LENGTHS = {
+  200: 10,
+  500: 50,
+  1000: 100,
+  2000: 200,
+  5000: 500,
+  10000: 1000,
+  20000: 2000,
+  50000: 5000,
+  100000: 10000,
+  200000: 20000,
+  300000: 20000,
+};
+
+// Conversion factor between millimeters and points.
+export const MM_PER_POINT = 2.83465;
+
+/**
+ * Normalizes an admin-supplied list option. The value may come as an array
+ * (used as-is), or as a comma-separated string (whitespace stripped). If
+ * neither, the fallback is used.
+ *
+ * @param {Array|string} value
+ * @param {Array} fallback
+ * @param {Function} [mapItem] Optional transform applied to each string item.
+ * @returns {Array}
+ */
+export const parseListOption = (value, fallback, mapItem = (el) => el) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value?.split(",").length > 1) {
+    return value
+      .replace(/\s/g, "")
+      .split(",")
+      .map((el) => mapItem(el));
+  }
+  return fallback;
+};
+
+/**
+ * Builds the mapping between scales and their fitting scale bar lengths
+ * (meters). Falls back to the defaults if the two arrays differ in length.
+ *
+ * @param {Array} scales
+ * @param {Array} scaleMeters
+ * @returns {Object} Map from scale to length in meters.
+ */
+export const buildScaleBarLengths = (scales, scaleMeters) => {
+  if (scales.length === scaleMeters.length) {
+    return scales.reduce((acc, curr, index) => {
+      acc[curr] = scaleMeters[index];
+      return acc;
+    }, {});
+  }
+  return DEFAULT_SCALE_BAR_LENGTHS;
+};
+
+const isBoolean = (v) => typeof v === "boolean";
+
+/**
+ * Normalizes raw plugin options exactly like the Print plugin entry point has
+ * always done. Returns a new object; the input is left untouched.
+ *
+ * @param {Object} rawOptions Options as supplied via plugin configuration.
+ * @param {Object} mapConfig The app's map configuration (for crossOrigin).
+ * @returns {Object} A new, normalized options object.
+ */
+export const normalizePrintOptions = (rawOptions, mapConfig) => {
+  const o = { ...rawOptions };
+
+  // Prepare scales from admin options, fallback to default if needed
+  o.scales = parseListOption(rawOptions.scales, DEFAULT_SCALES);
+
+  // Prepare scaleMeters from admin options, fallback to default if needed
+  o.scaleMeters = parseListOption(
+    rawOptions.scaleMeters,
+    [20, 40, 40, 100, 200, 200, 400, 600, 2000, 4000, 10000, 20000]
+  );
+
+  // Prepare dpis from admin options, fallback to default if needed
+  o.dpis = parseListOption(rawOptions.dpis, DEFAULT_DPIS, (el) => parseInt(el));
+
+  // Prepare paperFormats from admin options, fallback to default if needed
+  o.paperFormats = parseListOption(
+    rawOptions.paperFormats,
+    Object.keys(PAPER_DIMS_MM),
+    (el) => el.toLowerCase()
+  );
+
+  // If no valid max logo width is supplied, use a hard-coded default
+  o.logoMaxWidth =
+    typeof rawOptions?.logoMaxWidth === "number" ? rawOptions.logoMaxWidth : 40;
+
+  o.northArrowMaxWidth =
+    typeof rawOptions?.northArrowMaxWidth === "number"
+      ? rawOptions.northArrowMaxWidth
+      : 10;
+
+  // If no path to north-arrow image is supplied, use fallback
+  o.northArrow = rawOptions.northArrow || "/north_arrow.png";
+
+  o.includeImageBorder = isBoolean(rawOptions?.includeImageBorder)
+    ? rawOptions.includeImageBorder
+    : false;
+  o.allowLegendsInPdfOutput = isBoolean(rawOptions?.allowLegendsInPdfOutput)
+    ? rawOptions.allowLegendsInPdfOutput
+    : false;
+  o.generateLegendsByDefault = isBoolean(rawOptions?.generateLegendsByDefault)
+    ? rawOptions.generateLegendsByDefault
+    : false;
+
+  // Ensure we have a value for the crossOrigin parameter
+  o.crossOrigin = mapConfig?.crossOrigin || "anonymous";
+
+  return o;
+};

--- a/apps/client/src/plugins/Print/utils/images.js
+++ b/apps/client/src/plugins/Print/utils/images.js
@@ -1,0 +1,88 @@
+import QRCode from "qrcode";
+
+/**
+ * Image-related helpers for the print plugin.
+ */
+
+/**
+ * Returns a Promise which resolves if image loading succeeded.
+ * The Promise will contain an object with data blob of the loaded image.
+ * If loading fails, the Promise rejects.
+ *
+ * @param {*} url
+ * @returns {Promise}
+ */
+export const getImageDataBlobFromUrl = (url) => {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.setAttribute("crossOrigin", "anonymous"); //getting images from external domain
+
+    // We must resolve the promise even if
+    image.onerror = function (err) {
+      reject(err);
+    };
+
+    // When load succeeds
+    image.onload = function () {
+      const imgCanvas = document.createElement("canvas");
+      imgCanvas.width = this.naturalWidth;
+      imgCanvas.height = this.naturalHeight;
+
+      // Draw the image on canvas so that we can read the data blob later on
+      imgCanvas.getContext("2d").drawImage(this, 0, 0);
+
+      resolve({
+        data: imgCanvas.toDataURL("image/png"), // read data blob from canvas
+        width: imgCanvas.width, // also return dimensions so we can use them later
+        height: imgCanvas.height,
+      });
+    };
+
+    // Go, load!
+    image.src = url;
+  });
+};
+
+/**
+ * Helper function that takes a URL and max width and returns the ready data
+ * blob as well as width/height which fit into the specified max value.
+ *
+ * @param {*} url
+ * @param {*} maxWidth
+ * @returns {Promise<Object>} image data blob, image width, image height
+ */
+export const getImageForPdfFromUrl = async (url, maxWidth) => {
+  // Use the supplied URL to get img data blob and dimensions
+  const {
+    data,
+    width: sourceWidth,
+    height: sourceHeight,
+  } = await getImageDataBlobFromUrl(url);
+
+  // We must ensure that the image will be printed with a max width of X,
+  // while keeping the aspect ratio between width and height
+  const ratio = (maxWidth * 3) / sourceWidth;
+  const width = sourceWidth * ratio;
+  const height = sourceHeight * ratio;
+  return { data, width, height };
+};
+
+/**
+ * Generates a QR code (as a data URL) for the supplied URL.
+ *
+ * @param {string} url
+ * @param {number} qrSize Desired size; the resulting size is 4x this value.
+ * @returns {Promise<Object|string>} Object with data/width/height, or "" on failure.
+ */
+export const generateQR = async (url, qrSize) => {
+  try {
+    return {
+      data: await QRCode.toDataURL(url),
+      width: qrSize * 4,
+      height: qrSize * 4,
+    };
+  } catch (err) {
+    console.warn(err);
+    return "";
+  }
+};

--- a/apps/client/src/plugins/Print/utils/proxyUrl.js
+++ b/apps/client/src/plugins/Print/utils/proxyUrl.js
@@ -1,0 +1,32 @@
+/**
+ * Helpers for working with URLs that may need to be routed through the
+ * application's proxy.
+ */
+
+// A fake base used for resolving relative URL:s so we can detect this when
+// resolving the final URL to string (and remove it).
+// This let's us work with NodeJS URL API with relative URL:s.
+export const FAKE_BASE = "https://hajk.js.internal";
+
+/**
+ * Returns a URL object from the src string, prepended with proxy if any.
+ *
+ * @param {string} proxy The proxy prefix (may be empty).
+ * @param {string} src
+ * @returns {URL}
+ */
+export const getProxiedUrl = (proxy, src) => {
+  const location = (proxy || "") + src;
+  return new URL(location, FAKE_BASE);
+};
+
+/**
+ * Returns a string with the complete URL, removing fake base if any.
+ *
+ * @param {URL} url
+ * @returns {string}
+ */
+export const toUrlString = (url) => {
+  const urlString = url.toString();
+  return urlString.replace(FAKE_BASE, "");
+};

--- a/apps/client/src/plugins/Print/utils/scale.js
+++ b/apps/client/src/plugins/Print/utils/scale.js
@@ -1,0 +1,69 @@
+import { getPointResolution } from "ol/proj";
+
+/**
+ * Scale calculation helpers for the print plugin.
+ */
+
+// We have to make sure to get (and set on the print view) the current zoom
+// of the "original" view before calculating scale – otherwise the calculation
+// could be wrong since it depends on the static zoom of the print view.
+const SCREEN_DPI = 25.4 / 0.28;
+const INCHES_PER_METER = 39.37;
+
+/**
+ * Calculates the current map scale from a view.
+ *
+ * @param {import("ol/View").default} view
+ * @returns {number} The map scale denominator (e.g. 10000 for 1:10 000).
+ */
+export const getMapScaleFromView = (view) => {
+  const mpu = view.getProjection().getMetersPerUnit(),
+    res = view.getResolution();
+
+  return res * mpu * INCHES_PER_METER * SCREEN_DPI;
+};
+
+/**
+ * Returns the configured scale closest to the proposed (actual) scale.
+ *
+ * @param {number} proposedScale
+ * @param {Array<number>} scales Configured scales.
+ * @returns {number} The closest configured scale.
+ */
+export const findClosestScale = (proposedScale, scales) => {
+  return scales.reduce((prev, curr) => {
+    return Math.abs(curr - proposedScale) < Math.abs(prev - proposedScale)
+      ? curr
+      : prev;
+  });
+};
+
+/**
+ * Calculates the resolution required to render at the desired scale and DPI.
+ *
+ * @param {number} scale Scale denominator divided by 1000.
+ * @param {number} resolution Output DPI.
+ * @param {import("ol/proj/Projection").default} projection
+ * @param {Array<number>} center Map center coordinate.
+ * @returns {number}
+ */
+export const calculateScaleResolution = (
+  scale,
+  resolution,
+  projection,
+  center
+) => {
+  return scale / getPointResolution(projection, resolution / 25.4, center);
+};
+
+/**
+ * Formats a scale as a user friendly string prefixed with "1:".
+ * Using toLocaleString for sv-SE is the easiest way to get space as
+ * thousand separator, e.g "5000" -> "1:5 000".
+ *
+ * @param {*} scale Number that will be prefixed with "1:".
+ * @returns {string}
+ */
+export const getUserFriendlyScale = (scale) => {
+  return `1:${Number(scale).toLocaleString()}`;
+};


### PR DESCRIPTION
Split the PrintModel god class into focused modules: options/defaults, layout/ (textMeasure, scaleBarMath, placement, context), layers/tileMath and utils/ (images, proxyUrl, scale). Decompose the print pipeline into named steps and decouple PrintLayout from model state via an explicit per-build layout context. Remove dead code (unused snackbar HOCs, dead dims prop, duplicated color list). The public PrintModel API used by TimeSlider is preserved.